### PR TITLE
Document shared workroom conversation behavior

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -145,7 +145,10 @@ Reference: [Kaizen User Guide](/extensions/kaizen/kaizen-user-guide)
 2. Create a workroom with a title, classification banner, and optional labels.
 3. Decide whether the workroom should be persistent or temporary.
 4. Launch Kaizen from inside the workroom and confirm the app opens successfully.
-5. If sharing is enabled in your environment, add at least one collaborator and verify role-based behavior.
+5. If sharing is enabled in your environment, add at least one Contributor and one Viewer.
+6. Verify the Contributor can see the same non-global workroom agents and conversation history, add a later turn, and retain acting-user attribution on that turn.
+7. Verify the Viewer can see the same shared history but cannot create, send, upload, or edit.
+8. Verify the Global Workroom still preserves personal Kaizen visibility instead of cross-user sharing.
 
 Reference: [Workroom Manager User Guide](/extensions/workroom-manager/workroom-manager-user-guide)
 

--- a/docs/extensions/kaizen/kaizen-user-guide.md
+++ b/docs/extensions/kaizen/kaizen-user-guide.md
@@ -11,6 +11,8 @@ Instead of writing code to configure agents, you get a visual interface. Instead
 
 If you launch Kaizen from **Workroom Manager**, the conversation runs inside that workroom context. That lets analysts keep their agent activity aligned to a specific mission or case while still using the same Kaizen workflows described here.
 
+In a shared non-global workroom, Kaizen agents, conversations, uploads, and generated outputs are visible to authorized workroom members according to role. Owners and Contributors can continue shared conversations, while Viewers can open them read-only. The **Global Workroom** keeps legacy personal visibility behavior and is not treated as a shared Kaizen workspace.
+
 ---
 
 ## Launch Kaizen
@@ -133,13 +135,13 @@ After creation, your agent appears in the library. Each agent card shows its nam
 ![Agent Library](/img/extensions/kaizen/onboarding-07-agent-library.png)
 
 - **Chat**: Start a new conversation with this agent.
-- **Private Session**: Start an ephemeral conversation that is automatically deleted when you leave. This is useful for sensitive or one-off tasks.
+- **Private Session**: Start an ephemeral conversation that is automatically deleted when you leave. This is available in personal/global scope and is intended for sensitive or one-off tasks.
 - **Configure**: Edit the agent's model, skills, bundles, tools, or security policy.
 - **Delete**: Remove the agent and its conversations.
 
-Create as many agents as you need, such as a research agent, a data analyst, or a report writer. Each agent keeps its own configuration and conversation history.
+Create as many agents as you need, such as a research agent, a data analyst, or a report writer. Each agent keeps its own configuration. In a shared non-global workroom, that agent and its conversations are visible to other authorized workroom members, while the creator remains recorded for attribution and auditing. Shared visibility does not automatically grant reuse of the creator's private credentials; collaborator runs continue to use the acting user's own credentials or an explicitly shared workroom credential path.
 
-The left sidebar shows your recent conversations across all agents. Click any conversation to resume where you left off.
+The left sidebar shows recent conversations across all visible agents. In a shared non-global workroom, that means shared workroom history by default, with a list-level filter for items created by you. Click any conversation to resume where work left off.
 
 ---
 
@@ -192,6 +194,114 @@ The generated PDF is viewable and downloadable directly in the right panel.
 
 ---
 
+## Conversations
+
+The **Conversations** tab gives you a dedicated view of all visible conversations across every agent.
+
+Use the filters at the top of the page to narrow down what you're looking for:
+
+- **Filter by Agent** — select a specific agent to see only its conversations, or choose All Agents.
+- **Visibility** — switch between all workroom-visible conversations and only the ones you created.
+- **Sort By** — order conversations by most recent or other criteria.
+
+In a shared non-global workroom, this view is designed for handoff as well as recall. Click any conversation to resume where work left off, even if another Owner or Contributor created the earlier turns.
+
+---
+
+## Search
+
+The **Search** tab lets you search across all your past conversations to find specific messages, tool calls, and results.
+
+### Searching Conversations
+
+Enter a search term to find matching content across all conversations. You can refine results with filters:
+
+- **Tool Name** — filter by a specific tool (e.g., web search, code execution, file access).
+- **Event Type** — filter by the type of event (messages, tool calls, results).
+- **Date Range** — narrow results to a specific time window using the From and To date fields.
+
+Click **Search** to run your query. Results show matching content with context so you can quickly locate what you need.
+
+### Recipes
+
+The **Recipes** tab (next to Search) lets you save useful tool call patterns that you discover while searching. Recipes capture a reusable pattern so you can reference it later without having to search for it again.
+
+To create a recipe, find a tool call pattern in your search results and save it. Your saved recipes appear in the left sidebar for quick access.
+
+Recipes are useful for:
+
+- Capturing effective tool call sequences that produced good results
+- Building a personal library of proven patterns for common tasks
+- Sharing approaches across sessions without recreating them from scratch
+
+---
+
+## Metrics
+
+The **Metrics** tab provides a **Pipeline Dashboard** for monitoring Kaizen activity.
+
+The dashboard includes two views:
+
+- **Ingestion** — tracks data ingestion activity, including volume and timing.
+- **Model Health** — monitors inference performance and model availability.
+
+Use the time range selector (**24h**, **7d**, **30d**) to adjust the reporting window.
+
+The Metrics dashboard is most useful once you have active agents running conversations and processing data.
+
+---
+
+## Workroom Collaboration
+
+When Kaizen is launched from a workroom, a **workroom info bar** appears at the top of the page showing the workroom name and classification banner. Click it to expand the workroom status summary.
+
+![Workroom Collaboration panel](/img/extensions/kaizen/kaizen-workroom-collaboration.png)
+
+The expanded bar shows:
+
+| Field | Description |
+| :--- | :--- |
+| **Workroom** | The name of the workroom this Kaizen session belongs to. |
+| **Role** | Your role in the workroom (Owner, Contributor, or Viewer). |
+| **Members** | Total number of members with access to this workroom. |
+| **Live Now** | How many members are currently active in the workroom. |
+
+Click **Collaboration** to open the full collaboration panel on the right side. The panel includes:
+
+### Active Now
+
+Shows which members are currently active or idle in the workroom. This is a live view from the collaboration stream — use it to see who else is working in the same workroom at the same time.
+
+### Shared History
+
+In a shared non-global workroom, Kaizen keeps conversation history as shared workroom history. Later Owners and Contributors can open the same thread and continue it without losing prior context. Viewers can read that history but cannot add turns, upload files, or mutate agent settings.
+
+### Turn Attribution
+
+Kaizen attributes each human or agent-triggering turn to the acting user who initiated it. That attribution stays with the turn for later handoff and review; it is not inferred from the original conversation creator.
+
+### Member Roster
+
+Lists all workroom members with their roles and online status. Owners can click **Manage members** to open the full membership management panel directly from within Kaizen.
+
+![Workroom Members management panel](/img/extensions/kaizen/kaizen-workroom-members.png)
+
+The **Workroom Members** panel lets owners:
+
+- **Invite a member** — enter an email address, select a role (Viewer or Contributor), and confirm the attestation: *"I confirm the invited user has need-to-know for this workroom's content."*
+- **Change a member's role** — use the role dropdown on any non-owner member and click **Save role**.
+- **Remove a member** — click **Remove** to revoke access. If the member has an active session, you may be asked to confirm.
+- **Transfer ownership** — click **Transfer ownership** to make another member the primary owner of the workroom.
+
+### Audit Log
+
+Tracks recent lifecycle, membership, credential, and access activity for the workroom. Click **Open log** to view the audit timeline. Use the audit log to verify who changed membership, delegated credentials, or modified workroom lifecycle state during the current collaboration window.
+
+### Shared Credentials
+
+Shared visibility does not automatically grant access to another member's private credentials. If a shared agent depends on a connector, API key, or OAuth session, the acting user must use their own credentials or an explicitly workroom-shared credential binding when that capability is enabled in your environment.
+
+---
 ## Agent Capabilities
 
 | Capability | Description |

--- a/docs/extensions/kaizen/kaizen-user-guide.md
+++ b/docs/extensions/kaizen/kaizen-user-guide.md
@@ -255,7 +255,7 @@ The Metrics dashboard is most useful once you have active agents running convers
 
 When Kaizen is launched from a workroom, a **workroom info bar** appears at the top of the page showing the workroom name and classification banner. Click it to expand the workroom status summary.
 
-![Workroom Collaboration panel](/img/extensions/kaizen/kaizen-workroom-collaboration.png)
+[Screenshot Coming Soon] Workroom Collaboration panel showing the workroom info bar, role, member count, and live-presence summary for a shared non-global workroom.
 
 The expanded bar shows:
 
@@ -284,7 +284,7 @@ Kaizen attributes each human or agent-triggering turn to the acting user who ini
 
 Lists all workroom members with their roles and online status. Owners can click **Manage members** to open the full membership management panel directly from within Kaizen.
 
-![Workroom Members management panel](/img/extensions/kaizen/kaizen-workroom-members.png)
+[Screenshot Coming Soon] Workroom Members management panel showing invite, role change, removal, and ownership transfer controls available to workroom owners.
 
 The **Workroom Members** panel lets owners:
 

--- a/docs/extensions/workroom-manager/workroom-manager-user-guide.md
+++ b/docs/extensions/workroom-manager/workroom-manager-user-guide.md
@@ -76,6 +76,10 @@ Each workroom can open Kaizen in its own context.
 
 If your Kaizen deployment is already active, Workroom Manager shows the current deployment state in the detail panel.
 
+For Kaizen specifically, launching the app from a shared non-global workroom means authorized members see the same workroom-scoped agents, conversations, uploaded data, and generated outputs according to role. The **Global Workroom** remains a special system workspace and does not automatically expose personal Kaizen history across users.
+
+Shared visibility does not automatically share a creator's private credentials. If a Kaizen agent or workflow depends on personal secrets, OAuth connections, or other user-bound auth material, another member can see the shared agent or conversation without silently inheriting that credential path. Use the platform's shared-credential flow where your deployment exposes it.
+
 Reference: [Kaizen User Guide](/extensions/kaizen/kaizen-user-guide)
 
 ## Update Workroom Settings
@@ -113,9 +117,9 @@ Open the workroom detail panel and choose **Manage Members** to control sharing.
 
 Workroom roles are:
 
-- **Owner**: Can update settings, manage members, and transfer ownership.
-- **Contributor**: Can participate in the workroom but does not control ownership-level settings.
-- **Viewer**: Read-only participant for the workroom.
+- **Owner**: Can update settings, manage members, and transfer ownership. In Kaizen, Owners can also continue shared workroom conversations and create or update shared agents.
+- **Contributor**: Can participate in the workroom, use deployed applications, create shared Kaizen agents and conversations, and collaborate with other members.
+- **Viewer**: Read-only participant for the workroom, including shared Kaizen history and generated outputs.
 
 Owners can:
 
@@ -127,6 +131,10 @@ Owners can:
 If you remove a user who still has active sessions, the app may ask for confirmation before forcing the removal.
 
 The membership view can also show which members currently have active workroom sessions. Use that status as a quick operational check before changing access during a live collaboration session.
+
+In shared non-global workrooms, membership is the sharing boundary. You do not need to configure per-conversation or per-agent sharing inside Kaizen for another authorized member to see the same shared workroom history.
+
+Credential sharing remains separate from content sharing. Workroom membership controls visibility of shared Kaizen history and agents, but it does not automatically grant reuse of another member's personal credentials unless those credentials are explicitly shared through a supported workroom credential path.
 
 ## Lifecycle Notes
 

--- a/docs/versioned_docs/version-0.12.0/quickstart.md
+++ b/docs/versioned_docs/version-0.12.0/quickstart.md
@@ -141,11 +141,16 @@ Reference: [Kaizen User Guide](/extensions/kaizen/kaizen-user-guide)
 
 ### Validate Workroom Manager
 
+> **Version note:** The `0.12.0` baseline supports launching Kaizen inside a workroom context and enforcing basic role-aware writes, but the full non-global shared-workroom Kaizen contract described elsewhere in the docs may depend on a later patch or feature build. Validate the exact behavior present in your deployed Kaizen build before treating the checks below as release gates.
+
 1. Deploy **Workroom Manager** from **App Garden**.
 2. Create a workroom with a title, classification banner, and optional labels.
 3. Decide whether the workroom should be persistent or temporary.
 4. Launch Kaizen from inside the workroom and confirm the app opens successfully.
-5. If sharing is enabled in your environment, add at least one collaborator and verify role-based behavior.
+5. If sharing is enabled in your environment, add at least one Contributor and one Viewer.
+6. If your deployed Kaizen build includes shared non-global workroom conversations, verify the Contributor can see the same workroom agents and conversation history, add a later turn, and retain acting-user attribution on that turn.
+7. If your deployed Kaizen build includes shared non-global workroom conversations, verify the Viewer can see the same shared history but cannot create, send, upload, or edit.
+8. Verify the Global Workroom still preserves personal Kaizen visibility instead of cross-user sharing.
 
 Reference: [Workroom Manager User Guide](/extensions/workroom-manager/workroom-manager-user-guide)
 


### PR DESCRIPTION
## Summary
Document Kaizen's shared non-global workroom behavior and the explicit Global Workroom exception.

## What changed
- Kaizen user guide now describes shared agent/conversation visibility in non-global workrooms
- Workroom Manager guide now describes cross-member visibility and the credential caveat
- quickstart guidance now distinguishes current docs behavior from versioned `0.12.0` baseline wording
- docs explicitly note that shared visibility does not imply shared private credentials

## Validation
- `npm run build:docs`

## Notes
- this doc set preserves the explicit rule that Global Workroom does **not** become a shared visibility surface