### PR TITLE
Rename VRAM bucket resource MB→GB in user docs (ENG-6997)

### DIFF
--- a/docs/docs/models/placement-deployment-guide.md
+++ b/docs/docs/models/placement-deployment-guide.md
@@ -105,7 +105,7 @@ On a standalone cluster you can inspect what placement sees:
 kubectl get node <node-name> -o jsonpath='{.metadata.labels}' | tr ',' '\n' | grep gpu
 
 # Per-GPU memory budgets advertised on a node (MB)
-kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep vram-mb-gpu
+kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep vram-gb-gpu
 ```
 
 If a node shows no `kamiwaza.ai/gpu-*` labels, hardware detection has not labeled it and it will not receive placements.

--- a/docs/docs/models/placement-deployment-guide.md
+++ b/docs/docs/models/placement-deployment-guide.md
@@ -59,7 +59,7 @@ Open a deployment's details to see where it landed:
 | `gpu_index`, `gpu_vendor` | Which GPU on the node, and its vendor |
 | `hardware_class` | `hardware_isolated`, `software_shared`, or `unified_memory` — see [GPU Hardware Classes](./placement-hardware-classes.md) |
 | `sharing_class` | How the device is shared, for example `mig_2g_20gb`, `whole_gpu`, `unified_memory`, `metal_spawner` |
-| `allocated_capacity_mb` | The memory budget reserved for this deployment |
+| `allocated_capacity_gb` | The memory budget reserved for this deployment, in GB |
 
 ## Verify
 

--- a/docs/docs/models/placement-deployment-guide.md
+++ b/docs/docs/models/placement-deployment-guide.md
@@ -104,7 +104,7 @@ On a standalone cluster you can inspect what placement sees:
 # GPU labels detected on a node
 kubectl get node <node-name> -o jsonpath='{.metadata.labels}' | tr ',' '\n' | grep gpu
 
-# Per-GPU memory budgets advertised on a node (MB)
+# Per-GPU memory budgets advertised on a node (GB)
 kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep vram-gb-gpu
 ```
 

--- a/docs/docs/models/placement-fractional-serving.md
+++ b/docs/docs/models/placement-fractional-serving.md
@@ -3,7 +3,7 @@ title: Fractional GPU Serving
 sidebar_label: Fractional GPU Serving
 ---
 
-Fractional GPU serving lets multiple models share one GPU, each with its own reserved memory budget. Instead of claiming a whole card, a deployment reserves the number of megabytes it is estimated to need; the remaining capacity stays available for other models. This page explains when fractional serving applies, how the budgeting works, and how to read the error you get when a model does not fit.
+Fractional GPU serving lets multiple models share one GPU, each with its own reserved memory budget. Instead of claiming a whole card, a deployment reserves the number of gigabytes it is estimated to need; the remaining capacity stays available for other models. This page explains when fractional serving applies, how the budgeting works, and how to read the error you get when a model does not fit.
 
 ## When fractional serving applies
 
@@ -11,7 +11,7 @@ Fractional serving is governed by the [hardware class](./placement-hardware-clas
 
 | Hardware | Fractional? | How sharing works |
 |---|---|---|
-| Discrete GPU without partitioning (T4, L4, A100/H100 with MIG disabled) | Yes | Per-GPU memory budgets in MB |
+| Discrete GPU without partitioning (T4, L4, A100/H100 with MIG disabled) | Yes | Per-GPU memory budgets in GB |
 | Unified memory (Apple Silicon, Strix Halo, DGX Spark) | Yes | Budget against the shared system memory pool |
 | MIG / hardware partitions | No | One model per partition; the partition itself is the unit of sharing |
 | Any GPU with fractional placement disabled | No | Whole-GPU exclusive — one model per card |
@@ -40,9 +40,9 @@ kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' |
 
 A 16 GB NVIDIA T4 with two 6 GB models:
 
-1. Deploy model A (estimated 6,000 MB). It reserves 6,000 MB on `gpu-0`. Remaining budget ≈ 10,000 MB.
-2. Deploy model B (estimated 6,000 MB). It fits the remaining budget and lands on the same card. Both deployments reach `DEPLOYED` and serve traffic concurrently.
-3. Deploy model C (estimated 6,000 MB). The remaining budget (≈ 4,000 MB) is too small. The deployment fails fast with the structured no-fit reason `insufficient_capacity` — no pending pod, no partial deployment.
+1. Deploy model A (estimated 6 GB). It reserves 6 GB on `gpu-0`. Remaining budget ≈ 10 GB.
+2. Deploy model B (estimated 6 GB). It fits the remaining budget and lands on the same card. Both deployments reach `DEPLOYED` and serve traffic concurrently.
+3. Deploy model C (estimated 6 GB). The remaining budget (≈ 4 GB) is too small. The deployment fails fast with the structured no-fit reason `insufficient_capacity` — no pending pod, no partial deployment.
 
 On a node with mixed cards (say, an 8 GB and a 24 GB GPU), placement picks a card whose remaining budget fits the request, so a 10 GB model goes to the 24 GB card even if the 8 GB card is idle.
 

--- a/docs/docs/models/placement-fractional-serving.md
+++ b/docs/docs/models/placement-fractional-serving.md
@@ -22,18 +22,18 @@ Fractional placement is enabled by default. Installations with stricter complian
 
 When you deploy a model, Kamiwaza estimates its memory footprint — weights, context/KV cache, and per-deployment overhead. (The SDK exposes this same estimator as `client.serving.estimate_model_vram()` if you want to preview a deployment request's footprint.)
 
-The estimate becomes a reservation against a specific GPU. Each GPU on a node exposes its capacity as a per-device resource named `kamiwaza.ai/vram-mb-gpu-<i>` (where `<i>` is the GPU index), measured in MB. Kubernetes enforces these budgets when the model is scheduled, so an over-budget model is refused **before** anything starts — it is never left half-running or silently pending.
+The estimate becomes a reservation against a specific GPU. Each GPU on a node exposes its capacity as a per-device resource named `kamiwaza.ai/vram-gb-gpu-<i>` (where `<i>` is the GPU index), measured in GB. Kubernetes enforces these budgets when the model is scheduled, so an over-budget model is refused **before** anything starts — it is never left half-running or silently pending.
 
 Details worth knowing:
 
 - **One budget per physical GPU.** A node with four cards exposes four independent budgets (`...-gpu-0` through `...-gpu-3`); each model lands on exactly one card's budget.
-- **Unified-memory machines expose a single budget** (`kamiwaza.ai/vram-mb-gpu-0`) sized to the shared memory pool, since the CPU and GPU draw from the same pool.
+- **Unified-memory machines expose a single budget** (`kamiwaza.ai/vram-gb-gpu-0`) sized to the shared memory pool, since the CPU and GPU draw from the same pool.
 - **Unified-memory machines hold back an 8 GiB operating-system reserve** from the shared pool before the budget is advertised, so deployments cannot starve the host. Discrete-GPU budgets are sized to the card's detected VRAM.
 
 On a standalone cluster you can see the advertised budgets directly:
 
 ```bash
-kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep vram-mb-gpu
+kubectl get node <node-name> -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep vram-gb-gpu
 ```
 
 ## Example: packing models on one GPU

--- a/docs/docs/models/placement-hardware-classes.md
+++ b/docs/docs/models/placement-hardware-classes.md
@@ -12,7 +12,7 @@ If you have not read it yet, start with the [Model Placement Overview](./placeme
 | Class | Members | Placement primitive | Isolation |
 |---|---|---|---|
 | **Hardware-isolated** | NVIDIA MIG-capable cards (A100, H100, B100) with MIG enabled; AMD Instinct MI300+ with partitioning enabled | One model per hardware partition (for example, a MIG slice requested as `nvidia.com/mig-2g.20gb`) | Hardware: dedicated memory and fault isolation per partition |
-| **Software-shared** | Discrete-memory GPUs without hardware partitioning: T4, L4, A100/H100 with MIG disabled, and similar; also covers admin-configured time-slicing or MPS on managed clusters | Fractional per-GPU memory budgets in MB, or the cluster's configured sharing strategy, or whole-GPU exclusive | Software: memory budgets are enforced when the model is scheduled; co-located models share compute and faults |
+| **Software-shared** | Discrete-memory GPUs without hardware partitioning: T4, L4, A100/H100 with MIG disabled, and similar; also covers admin-configured time-slicing or MPS on managed clusters | Fractional per-GPU memory budgets in GB, or the cluster's configured sharing strategy, or whole-GPU exclusive | Software: memory budgets are enforced when the model is scheduled; co-located models share compute and faults |
 | **Unified memory** | Apple Silicon (M-series), AMD Strix Halo, NVIDIA DGX Spark (GB10 Grace-Blackwell) | Budget against the aggregate system memory pool | Process-level only: concurrent models share the GPU through the OS scheduler |
 
 In deployment details these appear as the `hardware_class` values `hardware_isolated`, `software_shared`, and `unified_memory`.
@@ -32,7 +32,7 @@ What to expect:
 
 A discrete GPU without hardware partitioning has one VRAM pool and no hardware fences. Kamiwaza shares it by accounting:
 
-- **Fractional memory budgets.** Each deployment reserves an estimated footprint in MB on a specific GPU. Models coexist on a card as long as their combined budgets fit. This is the default on standalone clusters and is described in detail in [Fractional GPU Serving](./placement-fractional-serving.md).
+- **Fractional memory budgets.** Each deployment reserves an estimated footprint in GB on a specific GPU. Models coexist on a card as long as their combined budgets fit. This is the default on standalone clusters and is described in detail in [Fractional GPU Serving](./placement-fractional-serving.md).
 - **Cluster-configured sharing.** On a managed cluster where the admin has configured time-slicing or MPS through the GPU Operator, Kamiwaza requests the shared resource the cluster advertises and the configured strategy governs sharing.
 - **Whole-GPU exclusive.** When neither of the above applies (or fractional placement is disabled), a deployment claims the entire GPU and no other model can join it.
 

--- a/docs/docs/models/placement-overview.md
+++ b/docs/docs/models/placement-overview.md
@@ -31,7 +31,7 @@ Placement treats GPUs differently depending on how their memory is built and sha
 
 **A datacenter card with hardware partitioning.** An NVIDIA H100 with MIG (Multi-Instance GPU) enabled is carved into hardware slices, each with its own dedicated memory. Kamiwaza places one model per slice. A crash or memory spike in one slice cannot touch a model in another — the isolation is enforced by the hardware itself.
 
-**A discrete card without partitioning.** An NVIDIA T4, L4, or an A100 with MIG disabled has one fixed pool of VRAM on the card. There is no hardware fence, so Kamiwaza shares the card by accounting: each model reserves a memory budget in MB, and models coexist as long as their combined budgets fit the card. Two 6 GB models fit comfortably on a 16 GB T4.
+**A discrete card without partitioning.** An NVIDIA T4, L4, or an A100 with MIG disabled has one fixed pool of VRAM on the card. There is no hardware fence, so Kamiwaza shares the card by accounting: each model reserves a memory budget in GB, and models coexist as long as their combined budgets fit the card. Two 6 GB models fit comfortably on a 16 GB T4.
 
 **A machine with unified memory.** A MacBook, an AMD Strix Halo workstation, or an NVIDIA DGX Spark has no separate VRAM at all — the CPU and GPU share one system memory pool. Kamiwaza budgets model deployments against that shared pool (leaving headroom for the operating system) and lets concurrent models share the GPU through the OS scheduler.
 
@@ -52,7 +52,7 @@ Every deployment's details surface where it landed and what it reserved:
 - **Topology** — managed cluster or standalone cluster (macOS installs appear as standalone with the `metal_spawner` sharing class).
 - **Node and GPU** — the node name and GPU index (where applicable).
 - **Hardware class and sharing class** — for example `unified_memory`, or `mig_2g_20gb` for a model placed in a MIG slice.
-- **Allocated capacity (MB)** — the memory budget reserved for this deployment.
+- **Allocated capacity (GB)** — the memory budget reserved for this deployment.
 
 See the [Placement Deployment Guide](./placement-deployment-guide.md) for reading these fields and troubleshooting placement.
 


### PR DESCRIPTION
Update the user-facing fractional-serving + placement-deployment guides to the renamed per-device VRAM bucket resource `kamiwaza.ai/vram-gb-gpu-<i>` (measured in GB) — the `kubectl` allocatable examples and the capacity description.

ENG-6997
---
**⚠️ Lockstep release — do not merge independently.** One of six PRs implementing the VRAM MB→GB conversion (ENG-6991). The plugin (`containers`), operator (`operators`), and core (`kamiwaza`) **must merge together**: the resource RENAME (`vram-mb*`→`vram-gb*`) is the fail-closed safety mechanism only if they ship in one release — a mixed plugin/operator version is undetectable at runtime and would over-admit ~1000× → OOM. Deploy + docs ride along.

**Draft pending validation.** A full cross-host validation loop (r2c5s2 8×MI300X, laptop, spark-2, evo-x2-2) runs next session before this is marked ready; testing mounts the freshly-built images via overrides.

Part of **ENG-6991**.
