### PR TITLE
Align placement docs with async deploy contract; add NVIDIA Secure Boot page

### DIFF
--- a/docs/docs/installation/nvidia-secure-boot.md
+++ b/docs/docs/installation/nvidia-secure-boot.md
@@ -1,0 +1,61 @@
+---
+title: NVIDIA GPU Hosts with Secure Boot Enabled
+sidebar_label: NVIDIA Secure Boot
+drafted_by: ai
+---
+
+# NVIDIA GPU Hosts with Secure Boot Enabled
+
+On a Linux host with UEFI Secure Boot enabled, the kernel refuses to load an unsigned NVIDIA driver module — `nvidia-smi` fails and the host appears to have no GPU. The historical workaround, disabling Secure Boot, fails the compliance baselines many regulated environments require. Kamiwaza supports keeping Secure Boot enabled by signing the NVIDIA kernel module with a per-host Machine Owner Key (MOK) that the firmware trusts, and automates everything except a single one-time console confirmation.
+
+## Before you start
+
+- An Ubuntu or Debian bare-metal GPU host with UEFI Secure Boot enabled. This flow is validated end-to-end on Ubuntu 22.04.
+- The NVIDIA driver installed via apt as a DKMS package (for example `nvidia-driver-580-server-open` on Ubuntu). Drivers installed via the NVIDIA `.run` installer are not supported — see [Limitations](#limitations).
+- Console access to the host (physical, BMC/IPMI KVM, or serial-over-LAN where the firmware exposes it). The one-time MOK enrollment is confirmed at the pre-boot console and cannot be done over SSH.
+
+## Enable the automation
+
+The Secure Boot signing automation ships default-off. Enable it for GPU hosts by setting the install variable `nvidia_secure_boot_enabled: true` for the install run — for example in the Ansible inventory `group_vars` for the GPU hosts, or as an extra variable on the playbook invocation:
+
+```bash
+ansible-playbook <install playbook> -e nvidia_secure_boot_enabled=true
+```
+
+When enabled, the automation verifies the driver is on the supported apt DKMS path, generates a per-host MOK, stages its enrollment, and configures DKMS to sign every built module with that key — so kernel and driver updates re-sign automatically with no recurring manual work. Non-NVIDIA hosts skip cleanly.
+
+## One-time MOK enrollment (per host)
+
+On a host whose MOK is not yet enrolled, the install run **fails deliberately** after staging the enrollment and prints a one-time password. That is expected — complete the console procedure, then re-run:
+
+1. Run the install with `nvidia_secure_boot_enabled=true`. Record the one-time password from the failure message.
+2. Reboot the host. The blue **MOK manager** screen appears before the OS boots. You have about 10 seconds to press a key — if it times out, the request stays pending; reboot again.
+3. Select **Enroll MOK**, then **Continue**, then **Yes**.
+4. Enter the one-time password from step 1.
+5. Select **Reboot**.
+6. Re-run the install. It verifies the module signature and `nvidia-smi`, and completes.
+
+If the password was lost before confirmation, clear the pending request with `sudo mokutil --revoke-import` and re-run the install to stage a fresh one.
+
+## Verify
+
+```bash
+# Secure Boot is enabled
+mokutil --sb-state                      # → SecureBoot enabled
+
+# The nvidia module is signed by the host MOK
+modinfo -F signer nvidia                # → <host> Secure Boot Module Signature key
+
+# Driver healthy
+nvidia-smi
+```
+
+The automation performs the same checks on every run, so a converged host passes with no changes.
+
+## Limitations
+
+- **The console confirmation cannot be automated.** Enrolling a MOK requires a human at the pre-boot MOK manager prompt; this is UEFI design and no flag or remote API replaces it.
+- **`.run`-installed drivers are not supported.** They bypass DKMS, so nothing re-signs the module on kernel updates. Remove the `.run` install (`sudo /usr/bin/nvidia-uninstall`) and install the apt DKMS driver instead.
+- **Ubuntu/Debian-family only.** The flow relies on the distribution's `shim-signed` mechanism and apt DKMS packages. On other distributions, use distribution-signed drivers or the distribution's own MOK tooling.
+- **Azure Trusted Launch VMs cannot complete MOK enrollment headlessly.** The platform provides no console path to the pre-boot MOK manager prompt. Prefer distribution-signed drivers there, or verify the available console facilities case by case.
+- **Firmware key resets revoke enrollment.** Clearing Secure Boot keys in firmware drops the enrolled MOK; the automation detects this and stages enrollment again.

--- a/docs/docs/models/placement-deployment-guide.md
+++ b/docs/docs/models/placement-deployment-guide.md
@@ -20,7 +20,7 @@ For background on how placement decides, read the [Model Placement Overview](./p
 3. Kamiwaza estimates the model's footprint, picks a GPU (or memory pool) with enough free budget, and starts the deployment. No placement input is required.
 4. Watch the status move through `DEPLOYING` and `INITIALIZING` to `DEPLOYED`. The statuses are described in [Model Deployment](./deployment.md#deployment-lifecycle-statuses).
 
-To run a second model on the same hardware, just deploy it the same way. If the combined budgets fit, both models run side by side; if not, the second deploy is rejected immediately with a [NoFit error](./placement-fractional-serving.md#what-a-nofit-error-means).
+To run a second model on the same hardware, just deploy it the same way. If the combined budgets fit, both models run side by side; if not, the second deployment fails fast with a [NoFit error](./placement-fractional-serving.md#what-a-nofit-error-means).
 
 ## Deploy a model with the SDK
 
@@ -44,7 +44,9 @@ deployment_id = client.serving.deploy_model(
 status = client.serving.get_deployment_status(deployment_id)
 ```
 
-A request that cannot be placed fails synchronously with HTTP 409 and the structured no-fit envelope — catch it and read the `reason` field rather than polling for a deployment that will never start.
+The deploy API is asynchronous: the server accepts the request and returns the deployment ID immediately. By default the SDK blocks client-side (`wait=True`), polling until the deployment reaches `DEPLOYED`; it raises `DeploymentFailedError` if the deployment reaches a terminal failure state (`FAILED`, `ERROR`, or `MUST_REDOWNLOAD`) and `TimeoutError` if the deployment is not ready within `timeout_seconds`. Pass `wait=False` to get the deployment ID back as soon as the server accepts the request, then observe progress with `get_deployment_status` or `wait_deployment_ready`.
+
+A model that cannot be placed fails fast with the no-fit reason recorded on the deployment (`last_error_code`, `last_error_message`) — see [What a NoFit error means](./placement-fractional-serving.md#what-a-nofit-error-means).
 
 ## Monitor placement
 
@@ -67,14 +69,14 @@ Open a deployment's details to see where it landed:
 
 ## Troubleshooting
 
-### The deploy request is rejected immediately (HTTP 409)
+### The deployment fails immediately with a placement (NoFit) error
 
-This is placement telling you the model does not fit anywhere, before anything starts. Read the `reason` field in the response — the [NoFit reference table](./placement-fractional-serving.md#what-a-nofit-error-means) lists every reason with common causes and fixes. The quick version:
+This is placement telling you the model does not fit anywhere, before any pod starts. The deployment shows `FAILED` with `last_error_code` set to `NoFitError` and the no-fit reason in `last_error_message` (the SDK raises `DeploymentFailedError` when waiting). The [NoFit reference table](./placement-fractional-serving.md#what-a-nofit-error-means) lists every reason with common causes and fixes. The quick version:
 
 - `insufficient_capacity` / `insufficient_system_memory` — pick a smaller or more quantized variant, reduce context length, or stop an unused deployment to free budget.
 - `vendor_mismatch` / `accel_version_unmet` — the engine does not match your hardware or driver generation; pick a matching variant.
 - `insufficient_gpu_count` — lower the tensor-parallel size or free GPUs on a multi-GPU node.
-- `sharing_not_configured` — ask your cluster admin to enable GPU sharing; the error includes a runbook link.
+- `sharing_not_configured` — ask your cluster admin to enable GPU sharing.
 
 ### A SharingNotConfigured notice appears
 

--- a/docs/docs/models/placement-fractional-serving.md
+++ b/docs/docs/models/placement-fractional-serving.md
@@ -16,7 +16,7 @@ Fractional serving is governed by the [hardware class](./placement-hardware-clas
 | MIG / hardware partitions | No | One model per partition; the partition itself is the unit of sharing |
 | Any GPU with fractional placement disabled | No | Whole-GPU exclusive — one model per card |
 
-Fractional placement is enabled by default. Installations with stricter compliance requirements can disable it at install time with the Helm value `placement.vramPluginV2.enabled=false` on the placement-operator chart, which falls back to whole-GPU exclusive placement: the first model claims the card, and a second model on the same card is rejected with `insufficient_capacity`.
+Fractional placement is enabled by default. Installations with stricter compliance requirements can disable it at install time with the Helm value `placement.vramPluginV2.enabled=false` on the placement-operator chart, which falls back to whole-GPU exclusive placement: the first model claims the card, and a second model on the same card fails with reason `insufficient_capacity`.
 
 ## How the VRAM budget works
 
@@ -42,7 +42,7 @@ A 16 GB NVIDIA T4 with two 6 GB models:
 
 1. Deploy model A (estimated 6,000 MB). It reserves 6,000 MB on `gpu-0`. Remaining budget ≈ 10,000 MB.
 2. Deploy model B (estimated 6,000 MB). It fits the remaining budget and lands on the same card. Both deployments reach `DEPLOYED` and serve traffic concurrently.
-3. Deploy model C (estimated 6,000 MB). The remaining budget (≈ 4,000 MB) is too small. The deploy request is rejected immediately with a structured `insufficient_capacity` error — no pending pod, no partial deployment.
+3. Deploy model C (estimated 6,000 MB). The remaining budget (≈ 4,000 MB) is too small. The deployment fails fast with the structured no-fit reason `insufficient_capacity` — no pending pod, no partial deployment.
 
 On a node with mixed cards (say, an 8 GB and a 24 GB GPU), placement picks a card whose remaining budget fits the request, so a 10 GB model goes to the 24 GB card even if the 8 GB card is idle.
 
@@ -52,41 +52,18 @@ A model whose footprint exceeds any single GPU can be deployed with tensor paral
 
 ## What a NoFit error means
 
-When no eligible GPU (or set of GPUs) can satisfy a request, the deploy API returns HTTP 409 with a structured envelope rather than creating a stuck deployment:
+The deploy API is asynchronous: it accepts the request and returns the deployment ID immediately. When no eligible GPU (or set of GPUs) can satisfy the request, the deployment then fails fast — before any pod is created — instead of sitting pending. The deployment shows status `FAILED` with `last_error_code` set to `NoFitError` and the no-fit reason recorded in `last_error_message`. (When deploying through the SDK with the default `wait=True`, this surfaces as a `DeploymentFailedError`; see the [Placement Deployment Guide](./placement-deployment-guide.md#deploy-a-model-with-the-sdk).)
 
-```json
-{
-  "error": "no_fit",
-  "reason": "insufficient_capacity",
-  "requested": {
-    "capacity_mb": 40000,
-    "gpu_count": 1
-  },
-  "largest_available": {
-    "capacity_mb": 24000,
-    "location": "node-3 GPU#0"
-  },
-  "candidates": {
-    "total": 8,
-    "filtered": 4,
-    "remaining": 4
-  },
-  "runbook_url": ""
-}
-```
-
-The `reason` field tells you why, and the `requested` and `largest_available` objects tell you how close the cluster was:
+The reason tells you why the model did not fit:
 
 | Reason | Meaning | Common causes and what to do |
 |---|---|---|
-| `insufficient_capacity` | No single GPU (or partition) has enough free budget for the request | The model is too large for the hardware, or other deployments hold the budget. Choose a smaller or more quantized variant, reduce context length, or stop an unused deployment. Compare `requested.capacity_mb` against `largest_available.capacity_mb`. |
+| `insufficient_capacity` | No single GPU (or partition) has enough free budget for the request | The model is too large for the hardware, or other deployments hold the budget. Choose a smaller or more quantized variant, reduce context length, or stop an unused deployment. |
 | `insufficient_system_memory` | Unified-memory budget exhausted | The shared memory pool is fully reserved. Stop another deployment or pick a smaller model. |
 | `insufficient_gpu_count` | A tensor-parallel request needs N GPUs but no node has N free | Lower the tensor-parallel size or free GPUs on a multi-GPU node. |
 | `vendor_mismatch` | The selected engine requires a GPU vendor the cluster does not have | For example, an engine that requires CUDA on an AMD-only cluster. Pick a model/engine variant that matches your hardware. |
 | `accel_version_unmet` | No node satisfies the engine's minimum accelerator version (for example, a required CUDA version) | Upgrade GPU drivers, or choose an engine/model variant built for your driver generation. |
-| `sharing_not_configured` | A managed cluster has no GPU sharing configured and the model cannot fit as whole-GPU | Ask your cluster admin to enable a sharing strategy (the error includes a runbook link), or free a GPU. |
-
-The `candidates` object summarizes the search: how many GPUs were considered (`total`), how many the filters ruled out in aggregate (`filtered`), and how many passed the filters but could not satisfy the request (`remaining`). Read together with `reason`, this tells "everything was too small" apart from "nothing matched the filters at all."
+| `sharing_not_configured` | A managed cluster has no GPU sharing configured and the model cannot fit as whole-GPU | Ask your cluster admin to enable a sharing strategy, or free a GPU. |
 
 ## Limits to know
 

--- a/docs/docs/models/placement-hardware-classes.md
+++ b/docs/docs/models/placement-hardware-classes.md
@@ -25,7 +25,7 @@ What to expect:
 
 - **One model per partition.** Each deployment gets a whole slice to itself. Kamiwaza does not pack multiple models into one slice.
 - **True isolation.** A crash, memory leak, or GPU fault in one partition does not affect models in other partitions.
-- **Capacity is the partition size**, not the whole card. A model that needs more than the largest configured partition will not fit — the deploy request is rejected with a structured error naming the largest available capacity (see [What a NoFit error means](./placement-fractional-serving.md#what-a-nofit-error-means)).
+- **Capacity is the partition size**, not the whole card. A model that needs more than the largest configured partition will not fit — the deployment fails with a structured no-fit error (see [What a NoFit error means](./placement-fractional-serving.md#what-a-nofit-error-means)).
 - The sharing class on deployment details names the partition, for example `mig_2g_20gb`.
 
 ## Software-shared
@@ -61,7 +61,7 @@ Detection is automatic, driven by node labels — you never set the class yourse
 | Label | Meaning |
 |---|---|
 | `kamiwaza.ai/gpu-memory-class` | `unified` or `discrete` — the unified-memory signal |
-| `kamiwaza.ai/gpu-memory-mb` | Detected GPU (or shared-pool) memory in MB |
+| `kamiwaza.ai/gpu-memory-mb` | Detected GPU (or shared-pool) memory. The value is in MiB, despite the label name |
 | `kamiwaza.ai/gpu-vendor` | GPU vendor |
 
 On a standalone cluster you can inspect the labels directly:

--- a/docs/docs/models/placement-overview.md
+++ b/docs/docs/models/placement-overview.md
@@ -11,7 +11,7 @@ The goal of placement is safe GPU coexistence: running more than one model on th
 
 A GPU is usually much larger than any single model you put on it. A 6 GB model deployed exclusively on an 80 GB card leaves 74 GB idle. Without placement, every deployment claims a whole GPU, so a second small model on the same card is refused even though there is plenty of room.
 
-With placement, Kamiwaza estimates each model's memory footprint, reserves that amount on a specific GPU, and lets additional models use the remaining capacity. A model that does not fit anywhere is rejected immediately with a structured error that names the largest available capacity — not left silently pending. See [Fractional GPU Serving](./placement-fractional-serving.md) for how the budgeting works.
+With placement, Kamiwaza estimates each model's memory footprint, reserves that amount on a specific GPU, and lets additional models use the remaining capacity. A model that does not fit anywhere fails fast with a structured placement error recorded on the deployment — it is never left silently pending. See [Fractional GPU Serving](./placement-fractional-serving.md) for how the budgeting works.
 
 ## Where Kamiwaza runs
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
 				"installation/redhat_online_install",
 				"installation/redhat_offline_install",
 				"installation/gpu_setup_guide",
+				"installation/nvidia-secure-boot",
 				"installation/two-node-deployment",
 			],
 		},


### PR DESCRIPTION
## Summary

GA-tail external docs sweep (close-feature Gate 3 for Model Placement 1.0).

**Correction:** The four Wave-5 placement pages still described the pre-ENG-6530 *synchronous* deploy contract — "the deploy API returns HTTP 409 with a structured envelope," "fails synchronously," "rejected immediately." Final merged behavior is async-by-default: `POST /serving/deploy_model` responds `202` with the deployment id immediately; a placement NoFit raised during the background launch lands on the deployment row as `FAILED` with `last_error_code=NoFitError` and the no-fit reason in `last_error_message` — it never reaches the route's 409 translation. Rewrote the NoFit section (dropping the no-longer-surfaced envelope JSON, `candidates` object, and runbook-link claims rather than documenting fields pollers cannot see), the SDK deploy paragraph (server async + `wait=True` client-side blocking, `DeploymentFailedError`/`TimeoutError`, `wait=False`), and the "rejected immediately (HTTP 409)" troubleshooting entry. Also corrected the `kamiwaza.ai/gpu-memory-mb` label units (MiB at source, despite the name).

**Authoring:** Added `installation/nvidia-secure-boot.md` — operator-facing page for keeping UEFI Secure Boot enabled on NVIDIA GPU hosts (gated `nvidia_secure_boot_enabled` install flag + one-time MOK console enrollment), condensed from the validated SOP at `kamiwaza-deploy/docs/NVIDIA-SECURE-BOOT.md`. External docs already cover bare-metal Ubuntu 22.04/24.04 installs, so the page has a home; registered in the installation sidebar. Page carries `drafted_by: ai` frontmatter per the style guide Part 2 protocol pending human review.

No SDK-reference authoring needed here: `docs/sdk/` is synced from kamiwaza-sdk at build time, and the SDK serving README on kamiwaza-sdk develop already documents the async server + `wait` semantics and `DeploymentFailedError`.

## Claim sources (style guide Part 2)

Every behavioral/numeric claim, verified at: kamiwaza develop `348c8cddc`, kamiwaza-sdk develop `4d3a1a6`, operators develop `5d68af3`, deploy develop `61d617f9`, containers `e5f82fc`.

| Claim | Source |
|---|---|
| Deploy API async-by-default, 202 + deployment id; admission/validation errors still synchronous | `kamiwaza/kamiwaza/serving/api.py:280-305` (route docstring + `status_code=202`); `kamiwaza/kamiwaza/serving/services.py:3116-3132` |
| Launch-time NoFit lands on the row (`FAILED`, `last_error_code=NoFitError`, reason in `last_error_message`), never the 409 path | `kamiwaza/kamiwaza/serving/services.py:3322-3340` (foreground-path-only comment), `:3745-3835` (`_handle_background_launch_failure`), `:2689-2760` (`_cleanup_failed_deployment_record` persists `type(error).__name__` + sanitized message); test `kamiwaza/tests/unit/serving/test_deploy_model_background.py::test_no_fit_in_background_persists_failure` |
| SDK `wait=True` default, client-side polling, `DeploymentFailedError` / `TimeoutError`, `wait=False` returns id immediately | `kamiwaza-sdk/kamiwaza_sdk/services/serving.py:48-152` |
| NoFit reason values (6) | `operators/internal/controller/serving/types/types.go:93-98` |
| Per-device buckets `kamiwaza.ai/vram-mb-gpu-<i>`, decimal MB (1 MB = 10^6 bytes) | `operators/internal/controller/serving/types/types.go:78`, `types/units.go:19-34` (ENG-6121) |
| Unified-memory single `...-gpu-0` bucket; 8 GiB OS reserve before advertising | `containers/images/vram-plugin/main.go:227-247` (`collapseSharedUMAPool`), `:371-398` (`computeUMAEffectiveVRAM`, `reserveMiB = 8 * 1024`) |
| `placement.vramPluginV2.enabled` default true; false = whole-GPU fallback | `deploy/charts/placement-operator/values.yaml:36-48` |
| `kamiwaza.ai/gpu-memory-mb` is MiB at source despite the name | `operators/internal/controller/serving/labelview/labelview.go:203-218` (`kamiwazaGPUMemoryMB` applies `MiBToMB`), `types/units.go` comment |
| Deployment detail fields (`topology`, `hardware_class`, `sharing_class`, `node_name`, `gpu_index`, `gpu_vendor`, `allocated_capacity_mb`, `last_error_*`) | `kamiwaza/kamiwaza/serving/schemas/serving.py:169-237` |
| Secure Boot page: flag name/default-off, apt-DKMS-only, MOK console steps, ~10s MOK manager window, verification commands, Azure Trusted Launch + Debian-family limitations, Ubuntu 22.04 validation | `kamiwaza-deploy/docs/NVIDIA-SECURE-BOOT.md` (validated SOP, ENG-6223) |

Checked, no drift found: (c) `node-role=inference` opt-in partitioning (`kamiwaza/kamiwaza/serving/engines/_topology_branch.py:123-160`, ENG-6674 fall-open) — no external page mentions node labels/partitioning, and nothing claims CPU-only installs need labeled nodes; (d) unified-memory pod limit = estimate + 2 GiB overhead capped at capacity (`kamiwaza/kamiwaza/serving/engines/k8s_gpu.py:669-762`) — external pages do not document pod limits and the 8 GiB *advertised-budget* reserve they do document is accurate.

## Verification

- `npm run build` passes; no broken links/anchors on changed pages (remaining warnings are pre-existing blog/versioned-docs anchors).
- `#what-a-nofit-error-means` heading kept verbatim to preserve inbound anchors from the hardware-classes and deployment-guide pages.