### PR TITLE
Stage RBAC policy file in from-source OpenAPI fallback (ENG-7897)

### DIFF
--- a/scripts/sync-openapi.ts
+++ b/scripts/sync-openapi.ts
@@ -211,6 +211,14 @@ print(json.dumps(app.openapi()))
 				KAMIWAZA_ENV: process.env.KAMIWAZA_ENV || "dev",
 				KAMIWAZA_LITE: process.env.KAMIWAZA_LITE || "true",
 				KAMIWAZA_ROOT: process.env.KAMIWAZA_ROOT || tempRoot,
+				// create_app() -> init_auth() requires the RBAC policy file; its
+				// default derives from KAMIWAZA_ROOT (<root>/runtime/auth_gateway_policy.yaml),
+				// which the ephemeral tempRoot does not have. Point at the policy
+				// shipped in the kamiwaza repo so from-source generation is
+				// self-contained (no running platform, no manual staging).
+				AUTH_GATEWAY_POLICY_FILE:
+					process.env.AUTH_GATEWAY_POLICY_FILE ||
+					path.join(repoPath, "config", "auth_gateway_policy.yaml"),
 				DATABASE_URL:
 					process.env.DATABASE_URL || `sqlite:///${path.join(tempDir, "main.db")}`,
 				CLUSTER_DATABASE_URL:


### PR DESCRIPTION
## What
`scripts/sync-openapi.ts` `generateOpenAPIFromLocalSource` exports the OpenAPI spec from source (no running platform) via `./scripts/kw_py -c "create_app(...).openapi()"`. But `create_app()` → `init_auth()` requires the RBAC policy file, whose default path derives from `KAMIWAZA_ROOT` → `<root>/runtime/auth_gateway_policy.yaml`. The fallback uses an ephemeral `tempRoot` that never contains it, so the documented from-source path fails with `RuntimeError: RBAC policy file required when auth is enabled`.

## Fix
Set `AUTH_GATEWAY_POLICY_FILE` in the generation env to the policy shipped in the kamiwaza repo (`config/auth_gateway_policy.yaml`), so from-source generation is self-contained — no running platform, no manual file staging.

## Validation
node_modules isn't installed in this checkout, so validated at the underlying `kw_py` layer against a `kamiwaza` develop checkout:
- **without** the env → `FileNotFoundError: .../runtime/auth_gateway_policy.yaml` (exit 1)
- **with** `AUTH_GATEWAY_POLICY_FILE=<repo>/config/auth_gateway_policy.yaml` → exit 0, valid **365-path** spec

## Context
Prerequisite for ENG-7897 (nightly openapi.json regeneration from develop). The committed `docs/api/openapi.json` is ~7 weeks stale (339 paths vs 365 from source; `/cluster/cluster_capabilities` shows `admin` vs the current `authenticated`).