### PR TITLE
ENG-4565: harden @docusaurus/* skew check (union + empty-set guard)

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -73,36 +73,67 @@ jobs:
       # plugins from docs/node_modules and the two halves disagree on
       # internal APIs (e.g. mdxCrossCompilerCache).
       #
-      # Compares only @docusaurus/* packages present in BOTH locks at the
-      # top level. Packages that exist on only one side (root has
-      # module-type-aliases / tsconfig / types as devDeps; docs/ doesn't)
-      # are correctly ignored.
+      # Asserts every top-level @docusaurus/* entry across the *union* of
+      # both locks resolves to the same version. Union (not intersection)
+      # is intentional: a docs/-only plugin pinned below a bumped root
+      # @docusaurus/core would crash the build the same way as direct
+      # cross-tree skew, but an intersection-only check would silently
+      # pass since the two halves share no entry. Packages legitimately
+      # present on only one side (e.g. root devDeps `module-type-aliases`,
+      # `tsconfig`, `types`) still pass as long as their version matches
+      # everything else in the family.
       - name: Detect @docusaurus/* version skew between root and docs/
         run: |
           node <<'EOF'
           const root = require("./package-lock.json").packages;
           const docs = require("./docs/package-lock.json").packages;
-          const extract = (pkgs) => {
-            const out = {};
+
+          const entries = {};
+          const collect = (pkgs, label) => {
             for (const [k, v] of Object.entries(pkgs)) {
               const m = k.match(/^node_modules\/(@docusaurus\/[^/]+)$/);
-              if (m) out[m[1]] = v.version;
+              if (m) {
+                entries[m[1]] = entries[m[1]] || {};
+                entries[m[1]][label] = v.version;
+              }
             }
-            return out;
           };
-          const r = extract(root), d = extract(docs);
-          const shared = Object.keys(r).filter((k) => k in d).sort();
-          const mismatches = shared.filter((k) => r[k] !== d[k]);
-          if (mismatches.length === 0) {
-            console.log(`OK: ${shared.length} @docusaurus/* package(s) agree across root and docs/ lockfiles`);
+          collect(root, "root");
+          collect(docs, "docs");
+
+          const names = Object.keys(entries).sort();
+
+          // Precondition: a future refactor that drops @docusaurus/* from
+          // both locks must not silently pass — the guard would otherwise
+          // be reporting "OK" on an empty set.
+          if (names.length === 0) {
+            console.error("ERROR: no @docusaurus/* packages found in either lockfile.");
+            console.error("If Docusaurus was deliberately removed, update or remove this guard step.");
+            process.exit(1);
+          }
+
+          const versions = new Set();
+          for (const name of names) {
+            const e = entries[name];
+            if (e.root) versions.add(e.root);
+            if (e.docs) versions.add(e.docs);
+          }
+
+          if (versions.size === 1) {
+            const v = [...versions][0];
+            console.log(`OK: ${names.length} @docusaurus/* package(s) across root and docs/ all at ${v}`);
             process.exit(0);
           }
-          console.error("ERROR: @docusaurus/* version skew between root and docs/ lockfiles:");
-          for (const k of mismatches) console.error(`  ${k}: root=${r[k]} docs=${d[k]}`);
+
+          console.error("ERROR: @docusaurus/* version skew across root and docs/ lockfiles:");
+          for (const name of names) {
+            const e = entries[name];
+            console.error(`  ${name}: root=${e.root || "(absent)"} docs=${e.docs || "(absent)"}`);
+          }
           console.error("");
-          console.error("Same package family resolving to different versions across the two locks");
-          console.error("causes `npm run build:docs` to load both into a single Node process and");
-          console.error("crash on internal-API mismatch (e.g. mdxCrossCompilerCache).");
+          console.error("All @docusaurus/* packages across both locks must resolve to the same version.");
+          console.error("Different versions sharing a single Node process at build time crash plugin");
+          console.error("init on internal-API mismatch (e.g. mdxCrossCompilerCache).");
           console.error("Re-align by regenerating one or both locks under the same registry snapshot.");
           process.exit(1);
           EOF


### PR DESCRIPTION
## Summary

Follow-up to #130, addressing two non-blocking review findings on the new `lockfile-check.yml` skew-check step.

CI-only change — no production code or lockfiles touched. The guard is strictly stricter; a third synthetic test path is now covered.

## Why

#130 introduced an intersection-based skew check between root and `docs/` `@docusaurus/*` versions. Two gaps surfaced in review:

1. **Intersection misses docs-only plugins (Codex)** — if root `@docusaurus/core` bumps but a docs/-only `@docusaurus/*` plugin stays pinned, the divergent plugin isn't in the intersection, so it's never compared. The build still crashes at runtime with the same `mdxCrossCompilerCache` symptom the guard targets.
2. **Empty-set silent pass (Claude Code)** — if both locks had no `@docusaurus/*` entries at all, the guard logged `OK: 0 ... agree` and exited 0. A future refactor dropping Docusaurus from both locks would silently neutralize the guard.

## Changes

`.github/workflows/lockfile-check.yml` — single step rewritten:

- **Intersection → union semantics**. Collect every top-level `@docusaurus/*` entry across the union of both locks; assert all resolve to a single version. Packages legitimately present on only one side (root devDeps `module-type-aliases`, `tsconfig`, `types`) still pass as long as they match the rest of the family.
- **Empty-set precondition**. Fail fast with a guard-maintenance pointer if no `@docusaurus/*` packages are found in either lock.

## Rejected (review finding from Claude Code)

I'd suggested generalizing to "any top-level package in both locks must agree" as a broader catch-all. Tested locally against the merged lockfiles: **222 packages** legitimately differ (`@babel/*`, `@algolia/*`, `@types/*`, `webpack` transitive chunks, etc.). The `@docusaurus/*` skew is uniquely dangerous because root's `docusaurus` binary loads plugins from `docs/node_modules` in a single Node process; most other packages don't share a runtime, so independent transitive drift between trees is harmless. A generalized check would need a substantial allowlist and isn't worth it. Kept the check `@docusaurus/*`-scoped.

## Test plan

Verified all three paths against the merged develop state:

- [x] **Current state passes**: `OK: 28 @docusaurus/* package(s) across root and docs/ all at 3.10.1` (exit 0)
- [x] **Synthetic docs-only skew is caught** (Codex's gap): delete `plugin-content-docs` from root and set docs version to 3.11.0 → `ERROR: ... root=(absent) docs=3.11.0` (exit 1). Prior intersection check would have passed silently.
- [x] **Empty-set fails**: synthetic locks with no `@docusaurus/*` entries → `ERROR: no @docusaurus/* packages found in either lockfile.` (exit 1). Prior check would have logged `OK: 0`.
- [ ] Lockfile-check workflow runs and passes on this PR

## Linked work

- Linear: [ENG-4565](https://linear.app/kamiwaza/issue/ENG-4565/) (piggybacking — this is review-feedback hardening on #130)
- Parent: #130 (alignment fix that introduced the original skew-check step)