### PR TITLE
ENG-3082 Add Dockerfile for containerized docs serving

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ docs/.docusaurus
 dist
 *.log
 .DS_Store
+.env*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+docs/node_modules
+docs/build
+docs/.docusaurus
+dist
+*.log
+.DS_Store

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -20,7 +20,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+
   build:
+    if: github.event_name != 'pull_request'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,35 @@
+# Container Build Pipeline
+#
+# Builds the Docusaurus docs container image defined in docker-bake.hcl
+# using the org reusable container-build workflow. Images are signed with
+# cosign, include provenance attestations and SBOMs, and are pushed to GHCR.
+#
+# The org workflow:
+#   1. Runs `prepare` to extract targets x platforms from docker-bake.hcl
+#   2. Builds each (target, platform) pair natively on arch-specific runners
+#   3. Merges per-platform digests into multi-arch OCI manifest lists
+#   4. Attests provenance, generates SBOMs, signs on main/release tags
+
+name: Container Build Pipeline
+
+on:
+  push:
+    tags: ["*"]
+    branches: [main, develop, "release/*"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    uses: kamiwaza-internal/.github/.github/workflows/container-build.yml@main
+    with:
+      bake-dir: .
+    secrets: inherit
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
 
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Validate Dockerfile via bake check
+        run: docker buildx bake -f docker-bake.hcl validate-docs
+
   build:
     if: github.event_name != 'pull_request'
     concurrency:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# Kamiwaza Docs — Docusaurus static site container
+# =============================================================================
+# Multi-stage build: npm build → serve static output.
+# Follows the same pattern as the kamiwaza frontend container.
+#
+# Stages:
+#   builder  — install deps + build Docusaurus static site
+#   runtime  — minimal Node image serving the built site
+#
+# Usage:
+#   docker build -t kamiwaza-docs .
+#   docker run -p 3000:3000 kamiwaza-docs
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Builder stage — npm install + docusaurus build
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS builder
+
+WORKDIR /build
+
+# Copy root package.json and lockfile first for cache efficiency
+COPY package.json package-lock.json ./
+
+# Install root dependencies (includes sync scripts)
+RUN npm ci --ignore-scripts
+
+# Copy the docs/ directory (contains the Docusaurus site)
+COPY docs/ docs/
+
+# Copy scripts needed by the build
+COPY scripts/ scripts/
+COPY tsconfig.json ./
+
+# Install docs-level dependencies
+WORKDIR /build/docs
+RUN npm ci
+
+# Build the Docusaurus site
+# Use build:docs (not build) to skip SDK sync — SDK docs are already
+# versioned in the repo.  This avoids needing the kamiwaza-sdk repo
+# at build time.
+WORKDIR /build
+RUN npm run build:docs
+
+# ---------------------------------------------------------------------------
+# Serve stage — install serve in isolation for a clean copy
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS serve-install
+
+WORKDIR /srv
+RUN npm init -y && npm install --omit=dev serve@14.2.4
+
+# ---------------------------------------------------------------------------
+# Runtime stage — serve the static build
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS runtime
+
+# Create non-root user matching the Kamiwaza convention (UID 65532)
+RUN groupadd -g 65532 nonroot && \
+    useradd -u 65532 -g 65532 -m -s /bin/false nonroot
+
+WORKDIR /app
+
+# Copy the built static site
+COPY --from=builder --chown=65532:65532 /build/docs/build/ /app/build/
+
+# Copy serve and its dependencies (clean install, no Docusaurus deps)
+COPY --from=serve-install --chown=65532:65532 /srv/node_modules/ /app/node_modules/
+
+USER nonroot
+
+EXPOSE 3000
+
+# Serve the static site in SPA mode on port 3000
+# --no-clipboard prevents clipboard access errors in containers
+CMD ["node", "node_modules/serve/build/main.js", "-s", "build", "-l", "3000", "--no-clipboard"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN npm ci --ignore-scripts
 WORKDIR /build
 COPY docs/ docs/
 
-# Build the Docusaurus site (baseUrl defaults to / in docusaurus.config.ts)
-WORKDIR /build
+# Build the Docusaurus site
 RUN npm run build:docs
 
 # ---------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,16 @@ COPY package.json package-lock.json ./
 # Install root dependencies (includes sync scripts)
 RUN npm ci --ignore-scripts
 
-# Copy the docs/ directory (contains the Docusaurus site)
-COPY docs/ docs/
-
-# Copy scripts needed by the build
-COPY scripts/ scripts/
-COPY tsconfig.json ./
+# Copy docs package files first for cache efficiency
+COPY docs/package.json docs/package-lock.json docs/
 
 # Install docs-level dependencies
 WORKDIR /build/docs
-RUN npm ci
+RUN npm ci --ignore-scripts
+
+# Copy the rest of the docs/ directory (Docusaurus site content)
+WORKDIR /build
+COPY docs/ docs/
 
 # Build the Docusaurus site with baseUrl="/docs/" so internal links
 # include the /docs prefix expected by the reverse proxy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,13 @@ FROM node:22-slim AS builder
 
 WORKDIR /build
 
-# Copy root package.json and lockfile first for cache efficiency
+# Root install uses --omit=dev: root devDependencies (puppeteer, ts-node, pdf-lib,
+# fs-extra, gh-pages) are only needed by sync/version/pdf scripts, not by build:docs.
+# Runtime deps are still installed — redoc (via redocusaurus) has an undeclared
+# transitive dependency on `yaml` that resolves via hoisting from the root install.
 COPY package.json package-lock.json ./
 
-# Install root dependencies (includes sync scripts)
-RUN npm ci --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy docs package files first for cache efficiency
 COPY docs/package.json docs/package-lock.json docs/
@@ -57,6 +59,8 @@ RUN npm init -y && npm install --omit=dev serve@14.2.4
 # Runtime stage — serve the static build
 # ---------------------------------------------------------------------------
 FROM node:22-slim AS runtime
+
+ENV NODE_ENV=production
 
 # Create non-root user matching the Kamiwaza convention (UID 65532)
 RUN groupadd -g 65532 nonroot && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,10 @@ WORKDIR /app
 # Copy the built static site
 COPY --from=builder --chown=65532:65532 /build/docs/build/ /app/build/
 
+# Disable clean URLs so serve doesn't 301-redirect .html requests
+# (Docusaurus SPA router can't resolve the stripped paths)
+COPY --chown=65532:65532 serve.json /app/build/
+
 # Copy serve and its dependencies (clean install, no Docusaurus deps)
 COPY --from=serve-install --chown=65532:65532 /srv/node_modules/ /app/node_modules/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@
 # Usage:
 #   docker build -t kamiwaza-docs .
 #   docker run -p 3000:3000 kamiwaza-docs
+#
+# The reverse proxy strips the /docs prefix before forwarding, so the
+# container sees requests at /.  Docusaurus is built with baseUrl="/docs/"
+# so all internal links include the prefix.
+
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -38,10 +43,11 @@ COPY tsconfig.json ./
 WORKDIR /build/docs
 RUN npm ci
 
-# Build the Docusaurus site
-# Use build:docs (not build) to skip SDK sync — SDK docs are already
-# versioned in the repo.  This avoids needing the kamiwaza-sdk repo
-# at build time.
+# Build the Docusaurus site with baseUrl="/docs/" so internal links
+# include the /docs prefix expected by the reverse proxy.
+ARG DOCS_BASE_URL="/docs/"
+ENV DOCS_BASE_URL=${DOCS_BASE_URL}
+
 WORKDIR /build
 RUN npm run build:docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@
 #   docker build -t kamiwaza-docs .
 #   docker run -p 3000:3000 kamiwaza-docs
 #
-# The reverse proxy strips the /docs prefix before forwarding, so the
-# container sees requests at /.  Docusaurus is built with baseUrl="/docs/"
-# so all internal links include the prefix.
-
+# Served behind host-based routing at docs.<domain> with baseUrl=/.
+# Matches the public deployment at docs.kamiwaza.ai.
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -43,11 +41,7 @@ RUN npm ci --ignore-scripts
 WORKDIR /build
 COPY docs/ docs/
 
-# Build the Docusaurus site with baseUrl="/docs/" so internal links
-# include the /docs prefix expected by the reverse proxy.
-ARG DOCS_BASE_URL="/docs/"
-ENV DOCS_BASE_URL=${DOCS_BASE_URL}
-
+# Build the Docusaurus site (baseUrl defaults to / in docusaurus.config.ts)
 WORKDIR /build
 RUN npm run build:docs
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ container-validate: ## Lint Dockerfile via bake check
 .PHONY: container-clean
 container-clean: ## Remove local docs container images
 	@echo "$(YELLOW)Removing docs container images...$(NC)"
-	@images=$$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "$(IMAGE_NAME)" || true); \
+	@images=$$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "(^|/)$(IMAGE_NAME):" || true); \
 		if [ -n "$$images" ]; then echo "$$images" | xargs docker rmi -f 2>/dev/null || true; fi
 	@echo "$(GREEN)Docs images removed$(NC)"
 

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,8 @@ container-validate: ## Lint Dockerfile via bake check
 .PHONY: container-clean
 container-clean: ## Remove local docs container images
 	@echo "$(YELLOW)Removing docs container images...$(NC)"
-	@docker images --format "{{.Repository}}:{{.Tag}}" | \
-		grep "$(IMAGE_NAME)" | \
-		xargs -r docker rmi -f 2>/dev/null || true
+	@images=$$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "$(IMAGE_NAME)" || true); \
+		if [ -n "$$images" ]; then echo "$$images" | xargs docker rmi -f 2>/dev/null || true; fi
 	@echo "$(GREEN)Docs images removed$(NC)"
 
 # ==============================================================================

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ NC := \033[0m
 container-build: ## Build docs container and push to local Kind registry
 	@echo "$(YELLOW)Building docs container...$(NC)"
 	@echo "$(CYAN)Registry: $(CONTAINER_REGISTRY) | Tag: $(CONTAINER_TAG)$(NC)"
-	docker build -t $(IMAGE_REF) .
-	docker push $(IMAGE_REF)
+	docker buildx build --push -t $(IMAGE_REF) .
 	@echo "$(GREEN)Docs container built and pushed: $(IMAGE_REF)$(NC)"
 
 .PHONY: container-build-local
@@ -45,7 +44,7 @@ container-build-local: container-build ## Alias for container-build
 .PHONY: container-run
 container-run: ## Build and run locally on port 3000 (no K8s needed)
 	@echo "$(YELLOW)Building docs container for local run...$(NC)"
-	docker build -t $(IMAGE_NAME):local .
+	docker buildx build --load -t $(IMAGE_NAME):local .
 	@echo "$(GREEN)Starting docs on http://localhost:3000$(NC)"
 	docker run --rm -p 3000:3000 $(IMAGE_NAME):local
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+# Makefile — Kamiwaza Docs container build
+#
+# Build and push the Docusaurus static site container to the local Kind
+# registry for development, or to GHCR for CI/release.
+#
+# Quick Reference:
+#   make container-build         # Build + push to local Kind registry
+#   make container-build-local   # Alias for container-build
+#   make container-run           # Run locally on port 3000 (no K8s)
+#   make container-clean         # Remove local images
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+CONTAINER_REGISTRY ?= host.docker.internal:5001
+IMAGE_NAME ?= kamiwaza-docs
+CONTAINER_TAG ?= local-dev
+
+# Full image reference
+IMAGE_REF := $(CONTAINER_REGISTRY)/$(IMAGE_NAME):$(CONTAINER_TAG)
+
+# Colors
+YELLOW := \033[1;33m
+GREEN := \033[1;32m
+CYAN := \033[1;36m
+RED := \033[1;31m
+NC := \033[0m
+
+# ==============================================================================
+# Container Build Targets
+# ==============================================================================
+
+.PHONY: container-build
+container-build: ## Build docs container and push to local Kind registry
+	@echo "$(YELLOW)Building docs container...$(NC)"
+	@echo "$(CYAN)Registry: $(CONTAINER_REGISTRY) | Tag: $(CONTAINER_TAG)$(NC)"
+	docker build -t $(IMAGE_REF) .
+	docker push $(IMAGE_REF)
+	@echo "$(GREEN)Docs container built and pushed: $(IMAGE_REF)$(NC)"
+
+.PHONY: container-build-local
+container-build-local: container-build ## Alias for container-build
+
+.PHONY: container-run
+container-run: ## Build and run locally on port 3000 (no K8s needed)
+	@echo "$(YELLOW)Building docs container for local run...$(NC)"
+	docker build -t $(IMAGE_NAME):local .
+	@echo "$(GREEN)Starting docs on http://localhost:3000$(NC)"
+	docker run --rm -p 3000:3000 $(IMAGE_NAME):local
+
+# ==============================================================================
+# Docusaurus Development
+# ==============================================================================
+
+.PHONY: dev
+dev: ## Start Docusaurus dev server (requires npm install first)
+	npm run start
+
+.PHONY: build
+build: ## Build Docusaurus static site locally
+	npm run build
+
+.PHONY: install
+install: ## Install dependencies
+	npm ci
+	cd docs && npm ci
+
+# ==============================================================================
+# Cleanup
+# ==============================================================================
+
+.PHONY: container-clean
+container-clean: ## Remove local docs container images
+	@echo "$(YELLOW)Removing docs container images...$(NC)"
+	@docker images --format "{{.Repository}}:{{.Tag}}" | \
+		grep "$(IMAGE_NAME)" | \
+		xargs -r docker rmi -f 2>/dev/null || true
+	@echo "$(GREEN)Docs images removed$(NC)"
+
+# ==============================================================================
+# Help
+# ==============================================================================
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  $(CYAN)%-25s$(NC) %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 # registry for development, or to GHCR for CI/release.
 #
 # Quick Reference:
-#   make container-build         # Build + push to local Kind registry
+#   make container-build         # Build + push to local Kind registry (bake)
 #   make container-build-local   # Alias for container-build
-#   make container-run           # Run locally on port 3000 (no K8s)
+#   make container-validate      # Lint Dockerfile (bake --call check)
 #   make container-clean         # Remove local images
 
 # ==============================================================================
@@ -15,10 +15,9 @@
 
 CONTAINER_REGISTRY ?= host.docker.internal:5001
 IMAGE_NAME ?= kamiwaza-docs
-CONTAINER_TAG ?= local-dev
 
-# Full image reference
-IMAGE_REF := $(CONTAINER_REGISTRY)/$(IMAGE_NAME):$(CONTAINER_TAG)
+# Read version from package.json for image tagging
+DOCS_VERSION := $(shell node -p "require('./package.json').version" 2>/dev/null)
 
 # Colors
 YELLOW := \033[1;33m
@@ -33,37 +32,18 @@ NC := \033[0m
 
 .PHONY: container-build
 container-build: ## Build docs container and push to local Kind registry
-	@echo "$(YELLOW)Building docs container...$(NC)"
-	@echo "$(CYAN)Registry: $(CONTAINER_REGISTRY) | Tag: $(CONTAINER_TAG)$(NC)"
-	docker buildx build --push -t $(IMAGE_REF) .
-	@echo "$(GREEN)Docs container built and pushed: $(IMAGE_REF)$(NC)"
+	@echo "$(YELLOW)Building docs container via docker bake...$(NC)"
+	@echo "$(CYAN)Registry: $(CONTAINER_REGISTRY) | Version: $(DOCS_VERSION)$(NC)"
+	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) IMAGE_NAME=$(IMAGE_NAME) DOCS_VERSION=$(DOCS_VERSION) \
+		docker buildx bake -f docker-bake.hcl local-docs
+	@echo "$(GREEN)Docs container built and pushed to $(CONTAINER_REGISTRY)/$(IMAGE_NAME):local-dev$(NC)"
 
 .PHONY: container-build-local
 container-build-local: container-build ## Alias for container-build
 
-.PHONY: container-run
-container-run: ## Build and run locally on port 3000 (no K8s needed)
-	@echo "$(YELLOW)Building docs container for local run...$(NC)"
-	docker buildx build --load -t $(IMAGE_NAME):local .
-	@echo "$(GREEN)Starting docs on http://localhost:3000$(NC)"
-	docker run --rm -p 3000:3000 $(IMAGE_NAME):local
-
-# ==============================================================================
-# Docusaurus Development
-# ==============================================================================
-
-.PHONY: dev
-dev: ## Start Docusaurus dev server (requires npm install first)
-	npm run start
-
-.PHONY: build
-build: ## Build Docusaurus static site locally
-	npm run build
-
-.PHONY: install
-install: ## Install dependencies
-	npm ci
-	cd docs && npm ci
+.PHONY: container-validate
+container-validate: ## Lint Dockerfile via bake check
+	docker buildx bake -f docker-bake.hcl validate-docs
 
 # ==============================================================================
 # Cleanup

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,139 @@
+// ============================================================================
+// Kamiwaza Docs — Container Build System (HCL)
+//
+// Single-image build for the Docusaurus static site container.
+// Follows the three-target pattern from the kamiwaza repo:
+//   docs target    → CI builds (multi-arch, metadata-action overlay)
+//   local-docs     → local dev builds (push to Kind registry + load to Docker)
+//   validate-docs  → Dockerfile lint (docker buildx bake --call check)
+//
+// Local builds:  docker buildx bake -f docker-bake.hcl local-docs
+//   → host.docker.internal:5001/kamiwaza-docs:local-dev
+// Inspect:       docker buildx bake -f docker-bake.hcl --print
+// Validate:      docker buildx bake -f docker-bake.hcl validate-docs
+// ============================================================================
+
+
+// ── Variables ───────────────────────────────────────────────────────────────
+
+variable "CONTAINER_REGISTRY" {
+  default = "host.docker.internal:5001"
+}
+
+// CI sets this to "kamiwaza-ai" so images land at ghcr.io/kamiwaza-ai/kamiwaza-docs.
+// Local builds don't use a prefix — the image name is the full repository path.
+variable "IMAGE_NAME" {
+  default = "kamiwaza-docs"
+}
+
+// Docs version. Populated automatically:
+//   - Local builds: Makefile reads package.json and exports it
+//   - CI builds:    the container-build action can set it
+variable "DOCS_VERSION" {
+  default = ""
+}
+
+// CI sets ATTEST=1 to enable provenance and SBOM attestations.
+variable "ATTEST" {
+  default = ""
+}
+
+
+// ============================================================================
+// Manifest Annotations Helper
+// ============================================================================
+
+function "manifest_annotations" {
+  params = [title, description, version]
+  result = [
+    "manifest:org.opencontainers.image.title=${title}",
+    "manifest:org.opencontainers.image.description=${description}",
+    "manifest:org.opencontainers.image.version=${version}",
+    "manifest:org.opencontainers.image.authors=Kamiwaza AI <support@kamiwaza.ai>",
+    "manifest:org.opencontainers.image.vendor=Kamiwaza AI",
+    "manifest:org.opencontainers.image.licenses=Kamiwaza EULA <https://www.kamiwaza.ai/eula-license>",
+    "manifest:org.opencontainers.image.url=https://www.kamiwaza.ai/",
+    "manifest:org.opencontainers.image.documentation=https://docs.kamiwaza.ai/",
+  ]
+}
+
+
+// ============================================================================
+// Base Targets
+// ============================================================================
+
+// Empty target for GitHub metadata-action inheritance
+target "docker-metadata-action" {}
+
+target "_common" {
+  inherits = ["docker-metadata-action"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+  ]
+  labels = {
+    "org.opencontainers.image.version"       = DOCS_VERSION
+    "org.opencontainers.image.authors"       = "Kamiwaza AI <support@kamiwaza.ai>"
+    "org.opencontainers.image.vendor"        = "Kamiwaza AI"
+    "org.opencontainers.image.licenses"      = "Kamiwaza EULA <https://www.kamiwaza.ai/eula-license>"
+    "org.opencontainers.image.url"           = "https://www.kamiwaza.ai/"
+    "org.opencontainers.image.documentation" = "https://docs.kamiwaza.ai/"
+  }
+  annotations = [
+    "manifest:org.opencontainers.image.authors=Kamiwaza AI <support@kamiwaza.ai>",
+    "manifest:org.opencontainers.image.vendor=Kamiwaza AI",
+    "manifest:org.opencontainers.image.licenses=Kamiwaza EULA <https://www.kamiwaza.ai/eula-license>",
+    "manifest:org.opencontainers.image.url=https://www.kamiwaza.ai/",
+    "manifest:org.opencontainers.image.documentation=https://docs.kamiwaza.ai/",
+  ]
+  attest = equal("1", ATTEST) ? [
+    "type=provenance,mode=max",
+    "type=sbom"
+  ] : []
+}
+
+
+// ============================================================================
+// Docs Target
+// ============================================================================
+
+target "docs" {
+  inherits   = ["_common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  labels = {
+    "org.opencontainers.image.title"       = "Kamiwaza Docs"
+    "org.opencontainers.image.description" = "Kamiwaza Docusaurus documentation site for air-gapped deployments."
+  }
+  annotations = manifest_annotations("Kamiwaza Docs", "Kamiwaza Docusaurus documentation site for air-gapped deployments.", DOCS_VERSION)
+  cache-from  = ["type=registry,ref=${CONTAINER_REGISTRY}/${IMAGE_NAME}:buildcache"]
+  cache-to    = ["type=registry,ref=${CONTAINER_REGISTRY}/${IMAGE_NAME}:buildcache,mode=max"]
+}
+
+target "local-docs" {
+  inherits  = ["docs"]
+  tags      = notequal("", DOCS_VERSION) ? [
+    "${CONTAINER_REGISTRY}/${IMAGE_NAME}:local-dev",
+    "${CONTAINER_REGISTRY}/${IMAGE_NAME}:${DOCS_VERSION}",
+  ] : ["${CONTAINER_REGISTRY}/${IMAGE_NAME}:local-dev"]
+  output    = ["type=image,push=true"]
+  platforms = []
+}
+
+target "validate-docs" {
+  inherits = ["docs"]
+  call     = "check"
+}
+
+
+// ============================================================================
+// Groups
+// ============================================================================
+
+group "all" {
+  targets = ["docs"]
+}
+
+group "default" {
+  targets = ["local-docs"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -79,13 +79,6 @@ target "_common" {
     "org.opencontainers.image.url"           = "https://www.kamiwaza.ai/"
     "org.opencontainers.image.documentation" = "https://docs.kamiwaza.ai/"
   }
-  annotations = [
-    "manifest:org.opencontainers.image.authors=Kamiwaza AI <support@kamiwaza.ai>",
-    "manifest:org.opencontainers.image.vendor=Kamiwaza AI",
-    "manifest:org.opencontainers.image.licenses=Kamiwaza EULA <https://www.kamiwaza.ai/eula-license>",
-    "manifest:org.opencontainers.image.url=https://www.kamiwaza.ai/",
-    "manifest:org.opencontainers.image.documentation=https://docs.kamiwaza.ai/",
-  ]
   attest = equal("1", ATTEST) ? [
     "type=provenance,mode=max",
     "type=sbom"

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -28,8 +28,8 @@ const config: Config = {
 	tagline: "Kamiwaza AI Platform Documentation",
 	favicon: "img/favicon.ico",
 
-	url: "https://docs.kamiwaza.ai",
-	baseUrl: "/",
+	url: process.env.DOCS_URL || "https://docs.kamiwaza.ai",
+	baseUrl: process.env.DOCS_BASE_URL || "/",
 	trailingSlash: false,
 
 	markdown: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -28,8 +28,8 @@ const config: Config = {
 	tagline: "Kamiwaza AI Platform Documentation",
 	favicon: "img/favicon.ico",
 
-	url: process.env.DOCS_URL || "https://docs.kamiwaza.ai",
-	baseUrl: process.env.DOCS_BASE_URL || "/",
+	url: "https://docs.kamiwaza.ai",
+	baseUrl: "/",
 	trailingSlash: false,
 
 	markdown: {

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": false
+}


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile: Docusaurus static build → `serve` on port 3000
- Follows frontend container pattern (node:22-slim, UID 65532, SPA mode)
- Built with `baseUrl="/"` — matches the public deployment at docs.kamiwaza.ai exactly
- `serve.json` disables clean URLs to serve static `.html` files directly
- `docker-bake.hcl` with three-target pattern (docs/local-docs/validate-docs) for CI and local builds
- GitHub Actions workflow for CI builds to GHCR
- Zero changes to docs content — all `.md` files are untouched

## Context
For air-gapped deployments where docs.kamiwaza.ai is unreachable. The container is served at `docs.<domain>` via host-based routing. A companion PR in the deploy repo handles the deployment configuration (`docs.enabled: false` by default).

## Test plan
- [x] `make container-build` builds and pushes to local Kind registry
- [x] `make container-validate` passes (Dockerfile lint)
- [x] Docs site loads at `https://docs.kamiwaza.test`
- [x] Static files (e.g., embedded leaderboard iframe) render correctly
- [x] All navigation links work without modification to docs content
- [x] Container runs as non-root (UID 65532)
- [ ] CI workflow pushes to GHCR (triggers on merge, not yet tested)