### PR TITLE
Add Context Service public docs

### DIFF
--- a/docs/docs/context-service/ingestion-and-storage.md
+++ b/docs/docs/context-service/ingestion-and-storage.md
@@ -1,0 +1,191 @@
+---
+title: Ingestion and Storage
+sidebar_label: Ingestion and Storage
+---
+
+# Ingestion and Storage
+
+Context Service accepts both direct file uploads and remote file references. In both cases, the service creates a pipeline job, processes the content in the background, and can retain raw file metadata for later inspection or download.
+
+> **Technical preview:** Remote source ingestion and raw-file retention are still evolving. Validate behavior in your environment before depending on specific operational details.
+
+## Ingest Modes
+
+### Inline upload
+
+Use `POST /context/upload/` when you want to send a single multipart file directly to Context Service.
+
+This path is useful for:
+
+- manual uploads from an application
+- simple tests
+- direct operator workflows
+
+### Pipeline request with inline content
+
+Use `POST /context/pipelines/` when you want to create a pipeline job explicitly and include one or more files in the request body using `content_base64`.
+
+### Pipeline request with `source_ref`
+
+Use `POST /context/pipelines/` with `source_ref` when the file should be pulled server-side by Context Service instead of being sent inline.
+
+This path is useful when:
+
+- files already live in a connected system
+- you want smaller request payloads
+- you need source metadata preserved with the ingest
+
+Exactly one of `content_base64` or `source_ref` must be provided for each file.
+
+## File Shape
+
+The pipeline accepts files with a shape equivalent to the current `FileInput` schema:
+
+```json
+{
+  "filename": "q4-plan.docx",
+  "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "source_urn": "m365://drives/drive-123/items/item-456",
+  "source_ref": {
+    "kind": "m365",
+    "connector_id": "11111111-2222-3333-4444-555555555555",
+    "drive_id": "drive-123",
+    "item_id": "item-456",
+    "url": "https://contoso.sharepoint.com/..."
+  },
+  "metadata": {
+    "folder": "finance"
+  }
+}
+```
+
+Inline content uses the same object shape, but replaces `source_ref` with `content_base64`.
+
+## Create A Pipeline Job
+
+`POST /context/pipelines/`
+
+Example request:
+
+```json
+{
+  "files": [
+    {
+      "filename": "notes.txt",
+      "content_base64": "aGVsbG8gY29udGV4dA==",
+      "content_type": "text/plain",
+      "source_urn": "local://notes.txt"
+    }
+  ],
+  "config": {
+    "collection_name": "team_notes"
+  }
+}
+```
+
+Typical behavior:
+
+- new jobs return `201 Created`
+- idempotent replays return `200 OK`
+- processing continues in the background after job creation
+
+## Pipeline Jobs
+
+Pipeline jobs are the main unit of ingest tracking.
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /context/pipelines/` | Create and start a job |
+| `GET /context/pipelines/` | List jobs in the authorized workroom |
+| `GET /context/pipelines/{job_id}` | Inspect one job |
+| `DELETE /context/pipelines/{job_id}` | Cancel or delete a job |
+| `GET /context/pipelines/supported-types` | List supported file extensions |
+
+The platform starts processing immediately for newly created jobs. If a matching job is replayed idempotently, the existing job record is returned instead of starting duplicate work.
+
+## Supported File Types
+
+Use `GET /context/pipelines/supported-types` to inspect the current extractor surface for your deployment.
+
+Example response:
+
+```json
+[".pdf", ".docx", ".md", ".txt"]
+```
+
+The exact list depends on the currently enabled extractors and pipeline configuration.
+
+## Raw File Metadata
+
+When raw storage is enabled, Context Service tracks stored file metadata and can optionally generate temporary download URLs.
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /context/storage/raw` | List raw stored files |
+| `GET /context/storage/raw/{file_id}` | Inspect one raw file record |
+| `GET /context/documents/{source_urn}` | Resolve an original document by source URN |
+
+Raw file metadata includes fields such as:
+
+- raw file record ID
+- workroom ID
+- pipeline job ID
+- original filename
+- content type
+- size in bytes
+- SHA-256 checksum
+- source kind and source reference
+- stored object URI
+
+## Raw File Example
+
+Example detail response from `GET /context/storage/raw/{file_id}?include_download_url=true`:
+
+```json
+{
+  "id": "3f061be0-16cb-47cc-a7a0-1e2ff4b06f92",
+  "workroom_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "job_id": "11111111-2222-3333-4444-555555555555",
+  "source_urn": "m365://drives/drive-123/items/item-456",
+  "filename": "q4-plan.docx",
+  "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "size_bytes": 248901,
+  "checksum_sha256": "6d7b4e7d...",
+  "source_kind": "m365",
+  "source_ref": {
+    "kind": "m365",
+    "connector_id": "11111111-2222-3333-4444-555555555555",
+    "drive_id": "drive-123",
+    "item_id": "item-456"
+  },
+  "s3_uri": "s3://bucket/workrooms/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/raw/q4-plan.docx",
+  "metadata": {},
+  "created_at": "2026-03-31T12:00:00Z",
+  "download_url": "https://..."
+}
+```
+
+## Document Download By Source URN
+
+`GET /context/documents/{source_urn}`
+
+This endpoint resolves a stored source document to a temporary download URL. Use it when your workflow already tracks `source_urn` values and you want the original document back without first looking up raw-file IDs.
+
+> **Note:** This endpoint returns a temporary URL only when document storage is configured and the document has a stored object backing it.
+
+## Operational Notes
+
+- Archived workrooms reject write operations with `409 Conflict`
+- Large or unsupported uploads return validation errors before processing
+- Remote ingestion depends on the configured source integration being reachable and authorized
+- Temporary download URLs are time-limited by the deployment configuration
+
+## Related Docs
+
+- [Context Service Overview](./overview)
+- [Search and Knowledge](./search-and-knowledge)
+- [Operations and API Reference](./operations-and-api-reference)

--- a/docs/docs/context-service/managed-backends-and-lifecycle.md
+++ b/docs/docs/context-service/managed-backends-and-lifecycle.md
@@ -1,0 +1,176 @@
+---
+title: Managed Backends and Lifecycle
+sidebar_label: Managed Backends and Lifecycle
+---
+
+# Managed Backends and Lifecycle
+
+Context Service can manage workroom-scoped backend instances for vector search, ontology-backed knowledge operations, and OmniParse processing. It also enforces archive-aware behavior for write paths so managed resources follow workroom lifecycle state.
+
+> **Technical preview:** Managed backend APIs are intended for advanced platform usage. Availability, readiness behavior, and configuration details may change between releases.
+
+## Managed Resource Types
+
+The current implementation exposes these managed resource families:
+
+| Resource | Purpose |
+| --- | --- |
+| VectorDB instances | Back indexed collections and direct vector operations |
+| Ontology instances | Back graph-style knowledge and memory operations |
+| OmniParse instances | Back advanced document parsing workflows |
+| Collections | Organize indexed chunks within a VectorDB instance |
+
+## VectorDB Instances
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /context/vectordbs` | List visible VectorDB instances |
+| `GET /context/vectordbs/{vectordb_id}` | Inspect one instance |
+| `POST /context/vectordbs` | Create an instance |
+| `PUT /context/vectordbs/{vectordb_id}` | Update configuration |
+| `POST /context/vectordbs/{vectordb_id}/scale` | Change replica count |
+| `DELETE /context/vectordbs/{vectordb_id}` | Delete an instance |
+| `POST /context/vectordbs/{vectordb_id}/insert` | Insert vectors into one instance |
+| `POST /context/vectordbs/insert` | Insert vectors using body-supplied `vectordb_id` |
+| `POST /context/vectordbs/{vectordb_id}/query` | Query one instance |
+| `POST /context/vectordbs/query` | Query using body-supplied `vectordb_id` |
+
+Current engines:
+
+- `milvus`
+- `vespa`
+
+Example create request:
+
+```json
+{
+  "name": "team-search",
+  "engine": "milvus",
+  "replicas": 1
+}
+```
+
+## Collections
+
+Collections are the searchable containers used by indexed chunks.
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /context/collections/` | List collections in the workroom |
+| `POST /context/collections/` | Create a collection |
+| `GET /context/collections/{collection_name}` | Inspect a collection |
+| `DELETE /context/collections/{collection_name}` | Delete a collection |
+
+Example create request:
+
+```json
+{
+  "name": "team_notes",
+  "dimension": 384,
+  "description": "Searchable notes for the team"
+}
+```
+
+> **Note:** Collection display names are user-facing, but the stored collection name may include an internal workroom-scoped prefix.
+
+## Ontology Instances
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /context/ontologies` | List ontology instances |
+| `GET /context/ontologies/{ontology_id}` | Inspect one instance |
+| `POST /context/ontologies` | Create an instance |
+| `DELETE /context/ontologies/{ontology_id}` | Delete an instance |
+
+Current backend options include `graphiti`, with additional enum values reserved in the schema for future expansion.
+
+Example create request:
+
+```json
+{
+  "name": "team-memory",
+  "backend": "graphiti"
+}
+```
+
+## OmniParse Instances
+
+Context Service also exposes managed OmniParse lifecycle routes:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /context/omniparses` | List OmniParse instances |
+| `GET /context/omniparses/{omniparse_id}` | Inspect one instance |
+| `POST /context/omniparses` | Create an instance |
+| `PUT /context/omniparses/{omniparse_id}` | Update an instance |
+| `DELETE /context/omniparses/{omniparse_id}` | Delete an instance |
+
+These routes are especially relevant when you want Context Service to manage the parsing backend used by ingest pipelines rather than treating OmniParse as an external dependency.
+
+## Readiness And Error Handling
+
+Managed backends may report lifecycle state such as:
+
+- `pending`
+- `running`
+- `stopped`
+- `failed`
+
+Some operations can return `503 Service Unavailable` when the targeted backend exists but is not yet ready. In those cases, the response may include structured details and a `Retry-After` header.
+
+Use the instance detail routes to confirm:
+
+- lifecycle status
+- endpoint availability
+- workroom scope
+- replica settings where applicable
+
+## Archive-Aware Behavior
+
+Context Service blocks write operations when the workroom is archived.
+
+This commonly affects:
+
+- creating or updating managed instances
+- creating or deleting collections
+- pipeline creation and uploads
+- vector insertion
+- ontology write operations
+
+Archived-write failures return `409 Conflict`.
+
+Read-oriented operations such as listing resources or searching may still remain available, depending on the specific route and backend state.
+
+## Internal Lifecycle Hooks
+
+Context Service also implements internal lifecycle endpoints for workroom-driven archive, restore, export, resource counting, and purge flows. These are service-to-service routes and are not part of the public OpenAPI surface.
+
+Operationally, that means:
+
+- public docs should treat archive state as an important runtime constraint
+- workroom lifecycle orchestration can affect Context Service availability and mutability
+- destructive cleanup and export workflows are owned by internal platform flows rather than normal end-user API usage
+
+## Destructive Actions
+
+Be careful with these operations:
+
+- deleting VectorDB instances
+- deleting ontology instances
+- deleting OmniParse instances
+- deleting collections
+- deleting ontology groups
+
+These calls remove or sever access to stored data and should be limited to trusted operators or controlled application flows.
+
+## Related Docs
+
+- [Context Service Overview](./overview)
+- [Ingestion and Storage](./ingestion-and-storage)
+- [Operations and API Reference](./operations-and-api-reference)

--- a/docs/docs/context-service/operations-and-api-reference.md
+++ b/docs/docs/context-service/operations-and-api-reference.md
@@ -1,0 +1,113 @@
+---
+title: Operations and API Reference
+sidebar_label: Operations and API Reference
+---
+
+# Operations and API Reference
+
+This page provides a compact reference for the current public Context Service REST surface. Use the workflow pages for explanations and examples, and use this page when you need the route inventory in one place.
+
+> **Technical preview:** Route organization and response details may continue to change. Validate production integrations against the currently installed version of the platform.
+
+## Base Path And Scope
+
+Public routes are exposed under `/context` and are workroom-aware. Most operations rely on the authorized `X-Workroom-Id` context and the caller's normal platform authentication.
+
+## Health
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/health` | Service health and advertised feature list |
+
+## VectorDB
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/vectordbs` | List VectorDB instances |
+| `GET` | `/context/vectordbs/{vectordb_id}` | Get one VectorDB instance |
+| `POST` | `/context/vectordbs` | Create a VectorDB instance |
+| `PUT` | `/context/vectordbs/{vectordb_id}` | Update a VectorDB instance |
+| `POST` | `/context/vectordbs/{vectordb_id}/scale` | Scale a VectorDB instance |
+| `DELETE` | `/context/vectordbs/{vectordb_id}` | Delete a VectorDB instance |
+| `POST` | `/context/vectordbs/{vectordb_id}/insert` | Insert vectors into one instance |
+| `POST` | `/context/vectordbs/insert` | Insert vectors using body-supplied instance ID |
+| `POST` | `/context/vectordbs/{vectordb_id}/query` | Query vectors in one instance |
+| `POST` | `/context/vectordbs/query` | Query vectors using body-supplied instance ID |
+
+## Ontology
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/ontologies` | List ontology instances |
+| `GET` | `/context/ontologies/{ontology_id}` | Get one ontology instance |
+| `POST` | `/context/ontologies` | Create an ontology instance |
+| `DELETE` | `/context/ontologies/{ontology_id}` | Delete an ontology instance |
+| `POST` | `/context/ontologies/{ontology_id}/knowledge` | Add knowledge from messages |
+| `POST` | `/context/ontologies/{ontology_id}/entity` | Add one entity |
+| `POST` | `/context/ontologies/{ontology_id}/search` | Search graph-backed knowledge |
+| `POST` | `/context/ontologies/{ontology_id}/memory` | Get memory-oriented context |
+| `GET` | `/context/ontologies/{ontology_id}/episodes/{group_id}` | List recent episodes |
+| `DELETE` | `/context/ontologies/{ontology_id}/groups/{group_id}` | Delete a knowledge group |
+| `GET` | `/context/ontologies/{ontology_id}/health` | Check ontology health |
+
+## OmniParse
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/omniparses` | List OmniParse instances |
+| `GET` | `/context/omniparses/{omniparse_id}` | Get one OmniParse instance |
+| `POST` | `/context/omniparses` | Create an OmniParse instance |
+| `PUT` | `/context/omniparses/{omniparse_id}` | Update an OmniParse instance |
+| `DELETE` | `/context/omniparses/{omniparse_id}` | Delete an OmniParse instance |
+
+## Collections
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/collections/` | List collections |
+| `POST` | `/context/collections/` | Create a collection |
+| `GET` | `/context/collections/{collection_name}` | Get collection details |
+| `DELETE` | `/context/collections/{collection_name}` | Delete a collection |
+
+## Pipelines And Uploads
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `POST` | `/context/pipelines/` | Create and start a pipeline job |
+| `GET` | `/context/pipelines/` | List pipeline jobs |
+| `GET` | `/context/pipelines/supported-types` | List supported file extensions |
+| `GET` | `/context/pipelines/{job_id}` | Get pipeline job status |
+| `DELETE` | `/context/pipelines/{job_id}` | Cancel or delete a pipeline job |
+| `POST` | `/context/upload/` | Upload one file directly into the pipeline |
+
+## Raw Storage And Documents
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/context/storage/raw` | List raw stored files |
+| `GET` | `/context/storage/raw/{file_id}` | Get raw stored file metadata |
+| `GET` | `/context/documents/{source_urn}` | Get a temporary download URL for a stored source document |
+
+## Search
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `POST` | `/context/search` | Unified search with optional enrichment |
+| `POST` | `/context/search/simple` | Legacy simple search route |
+| `POST` | `/context/search/retrieve` | Legacy retrieval-focused route |
+| `POST` | `/context/search/agentic` | Legacy agentic search route |
+
+## Important Notes
+
+- New integrations should prefer `POST /context/search`
+- Write routes can return `409 Conflict` when the workroom is archived
+- Managed-resource operations can return `503 Service Unavailable` while a backend is not ready
+- Raw-document download routes depend on configured object storage
+- Internal lifecycle endpoints exist, but they are service-to-service routes and are not listed here
+
+## Related Docs
+
+- [Context Service Overview](./overview)
+- [Ingestion and Storage](./ingestion-and-storage)
+- [Search and Knowledge](./search-and-knowledge)
+- [Managed Backends and Lifecycle](./managed-backends-and-lifecycle)

--- a/docs/docs/context-service/overview.md
+++ b/docs/docs/context-service/overview.md
@@ -1,0 +1,106 @@
+---
+title: Context Service Overview
+sidebar_label: Overview
+---
+
+# Context Service Overview
+
+Context Service is Kamiwaza's workroom-scoped ingestion, storage, search, and knowledge layer. It takes files or remote file references, processes them into searchable chunks, stores raw content for traceability, and exposes retrieval and knowledge APIs over the resulting data.
+
+> **Technical preview:** Context Service is intended for advanced operators and developers. APIs and operational details may change as the service continues to harden.
+
+## What Context Service Does
+
+Context Service brings several capabilities under one API surface:
+
+- **Ingestion pipelines** for uploaded files and remote source references
+- **Raw file tracking** with stored metadata and temporary download access
+- **Vector-backed search** for chunk-level semantic retrieval
+- **Knowledge operations** for ontology-backed memory and fact search
+- **Managed backends** for VectorDB, Ontology, and OmniParse instances
+
+In practice, this means you can move from source documents to retrieval-ready context without building your own pipeline orchestration layer.
+
+## How It Fits Into Kamiwaza
+
+Context Service sits between source systems and retrieval consumers:
+
+- **Distributed Data Engine** handles connector-oriented data movement and ingestion orchestration at the platform level
+- **OmniParse** provides advanced extraction and parsing for supported content types
+- **VectorDB backends** store embeddings and power semantic search
+- **Ontology backends** store graph-style knowledge for memory and fact lookup
+- **Applications and agents** call Context Service to ingest, search, and retrieve context
+
+For related platform docs, see [Distributed Data Engine](../data-engine), [Retrieval Service](../retrieval-service), and [Platform Architecture Overview](../architecture/overview).
+
+## Workroom Scoping
+
+Context Service is scoped by workroom. Public endpoints expect the authorized workroom context to be supplied through the request headers, most notably:
+
+- `X-Workroom-Id`: the workroom to operate in
+- Standard auth headers or session cookies accepted by the Kamiwaza platform
+
+Workroom scoping affects:
+
+- which pipeline jobs you can see
+- which collections are searched
+- which raw files can be listed or downloaded
+- which managed backend instances are visible
+
+Context Service uses the workroom boundary to isolate data and operations. Collection names, stored files, and managed resources are resolved within that scope.
+
+## High-Level Flow
+
+The typical Context Service flow looks like this:
+
+1. **Ingest** a file upload or a remote `source_ref`
+2. **Store raw content** and record source metadata
+3. **Extract and chunk** content through the pipeline
+4. **Generate embeddings** and index chunks into a VectorDB collection
+5. **Search or retrieve** context from indexed data
+6. **Optionally add or query knowledge** through ontology-backed endpoints
+
+```mermaid
+flowchart LR
+    A["Upload or source_ref"] --> B["Pipeline job"]
+    B --> C["Raw storage + metadata"]
+    C --> D["Extraction and chunking"]
+    D --> E["Embeddings + VectorDB index"]
+    E --> F["Search and retrieval"]
+    E --> G["Ontology knowledge operations"]
+```
+
+## Main API Areas
+
+The public REST surface is organized around a few resource families:
+
+| Area | Purpose |
+| --- | --- |
+| `/context/pipelines/*` | Create, inspect, and delete pipeline jobs |
+| `/context/upload/` | Upload one file directly into the pipeline |
+| `/context/storage/raw/*` | List raw stored files and request temporary download URLs |
+| `/context/documents/{source_urn}` | Resolve a stored source document to a temporary download URL |
+| `/context/search*` | Run semantic, retrieval, and enriched search flows |
+| `/context/vectordbs*` | Manage VectorDB instances and direct vector operations |
+| `/context/ontologies*` | Manage ontology instances and knowledge operations |
+| `/context/collections/*` | Manage workroom-scoped collections |
+| `/context/omniparses*` | Manage OmniParse instances in preview |
+
+## When To Use It
+
+Context Service is a good fit when you need:
+
+- a workroom-aware ingestion pipeline
+- semantic retrieval over uploaded or remotely referenced documents
+- traceable source metadata and raw-file retention
+- graph-backed memory or knowledge search
+- platform-managed vector and ontology backends
+
+If you need connector-centric workflows first, start with [Distributed Data Engine](../data-engine). If you only need dataset retrieval against existing datasets, start with [Retrieval Service](../retrieval-service).
+
+## Next Steps
+
+- Use [Ingestion and Storage](./ingestion-and-storage) to understand pipeline jobs, uploads, remote ingestion, and raw-file access
+- Use [Search and Knowledge](./search-and-knowledge) to understand search modes and ontology operations
+- Use [Managed Backends and Lifecycle](./managed-backends-and-lifecycle) for managed resource operations and archive behavior
+- Use [Operations and API Reference](./operations-and-api-reference) for the compact route inventory

--- a/docs/docs/context-service/search-and-knowledge.md
+++ b/docs/docs/context-service/search-and-knowledge.md
@@ -1,0 +1,215 @@
+---
+title: Search and Knowledge
+sidebar_label: Search and Knowledge
+---
+
+# Search and Knowledge
+
+Context Service exposes a unified search API for vector-backed retrieval and a separate ontology surface for graph-style memory and fact operations. Together, these APIs support common RAG and agent workflows without requiring clients to coordinate multiple backend systems directly.
+
+> **Technical preview:** Advanced search enrichment and ontology-backed memory features are available for evaluation, but response details and tuning controls may continue to change.
+
+## Unified Search
+
+The primary search endpoint is:
+
+- `POST /context/search`
+
+This endpoint supports a fast base mode and several optional enrichment flags.
+
+### Base mode
+
+Without enrichment flags, unified search returns:
+
+- the query
+- ranked chunk results
+- source references
+- search timing and searched collections
+
+Example request:
+
+```json
+{
+  "query": "What changed in the quarterly plan?",
+  "top_k": 5,
+  "collection_name": "team_notes"
+}
+```
+
+### Progressive enrichment
+
+Unified search can add richer outputs as needed:
+
+| Option | Effect |
+| --- | --- |
+| `format_context=true` | Adds an LLM-ready `context` string |
+| `synthesize=true` | Adds synthesized text and structured citations |
+| `max_iterations > 1` | Enables iterative refinement history |
+| `enable_graph_search=true` | Includes ontology-backed search behavior when paired with ontology inputs |
+
+Example enriched request:
+
+```json
+{
+  "query": "Summarize the quarterly plan with citations",
+  "collection_name": "team_notes",
+  "top_k": 5,
+  "format_context": true,
+  "synthesize": true,
+  "max_iterations": 2
+}
+```
+
+Example response shape:
+
+```json
+{
+  "query": "Summarize the quarterly plan with citations",
+  "results": [
+    {
+      "id": "chunk-1",
+      "content": "The plan expands the support rollout...",
+      "score": 0.93,
+      "metadata": {
+        "source_file": "q4-plan.docx",
+        "source_urn": "m365://drives/drive-123/items/item-456",
+        "page_number": 2,
+        "chunk_index": 0,
+        "document_uri": "s3://bucket/..."
+      }
+    }
+  ],
+  "sources": [
+    {
+      "chunk_id": "chunk-1",
+      "filename": "q4-plan.docx",
+      "source_urn": "m365://drives/drive-123/items/item-456",
+      "page_number": 2,
+      "score": 0.93,
+      "snippet": "The plan expands the support rollout..."
+    }
+  ],
+  "context": "Source 1: The plan expands the support rollout...",
+  "synthesis": "The quarterly plan expands support coverage [1].",
+  "citations": [
+    {
+      "citation_id": 1,
+      "source_file": "q4-plan.docx",
+      "chunk_id": "chunk-1",
+      "relevance_score": 0.93,
+      "excerpt": "The plan expands the support rollout..."
+    }
+  ]
+}
+```
+
+## Legacy Compatibility Search Routes
+
+The current implementation still exposes legacy compatibility routes under `/context/search/*`:
+
+| Endpoint | Use |
+| --- | --- |
+| `POST /context/search/simple` | Simple semantic search |
+| `POST /context/search/retrieve` | Retrieval-oriented context response |
+| `POST /context/search/agentic` | Agentic search response |
+
+Prefer `POST /context/search` for new integrations. Use the compatibility routes only when you need older response shapes.
+
+## Search Inputs
+
+The unified request can target:
+
+- one collection with `collection_name`
+- multiple collections with `collection_names`
+- a specific VectorDB instance with `vectordb_id`
+- filtered search with safe metadata filters
+
+For agentic search behavior, the current implementation also supports:
+
+- `vectordb_ids`
+- `ontology_id`
+- `group_ids`
+
+## Ontology Knowledge Operations
+
+Ontology endpoints operate on a specific ontology instance and are useful for graph-backed knowledge, memory, and episode retrieval.
+
+Relevant endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /context/ontologies/{ontology_id}/knowledge` | Add knowledge from messages |
+| `POST /context/ontologies/{ontology_id}/entity` | Add a specific entity |
+| `POST /context/ontologies/{ontology_id}/search` | Search graph-backed facts |
+| `POST /context/ontologies/{ontology_id}/memory` | Return memory-style context for a query |
+| `GET /context/ontologies/{ontology_id}/episodes/{group_id}` | List recent episodes |
+| `DELETE /context/ontologies/{ontology_id}/groups/{group_id}` | Delete one knowledge group |
+| `GET /context/ontologies/{ontology_id}/health` | Check ontology backend health |
+
+### Add knowledge from messages
+
+Example request:
+
+```json
+{
+  "group_id": "conversation-42",
+  "messages": [
+    {
+      "content": "Alice approved the Q4 rollout plan.",
+      "role": "user",
+      "name": "operator"
+    }
+  ]
+}
+```
+
+### Search knowledge
+
+Example request:
+
+```json
+{
+  "query": "Who approved the Q4 rollout plan?",
+  "group_ids": ["conversation-42"],
+  "max_results": 5
+}
+```
+
+### Get memory
+
+Example request:
+
+```json
+{
+  "group_id": "conversation-42",
+  "query": "What do we know about the rollout?",
+  "max_facts": 5
+}
+```
+
+## Choosing The Right Path
+
+Use unified search when:
+
+- your content is already indexed into collections
+- you want ranked chunk retrieval
+- you need optional formatted context or synthesized answers
+
+Use ontology operations when:
+
+- you want graph-style memory from messages or entities
+- you need fact-oriented retrieval rather than chunk similarity
+- you want to organize knowledge around groups or conversations
+
+## Operational Notes
+
+- Read operations require workroom authorization
+- Some ontology calls may return `503` while a managed backend is not yet ready
+- Search results are scoped to the authorized workroom and targeted resources
+- Compatibility routes remain available, but new integrations should prefer the unified endpoint
+
+## Related Docs
+
+- [Context Service Overview](./overview)
+- [Managed Backends and Lifecycle](./managed-backends-and-lifecycle)
+- [Operations and API Reference](./operations-and-api-reference)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -96,6 +96,21 @@ const sidebars: SidebarsConfig = {
 			],
 		},
 		{
+			type: "category",
+			label: "Context Service",
+			items: [
+				{
+					type: "doc",
+					id: "context-service/overview",
+					label: "Overview",
+				},
+				"context-service/ingestion-and-storage",
+				"context-service/search-and-knowledge",
+				"context-service/managed-backends-and-lifecycle",
+				"context-service/operations-and-api-reference",
+			],
+		},
+		{
 			type: "doc",
 			id: "observability",
 			label: "Observability",

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -93,21 +93,21 @@ const sidebars: SidebarsConfig = {
 				"data-connectors",
 				"data-catalog",
 				"retrieval-service",
-			],
-		},
-		{
-			type: "category",
-			label: "Context Service",
-			items: [
 				{
-					type: "doc",
-					id: "context-service/overview",
-					label: "Overview",
+					type: "category",
+					label: "Context Service",
+					items: [
+						{
+							type: "doc",
+							id: "context-service/overview",
+							label: "Overview",
+						},
+						"context-service/ingestion-and-storage",
+						"context-service/search-and-knowledge",
+						"context-service/managed-backends-and-lifecycle",
+						"context-service/operations-and-api-reference",
+					],
 				},
-				"context-service/ingestion-and-storage",
-				"context-service/search-and-knowledge",
-				"context-service/managed-backends-and-lifecycle",
-				"context-service/operations-and-api-reference",
 			],
 		},
 		{


### PR DESCRIPTION
## Summary
- add a new Context Service section to the public platform docs
- document preview coverage for overview, ingestion/storage, search/knowledge, managed backends, and API reference
- add the Context Service category to the main sidebar after Distributed Data Engine

## Verification
- npm run build
- build completes successfully
- existing unrelated broken-link warnings remain elsewhere in the repo