### PR TITLE
Fix cross-mesh dataset grant docs (ENG-7500)

### DIFF
--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -219,28 +219,35 @@ Fine-grained authorization. All mesh and federation operations go through ReBAC 
 ### Grant a Relation
 
 ```
-POST /api/auth/relations/
+POST /api/auth/tuples
 ```
 
 **Request:**
 ```json
 {
-  "object_namespace": "federation" | "dataset" | "model" | "cluster_jobs",
-  "object_id": "string",
+  "subject": {"namespace": "user", "id": "<uuid>"},
   "relation": "operator" | "viewer" | "owner" | "executor",
-  "subject_namespace": "user",
-  "subject_id": "uuid"
+  "object": {
+    "namespace": "federation" | "dataset" | "model" | "cluster_jobs",
+    "id": "string"
+  }
 }
 ```
+
+This grants a relation to a **local** user — one with an account on the cluster you call. It does **not** work for brokered mesh users (see the note below).
 
 ### Common Grant Patterns
 
 | Scenario | Namespace | Relation | Notes |
 |----------|-----------|----------|-------|
-| User can use a federation | `federation` | `operator` | Required to call `/api/mesh/{fed}/*` |
-| User can query a dataset | `dataset` | `viewer` | Required for local and mesh retrieval |
+| User can use a federation | `federation` | `operator` | Required to call `/api/mesh/{fed}/*`; granted to a local user on the **source** cluster |
+| Local user can query a dataset | `dataset` | `viewer` | For native (non-mesh) retrieval on this cluster |
 | User can submit jobs | `cluster_jobs` | `executor` | Object id is the constant `"__all__"` |
 | User can own a dataset | `dataset` | `owner` | Can write and manage |
+
+:::warning Brokered mesh users
+A federated caller has **no local account** on the target cluster until their first mesh request, when brokering auto-provisions a local Keycloak user with a freshly-minted UUID. The per-dataset check authorizes against that local UUID, so granting `dataset:viewer` via `/api/auth/tuples` with the source UUID returns `204` but never matches (retrieval stays `404`). Grant cross-mesh dataset access through the federation allowlist's `initial_tuples` instead — see [Retrieval → Access Control](./retrieval.md#access-control).
+:::
 
 ---
 

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -154,13 +154,13 @@ curl -sk "https://kamiwaza.test/api/mesh/studio-1/api/serving/deployments" \
 
 **Diagnosis:**
 
-1. Check the `authorization_relations` table on the **target** cluster:
+1. Check the `authorization_relations` table on the **target** cluster. Note the relevant `subject_id` is the **local brokered KC UUID** (auto-provisioned on first mesh request), **not** the source cluster's user UUID — query by relation/object, or list the brokered user's local UUID first via `GET /api/cluster/federations/{id}/users`:
 
    ```bash
    kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
      "SELECT subject_namespace, subject_id, relation, object_namespace, object_id
       FROM authorization_relations
-      WHERE subject_id = '<remote-user-uuid>';"
+      WHERE object_namespace = 'dataset' AND object_id = '<dataset-urn>';"
    ```
 
 2. For catalog/retrieval operations, the remote user needs a `viewer` relation on the `dataset` namespace for each dataset they access.
@@ -169,21 +169,23 @@ curl -sk "https://kamiwaza.test/api/mesh/studio-1/api/serving/deployments" \
 
 **Resolution:**
 
-Seed the required ReBAC relation on the target cluster:
+Seed the per-dataset grant through the brokered-user allowlist's `initial_tuples` field. Do **not** use `/api/auth/tuples` for a brokered user: that user has no local account on the target cluster until their first mesh request, when brokering auto-provisions a local Keycloak user with a freshly-minted UUID. The check authorizes against **that local UUID**, so a tuple written against the source UUID returns `204` but never matches (access stays `404`). `initial_tuples` resolves the `{{user_id}}` placeholder to the local UUID at provision time.
 
 ```bash
-# Grant viewer access to a specific dataset
-curl -sk -X POST "https://192.168.50.13/api/auth/tuples" \
+# Grant viewer on a dataset to a brokered user, via the allowlist. Re-POSTing
+# the entry for an already-provisioned user is idempotent.
+curl -sk -X POST "https://<TARGET_IP>/api/cluster/federations/<FEDERATION_ID>/users" \
   -H "Authorization: Bearer $REMOTE_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "subject": {"namespace": "user", "id": "<remote-user-uuid>"},
-    "relation": "viewer",
-    "object": {"namespace": "dataset", "id": "<dataset-urn>"}
+    "external_id": "<source-user-uuid>@<source-cluster-uuid>",
+    "initial_tuples": [
+      {"subject": "user:{{user_id}}", "relation": "viewer", "object": "dataset:<dataset-urn>"}
+    ]
   }'
 ```
 
-For federation operator access on the source cluster (needed to use the mesh proxy at all):
+For federation **operator** access on the **source** cluster (needed to use the mesh proxy at all) — this is a local user on its home cluster, so `/api/auth/tuples` is the correct path here:
 
 ```bash
 # Grant operator on federation namespace (normally seeded during pairing)

--- a/docs/docs/federation/retrieval.md
+++ b/docs/docs/federation/retrieval.md
@@ -95,19 +95,33 @@ On Istio clusters with the `extauthz` trust model, admin users bypass per-resour
 
 Non-admin users require explicit per-dataset ReBAC grants on the target cluster. The admin bypass is suppressed for mesh-originated requests — federated callers must have explicit `viewer` access to each dataset they query or browse. The catalog listing endpoint filters results so federated users only see datasets they have grants for.
 
-To grant access:
+Grant access **at federation-pairing time** through the brokered-user allowlist's `initial_tuples` field — **not** through `/api/auth/tuples`.
+
+:::warning Why not `/api/auth/tuples`?
+A federated caller has no local user account on the target cluster until their *first* mesh request, when the brokering service auto-provisions a local Keycloak user with a freshly-minted UUID. The per-dataset check authorizes against **that local UUID**, which isn't known ahead of time — so a tuple written against the source cluster's user UUID via `/api/auth/tuples` never matches, and the call returns `204` while access stays denied (`404 Dataset not found`). The allowlist's `initial_tuples` solves this with a `{{user_id}}` placeholder that renders to the local UUID at provision time.
+:::
 
 ```bash
-# On the TARGET cluster, seed a relation for the remote user
-curl -sk -X POST "https://<TARGET_IP>/api/auth/tuples" \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
+# On the TARGET cluster, add the source user to the federation allowlist
+# WITH the dataset grant. `{{user_id}}` renders to the local brokered KC
+# UUID when the user is auto-provisioned on first mesh request, so the
+# viewer relation lands on the subject the per-dataset check looks up.
+curl -sk -X POST "https://<TARGET_IP>/api/cluster/federations/<FEDERATION_ID>/users" \
+  -H "Authorization: Bearer $REMOTE_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "subject": {"namespace": "user", "id": "<remote-user-uuid>"},
-    "relation": "viewer",
-    "object": {"namespace": "dataset", "id": "<dataset-urn>"}
+    "external_id": "<source-user-uuid>@<source-cluster-uuid>",
+    "initial_tuples": [
+      {
+        "subject": "user:{{user_id}}",
+        "relation": "viewer",
+        "object": "dataset:<dataset-urn>"
+      }
+    ]
   }'
 ```
+
+`initial_tuples` entries use namespaced `"<namespace>:<id>"` strings; `{{user_id}}` (local brokered UUID) and `{{external_id}}` (`<source-user-uuid>@<source-cluster-uuid>`) are substituted at provision time. To add a grant for an *already-provisioned* brokered user, re-POST the allowlist entry — seeding is idempotent.
 
 ## Mesh Proxy Endpoint Reference
 


### PR DESCRIPTION
## ENG-7500 — cross-mesh dataset grant docs were wrong

The federation docs told users to grant a brokered mesh-user `dataset:viewer` via
`POST /api/auth/tuples` with the **source** cluster's user UUID. That returns `204`
but never enables mesh retrieval (stays `404 Dataset not found`) — because the brokered
user has **no local account** on the target cluster until their first mesh request, when
brokering auto-provisions a local Keycloak user with a freshly-minted UUID. The per-dataset
check authorizes against **that local UUID**, which the source UUID never matches.

### Fix (docs-only; the code works as designed)
- `retrieval.md` + `operations.md`: replace the broken `/api/auth/tuples` grant with the
  working **allowlist `initial_tuples`** path — `POST /api/cluster/federations/{id}/users`
  with `{"subject": "user:{{user_id}}", "relation": "viewer", "object": "dataset:<urn>"}`.
  `{{user_id}}` renders to the local brokered UUID at provision time (verified against
  `brokering.py::_parse_initial_tuple` / `_seed_initial_rebac_tuples`).
- Kept the **source-cluster operator** grant on `/api/auth/tuples` (that subject is a local
  user on its home cluster — the endpoint is correct there).
- Corrected the `rebac_denied` diagnosis query (the `subject_id` to look for is the local
  brokered UUID, not the source UUID).

1.0 P0 blocker `2026-07 (1.0)`. Overlaps the ENG-7533 D-series doc-gap cleanup. Base = `develop`
(the active docs integration branch; `main` is the published release branch, 32 commits behind).