### PR TITLE
ENG-2962: Add security verification and workrooms to admin guide

### DIFF
--- a/docs/docs/security/admin-guide.md
+++ b/docs/docs/security/admin-guide.md
@@ -180,7 +180,7 @@ Kamiwaza defines three primary roles:
 
 There is also an `extension` role used as a service identity for platform extensions and automated tools. It is not assigned to human users.
 
-> **Current state:** Today, the platform enforces two effective access tiers: `admin` (full access) and everyone else (`user`/`viewer`). Finer-grained role distinctions are planned but not yet enforced at the endpoint level.
+> **Current state:** The gateway RBAC policy enforces different rules per role (e.g., `viewer` cannot access write endpoints). At the FastAPI endpoint level, most routes currently distinguish `admin` vs. any authenticated user.
 
 **Assigning Roles:**
 
@@ -388,6 +388,8 @@ Workrooms are collaborative workspaces that group resources and control team acc
 | **contributor** | Create and modify resources within the workroom |
 | **viewer** | Read-only access to workroom resources |
 
+Workroom roles are separate from platform RBAC roles. The workroom `contributor` role maps to the ReBAC `editor` relation — the product uses "contributor" to distinguish workroom-level write access from any future platform-level `editor` role.
+
 Workroom access is enforced via ReBAC tuples when ReBAC is enabled, or via the workroom service's built-in membership checks in RBAC-only mode.
 
 ### 3.5 Hot Reload (No Restart Required)
@@ -404,7 +406,7 @@ The RBAC policy file is automatically reloaded when modified:
 
 **⚠️ Important:** Invalid YAML syntax will prevent reload and retain the previous valid configuration.
 
-### 3.4 Adding Custom Endpoints
+### 3.6 Adding Custom Endpoints
 
 **Example: Protecting a new analytics endpoint**
 
@@ -881,8 +883,12 @@ The same information is available in machine-readable form at `/api/openapi.json
 
 A small number of endpoints are accessible without authentication. These exist because they must function before a user has logged in (login flows, health probes, consent gates). Each one is documented in the OpenAPI spec with the reason it's public.
 
-Common examples:
-- `/api/auth/*` — Login, logout, OAuth callbacks, SAML flows, token refresh
+Common examples (not all `/api/auth/` routes are public — many require authentication):
+- `/api/auth/login`, `/api/auth/logout` — Browser login/logout flows
+- `/api/auth/token`, `/api/auth/refresh` — Token acquisition and refresh
+- `/api/auth/callback`, `/api/auth/saml/acs` — OAuth/SAML callbacks from identity providers
+- `/api/auth/jwks` — Public key discovery for token verification
+- `/api/auth/validate` — Token validation service
 - `/api/security/public/config` — Pre-login consent gate and classification banner configuration
 - `/api/node/node_status` — Kubernetes liveness probe
 
@@ -894,15 +900,15 @@ These settings must be reviewed before deploying to production:
 |---------|-------------|-----------------|
 | `KAMIWAZA_USE_AUTH` | Master switch for authentication enforcement | `true` — **must** be enabled |
 | `AUTH_GATEWAY_DEFAULT_DENY` | Reject requests that don't match any policy rule | `true` — prevents unintended access |
-| `AUTH_FORWARD_HEADER_SECRET` | HMAC secret for signing identity headers between Traefik and the API | **Must be set** — without this, identity headers can be spoofed |
+| `AUTH_FORWARD_HEADER_SECRET` | HMAC secret for signing identity headers between Traefik and the API | **Must be set** — in production, unsigned ForwardAuth headers are rejected; in dev mode, a warning is logged but requests proceed |
 | `AUTH_GATEWAY_ENABLE_DEV_ENDPOINTS` | Enables `/auth/mint` for minting arbitrary tokens | `false` — **never** enable in production |
 | `AUTH_REBAC_ENABLED` | Enable relationship-based access control | Your choice — `false` for RBAC-only, `true` for fine-grained resource control |
 
-The platform refuses to start with `KAMIWAZA_USE_AUTH=false` in production-like environments (returns HTTP 503 instead of silently running without auth).
+In production-like environments, setting `KAMIWAZA_USE_AUTH=false` causes all authenticated API requests to return HTTP 503 rather than silently running without auth.
 
 ### 6.4 ReBAC Verification
 
-If ReBAC is enabled, you can check for authorization tuple drift using the tenant management tool:
+If ReBAC is enabled, you can check for authorization tuple drift using the tenant management tool (`scripts/rebac_tenant.py` in the platform installation directory, requires Python 3.12+):
 
 ```bash
 # Check if actual tuples match the expected baseline

--- a/docs/docs/security/admin-guide.md
+++ b/docs/docs/security/admin-guide.md
@@ -178,6 +178,10 @@ Kamiwaza defines three primary roles:
 | **user** | Standard access: read, write (no delete/admin) | Data scientists, developers, analysts |
 | **viewer** | Read-only access | Auditors, observers, stakeholders |
 
+There is also an `extension` role used as a service identity for platform extensions and automated tools. It is not assigned to human users.
+
+> **Current state:** Today, the platform enforces two effective access tiers: `admin` (full access) and everyone else (`user`/`viewer`). Finer-grained role distinctions are planned but not yet enforced at the endpoint level.
+
 **Assigning Roles:**
 
 1. Navigate to **Users** → Select user
@@ -374,7 +378,19 @@ Once a tuple exists, the UI/API automatically enforces it—no redeploy or resta
 - **Embedding endpoints** require an authenticated user.
 - **Vector database endpoints** (create, search, manage collections) require admin access and return a clear error if no VectorDB is deployed.
 
-### 3.3 Hot Reload (No Restart Required)
+### 3.4 Workrooms
+
+Workrooms are collaborative workspaces that group resources and control team access. Each workroom has its own membership model:
+
+| Workroom Role | Access |
+|---------------|--------|
+| **owner** | Full control — manage members, archive, delete the workroom |
+| **contributor** | Create and modify resources within the workroom |
+| **viewer** | Read-only access to workroom resources |
+
+Workroom access is enforced via ReBAC tuples when ReBAC is enabled, or via the workroom service's built-in membership checks in RBAC-only mode.
+
+### 3.5 Hot Reload (No Restart Required)
 
 The RBAC policy file is automatically reloaded when modified:
 
@@ -849,9 +865,58 @@ If `KAMIWAZA_EPHEMERAL_EXTENSIONS=true` is set, this should return empty results
 
 ---
 
-## 6. Monitoring & Troubleshooting
+## 6. Verifying Security Posture
 
-### 6.1 Health Checks
+### 6.1 OpenAPI Spec Verification
+
+The platform's interactive API documentation at `/api/docs` shows the authentication requirements for every endpoint:
+
+- Endpoints marked with a **lock icon** require authentication
+- The **`x-auth-role`** field in each endpoint's details shows the minimum role required (e.g., `admin` for destructive operations, `authenticated` for read operations)
+- Endpoints marked **`x-auth-exempt`** are intentionally public, with a documented reason (e.g., "Pre-login consent gate" or "Kubernetes health probe")
+
+The same information is available in machine-readable form at `/api/openapi.json` for automated security scanning tools.
+
+### 6.2 Intentionally Public Endpoints
+
+A small number of endpoints are accessible without authentication. These exist because they must function before a user has logged in (login flows, health probes, consent gates). Each one is documented in the OpenAPI spec with the reason it's public.
+
+Common examples:
+- `/api/auth/*` — Login, logout, OAuth callbacks, SAML flows, token refresh
+- `/api/security/public/config` — Pre-login consent gate and classification banner configuration
+- `/api/node/node_status` — Kubernetes liveness probe
+
+### 6.3 Production Hardening Checklist
+
+These settings must be reviewed before deploying to production:
+
+| Setting | What It Does | Production Value |
+|---------|-------------|-----------------|
+| `KAMIWAZA_USE_AUTH` | Master switch for authentication enforcement | `true` — **must** be enabled |
+| `AUTH_GATEWAY_DEFAULT_DENY` | Reject requests that don't match any policy rule | `true` — prevents unintended access |
+| `AUTH_FORWARD_HEADER_SECRET` | HMAC secret for signing identity headers between Traefik and the API | **Must be set** — without this, identity headers can be spoofed |
+| `AUTH_GATEWAY_ENABLE_DEV_ENDPOINTS` | Enables `/auth/mint` for minting arbitrary tokens | `false` — **never** enable in production |
+| `AUTH_REBAC_ENABLED` | Enable relationship-based access control | Your choice — `false` for RBAC-only, `true` for fine-grained resource control |
+
+The platform refuses to start with `KAMIWAZA_USE_AUTH=false` in production-like environments (returns HTTP 503 instead of silently running without auth).
+
+### 6.4 ReBAC Verification
+
+If ReBAC is enabled, you can check for authorization tuple drift using the tenant management tool:
+
+```bash
+# Check if actual tuples match the expected baseline
+python scripts/rebac_tenant.py diff
+
+# Export current tuples for review
+python scripts/rebac_tenant.py export
+```
+
+---
+
+## 7. Monitoring & Troubleshooting
+
+### 7.1 Health Checks
 
 **Auth Service Health Endpoint:**
 
@@ -880,11 +945,11 @@ curl http://localhost:8080/health/ready
 {"status":"UP"}
 ```
 
-### 6.2 Log Monitoring
+### 7.2 Log Monitoring
 
 Refer to the [Observability Guide](../observability.md) for end-to-end logging, OTEL, and SIEM integration. It covers how to tail auth logs, forward them to your enterprise collectors, and verify that allow/deny events appear in the standard dashboards.
 
-### 6.3 Common Issues and Solutions
+### 7.3 Common Issues and Solutions
 
 #### Issue: 401 Unauthorized on All Requests
 
@@ -997,7 +1062,7 @@ Refer to the [Observability Guide](../observability.md) for end-to-end logging, 
 - Ensure client secret is configured in Keycloak
 - Enable identity provider in Keycloak authentication flow
 
-### 6.4 Diagnostic Commands
+### 7.4 Diagnostic Commands
 
 **Test Token Generation:**
 
@@ -1103,6 +1168,10 @@ The same curl commands can be scripted in CI to ensure future changes do not bre
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
+| `AUTH_GATEWAY_DEFAULT_DENY` | Reject requests not matching any policy rule | `true` | Yes (production) |
+| `AUTH_FORWARD_HEADER_SECRET` | HMAC secret for ForwardAuth header signing | - | Yes (production) |
+| `AUTH_GATEWAY_ENABLE_DEV_ENDPOINTS` | Enable `/auth/mint` token minting | `false` | No (must be `false` in production) |
+| `AUTH_REBAC_ENABLED` | Enable relationship-based access control | `false` | No |
 | `AUTH_REQUIRE_SUB` | Require 'sub' claim in tokens | `false` | No |
 | `AUTH_EXPOSE_TOKEN_HEADER` | Expose token in response headers | `true` | No |
 | `AUTH_ALLOW_UNSIGNED_STATE` | Allow unsigned OIDC state | `true` (dev only) | No |

--- a/docs/docs/security/admin-guide.md
+++ b/docs/docs/security/admin-guide.md
@@ -178,7 +178,7 @@ Kamiwaza defines three primary roles:
 | **user** | Standard access: read, write (no delete/admin) | Data scientists, developers, analysts |
 | **viewer** | Read-only access | Auditors, observers, stakeholders |
 
-There is also an `extension` role used as a service identity for platform extensions and automated tools. It is not assigned to human users.
+There is also an `extension` role used as a service identity for platform extensions and automated tools. It is assigned via Keycloak service accounts or client credentials, not to human users.
 
 > **Current state:** The gateway RBAC policy enforces different rules per role (e.g., `viewer` cannot access write endpoints). At the FastAPI endpoint level, most routes currently distinguish `admin` vs. any authenticated user.
 
@@ -871,7 +871,7 @@ If `KAMIWAZA_EPHEMERAL_EXTENSIONS=true` is set, this should return empty results
 
 ### 6.1 OpenAPI Spec Verification
 
-The platform's interactive API documentation at `/api/docs` shows the authentication requirements for every endpoint:
+The platform's interactive API documentation at `/api/docs` on a **running deployment** shows the authentication requirements for every endpoint:
 
 - Endpoints marked with a **lock icon** require authentication
 - The **`x-auth-role`** field in each endpoint's details shows the minimum role required (e.g., `admin` for destructive operations, `authenticated` for read operations)
@@ -879,18 +879,21 @@ The platform's interactive API documentation at `/api/docs` shows the authentica
 
 The same information is available in machine-readable form at `/api/openapi.json` for automated security scanning tools.
 
+> **Note:** These annotations are generated at runtime by the live API. Static OpenAPI exports in this documentation repository do not include them. Always query the live `/api/openapi.json` endpoint for the authoritative auth surface.
+
 ### 6.2 Intentionally Public Endpoints
 
-A small number of endpoints are accessible without authentication. These exist because they must function before a user has logged in (login flows, health probes, consent gates). Each one is documented in the OpenAPI spec with the reason it's public.
+A small number of endpoints are accessible without authentication because they serve pre-login flows, health probes, or token operations. These are marked with `x-auth-exempt` in the live OpenAPI spec at `/api/openapi.json`.
 
-Common examples (not all `/api/auth/` routes are public — many require authentication):
-- `/api/auth/login`, `/api/auth/logout` — Browser login/logout flows
-- `/api/auth/token`, `/api/auth/refresh` — Token acquisition and refresh
-- `/api/auth/callback`, `/api/auth/saml/acs` — OAuth/SAML callbacks from identity providers
-- `/api/auth/jwks` — Public key discovery for token verification
-- `/api/auth/validate` — Token validation service
-- `/api/security/public/config` — Pre-login consent gate and classification banner configuration
-- `/api/node/node_status` — Kubernetes liveness probe
+Note: not all `/api/auth/` routes are public — user management, tuple administration, and IdP configuration endpoints require authentication.
+
+Common public endpoints:
+- `/api/auth/login`, `/api/auth/token`, `/api/auth/refresh` — Login and token lifecycle
+- `/api/auth/callback`, `/api/auth/saml/acs` — Identity provider callbacks
+- `/api/auth/jwks`, `/api/auth/validate` — Token verification
+- `/api/auth/logout` — Session termination
+- `/api/security/public/config` — Pre-login consent gate and banner configuration
+- `/api/node/node_status` — Kubernetes health probe
 
 ### 6.3 Production Hardening Checklist
 
@@ -903,6 +906,7 @@ These settings must be reviewed before deploying to production:
 | `AUTH_FORWARD_HEADER_SECRET` | HMAC secret for signing identity headers between Traefik and the API | **Must be set** — in production, unsigned ForwardAuth headers are rejected; in dev mode, a warning is logged but requests proceed |
 | `AUTH_GATEWAY_ENABLE_DEV_ENDPOINTS` | Enables `/auth/mint` for minting arbitrary tokens | `false` — **never** enable in production |
 | `AUTH_REBAC_ENABLED` | Enable relationship-based access control | Your choice — `false` for RBAC-only, `true` for fine-grained resource control |
+| `AUTH_ALLOW_UNSIGNED_STATE` | Allow unsigned OIDC state parameter | `false` — recommended in production to prevent state tampering |
 
 In production-like environments, setting `KAMIWAZA_USE_AUTH=false` causes all authenticated API requests to return HTTP 503 rather than silently running without auth.
 
@@ -1180,7 +1184,7 @@ The same curl commands can be scripted in CI to ensure future changes do not bre
 | `AUTH_REBAC_ENABLED` | Enable relationship-based access control | `false` | No |
 | `AUTH_REQUIRE_SUB` | Require 'sub' claim in tokens | `false` | No |
 | `AUTH_EXPOSE_TOKEN_HEADER` | Expose token in response headers | `true` | No |
-| `AUTH_ALLOW_UNSIGNED_STATE` | Allow unsigned OIDC state | `true` (dev only) | No |
+| `AUTH_ALLOW_UNSIGNED_STATE` | Allow unsigned OIDC state | `true` (dev only) | Recommended `false` in production |
 | `AUTH_GATEWAY_TOKEN_LEEWAY` | Clock skew tolerance (seconds) | `30` | No |
 | `AUTH_GATEWAY_JWKS_CACHE_TTL` | JWKS cache duration (seconds) | `300` | No |
 


### PR DESCRIPTION
## Summary

Updates the existing security Administrator Guide with content from Auth N/Z 1.0 (UAC-3.4 / UAC-4). Adds to the existing doc rather than creating a separate file.

## Changes

- **Roles note**: Documents current state (admin + everyone else) and extension role
- **Workrooms section** (3.4): Owner/contributor/viewer workroom roles and how they integrate with ReBAC
- **Verifying Security Posture** (section 6): New section covering:
  - OpenAPI lock icons and `x-auth-role` annotations (from [kamiwaza PR #1403](https://github.com/kamiwaza-internal/kamiwaza/pull/1403))
  - Intentionally public endpoints and why they're exempt
  - Production hardening checklist (5 critical env vars)
  - ReBAC tuple drift verification
- **Appendix A**: Added missing hardening env vars (`AUTH_GATEWAY_DEFAULT_DENY`, `AUTH_FORWARD_HEADER_SECRET`, `AUTH_GATEWAY_ENABLE_DEV_ENDPOINTS`, `AUTH_REBAC_ENABLED`)

## Related

- Platform PR: https://github.com/kamiwaza-internal/kamiwaza/pull/1403 (OpenAPI auth annotations)
- Linear: ENG-2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)