### PR TITLE
Refresh api/openapi.json from platform develop (ENG-7897)

### DIFF
--- a/docs/api/openapi-metadata.json
+++ b/docs/api/openapi-metadata.json
@@ -1,7 +1,10 @@
 {
-  "syncedAt": "2026-05-11T20:07:14.929Z",
+  "syncedAt": "2026-07-01T01:54:24.043Z",
+  "sourceRemote": "git@github.com:kamiwaza-internal/kamiwaza.git",
+  "sourceBranch": "develop",
+  "sourceCommit": "8b8f95057b1a467f787a9aa9bd6a7eb3620138d2",
   "originalApiVersion": "0.1.0",
   "patchedApiVersion": "0.13.0",
-  "endpoints": 339,
-  "schemas": 428
+  "endpoints": 366,
+  "schemas": 459
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2241,6 +2241,454 @@
         "x-auth-exempt": true,
         "x-auth-exempt-reason": "Token validation"
       },
+      "options": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_validate_options",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "Token validation"
+      },
+      "delete": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_validate_delete",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "Token validation"
+      },
+      "patch": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_validate_patch",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "Token validation"
+      },
+      "put": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_validate_put",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "Token validation"
+      },
       "post": {
         "tags": [
           "forward-auth"
@@ -3279,7 +3727,1129 @@
         "x-auth-role": "authenticated"
       }
     },
+    "/auth/forward/validate/{path}": {
+      "options": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__options",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      },
+      "delete": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__delete",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      },
+      "patch": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__patch",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      },
+      "put": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__put",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      },
+      "post": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      },
+      "get": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate__path__get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint subpath variants"
+      }
+    },
     "/auth/forward/validate": {
+      "options": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate_options",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint"
+      },
+      "delete": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate_delete",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint"
+      },
+      "patch": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate_patch",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint"
+      },
+      "put": {
+        "tags": [
+          "forward-auth"
+        ],
+        "summary": "Validate",
+        "description": "Ingress auth validation endpoint for ForwardAuth / ext_authz callers.\n\nCalled by the ingress gateway to authenticate and authorize incoming\nrequests before they reach an upstream service.",
+        "operationId": "validate_auth_forward_validate_put",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-Forwarded-Method",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Method"
+            }
+          },
+          {
+            "name": "X-Forwarded-Uri",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Uri"
+            }
+          },
+          {
+            "name": "X-Forwarded-Host",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Host"
+            }
+          },
+          {
+            "name": "X-Forwarded-Proto",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Forwarded-Proto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-exempt": true,
+        "x-auth-exempt-reason": "ForwardAuth validation endpoint"
+      },
       "post": {
         "tags": [
           "forward-auth"
@@ -3723,6 +5293,18 @@
               "format": "uuid",
               "title": "Model Id"
             }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Tear down active deployments instead of refusing deletion (ENG-2279).",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Tear down active deployments instead of refusing deletion (ENG-2279)."
           }
         ],
         "responses": {
@@ -3814,7 +5396,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       },
       "get": {
         "tags": [
@@ -4921,7 +6503,7 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/models/deploy_after_download/{model_key}": {
@@ -5001,7 +6583,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/guide/": {
@@ -5344,6 +6926,176 @@
         "x-auth-role": "admin"
       }
     },
+    "/serving/routes/greymatter": {
+      "post": {
+        "tags": [
+          "serving"
+        ],
+        "summary": "Upsert Greymatter Route Intent",
+        "description": "Internal API for controllers to submit generated Greymatter route intents.",
+        "operationId": "upsert_greymatter_route_intent_serving_routes_greymatter_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "x-kamiwaza-route-intent-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Kamiwaza-Route-Intent-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GreymatterRouteIntentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GreymatterRouteStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/serving/routes/greymatter/{route_id}": {
+      "delete": {
+        "tags": [
+          "serving"
+        ],
+        "summary": "Delete Greymatter Route Intent",
+        "description": "Internal API for controllers to remove generated Greymatter route intents.",
+        "operationId": "delete_greymatter_route_intent_serving_routes_greymatter__route_id__delete",
+        "parameters": [
+          {
+            "name": "route_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_.-]+$",
+              "title": "Route Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "x-kamiwaza-route-intent-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Kamiwaza-Route-Intent-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GreymatterRouteStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
     "/serving/status": {
       "get": {
         "tags": [
@@ -5442,7 +7194,7 @@
           "serving"
         ],
         "summary": "Deploy Model",
-        "description": "Asynchronously deploy a model based on the provided deployment request.\n\nArgs:\n    create_model_request (CreateModelDeployment): The deployment request containing model configuration.\n\nReturns:\n    Union[UUID, bool]: The UUID of the deployed model or False if deployment failed.",
+        "description": "Deploy a model asynchronously (ENG-6530): respond 202 Accepted with the\ndeployment id as soon as the deployment record is created and the launch\nis kicked off in background. The body is the bare UUID existing clients\nalready parse. Poll GET /serving/deployments for progress; launch\nfailures land on the row as a terminal status with last_error_message.\nValidation/admission errors raised before the record exists still fail\nthis request synchronously.\n\nArgs:\n    create_model_request (CreateModelDeployment): The deployment request containing model configuration.\n\nReturns:\n    Union[UUID, bool]: The UUID of the accepted deployment. Failures\n    before the record exists never return False to the client — they\n    raise HTTPException (404/409/5xx) from this route instead; the bool\n    in the response model is legacy contract surface only.",
         "operationId": "deploy_model_serving_deploy_model_post",
         "requestBody": {
           "content": {
@@ -5455,7 +7207,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "202": {
             "description": "Successful Response",
             "content": {
               "application/json": {
@@ -5493,7 +7245,7 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/serving/deployments": {
@@ -5636,7 +7388,7 @@
           "serving"
         ],
         "summary": "Stop Deployment",
-        "description": "Authenticated HTTP wrapper for shared model deployment teardown.",
+        "description": "Admin-only HTTP wrapper for shared model deployment teardown.",
         "operationId": "stop_deployment_serving_deployment__deployment_id__delete",
         "security": [
           {
@@ -5691,7 +7443,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/serving/deployment/{deployment_id}/delete": {
@@ -6027,7 +7779,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/serving/deployment/{deployment_id}/logs/patterns": {
@@ -6080,7 +7832,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/serving/logs/{engine_type}": {
@@ -6132,7 +7884,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/serving/external-endpoints/discover": {
@@ -6279,6 +8031,170 @@
         "x-auth-role": "admin"
       }
     },
+    "/catalog/datasets/{urn}/gate": {
+      "put": {
+        "tags": [
+          "dataset-gate-binding"
+        ],
+        "summary": "Set Dataset Attribute Gate",
+        "description": "T2.5: bind an AttributeGate to a dataset.\n\nAuth (M3 Proactive Security Checklist §4.4.3.1):\n  - NativeRealmRequired: mesh-origin rejected.\n  - Owner-on-dataset ReBAC: only the dataset's owner (per ReBAC\n    relations) can rebind its gate. Closes the privilege-escalation\n    gap where any admin could rewrite any other admin's dataset gate.\n\nSide effects:\n  - Validates type is an AttributeGate subclass (else 400 wrong_kind).\n  - Validates config against gate.config_schema() (T2.6).\n  - Writes properties.gate = {type, config} via the configured\n    DatasetGateStore (T2.7).\n  - Invalidates the discover cache (v0.3.5 OQ-10).\n  - Emits gate_binding/set audit event with dataset_urn (T2.12).",
+        "operationId": "set_dataset_attribute_gate_catalog_datasets__urn__gate_put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "urn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Urn"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttributeGateBindingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeGateBindingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "get": {
+        "tags": [
+          "dataset-gate-binding"
+        ],
+        "summary": "Get Dataset Attribute Gate",
+        "description": "T2.5: read the active AttributeGate binding for a dataset.\n\nAuth: viewer or owner on dataset:{urn} (ReBAC). Symmetric with\nworkrooms/api.py's get_workroom shape.\n\nReturns 404 ``not_configured`` when the dataset exists but has no\ngate, and 404 ``dataset_not_found`` when the URN itself is unknown.\nDistinguishing these matters for SDK callers — the first is a\n\"no policy yet\" signal, the second is a typo.",
+        "operationId": "get_dataset_attribute_gate_catalog_datasets__urn__gate_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "urn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Urn"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeGateBindingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "delete": {
+        "tags": [
+          "dataset-gate-binding"
+        ],
+        "summary": "Delete Dataset Attribute Gate",
+        "description": "T2.5: clear a dataset's AttributeGate binding.\n\nAuth: owner on dataset:{urn} (ReBAC) + NativeRealmRequired.",
+        "operationId": "delete_dataset_attribute_gate_catalog_datasets__urn__gate_delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "urn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Urn"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Dataset Attribute Gate Catalog Datasets  Urn  Gate Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
     "/catalog/health": {
       "get": {
         "tags": [
@@ -6379,7 +8295,7 @@
           "datasets"
         ],
         "summary": "List Datasets",
-        "description": "List datasets, optionally filtering by query or other properties.",
+        "description": "List datasets, optionally filtering by query or other properties.\n\nWhen ReBAC is enabled, results are filtered to the datasets that are\ncanonically visible to the caller under the resolved requester and\nworkroom posture, regardless of caller origin.",
         "operationId": "list_datasets_catalog_datasets__get",
         "security": [
           {
@@ -10605,7 +12521,7 @@
           "cluster"
         ],
         "summary": "Get Cluster Capabilities",
-        "description": "Endpoint to retrieve cluster capabilities for model deployment and platform selection.\n\nReturns hardware information, system type, available platforms, and tool availability\nincluding whether llamacpp is installed and what inference engines are supported.\n\nReturns:\n    Dict[str, Any]: A dictionary containing cluster capabilities information.",
+        "description": "Endpoint to retrieve cluster capabilities for model deployment and platform selection.\n\nReturns hardware information, system type, available platforms, and tool availability\nincluding whether llamacpp is installed and what inference engines are supported.\n\nAuth widened by ENG-4697 / T5.20: viewer or owner on cluster:<local_uuid>\n(admin's install-seeded owner relation still passes). Mesh-origin probes\nwith the baseline federation grant can reach this endpoint per design\n`system-design.md` §4.4.3.\n\nReturns:\n    Dict[str, Any]: A dictionary containing cluster capabilities information.",
         "operationId": "get_cluster_capabilities_cluster_cluster_capabilities_get",
         "responses": {
           "200": {
@@ -10639,7 +12555,7 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "authenticated"
       }
     },
     "/cluster/attach_pairing": {
@@ -10949,7 +12865,7 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "authenticated"
       }
     },
     "/cluster/federations/{federation_id}": {
@@ -11091,6 +13007,188 @@
               "type": "string",
               "format": "uuid",
               "title": "Federation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/cluster/federations/{federation_id}/users": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "Add Federation User",
+        "description": "Add a brokered user to a federation's allowlist (FR-51 / FR-80).",
+        "operationId": "add_federation_user_cluster_federations__federation_id__users_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "federation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Federation Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "get": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "List Federation Users",
+        "description": "List all brokered users on a federation's allowlist.",
+        "operationId": "list_federation_users_cluster_federations__federation_id__users_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "federation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Federation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/cluster/federations/{federation_id}/users/{external_id}/revoke": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "Revoke Federation User",
+        "description": "Revoke a brokered user (FR-79).\n\nSets ``disabled_at = now()`` on the allowlist row — next inbound\nmesh request from the user is rejected at brokered_ingress with\n``revoked_brokered_user``.\n\nWhen ``cancel_in_flight_jobs=true`` (ENG-4708 / T5.31), also marks\nthe user's active jobs as STOPPED in the DB so the in-flight\ncompute reports as canceled in ``GET /api/cluster/jobs``. The\ncascade is best-effort: failures log but do not roll back the\nrevoke itself — the gate (disabled_at) is the load-bearing\nguarantee.",
+        "operationId": "revoke_federation_user_cluster_federations__federation_id__users__external_id__revoke_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "federation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Federation Id"
+            }
+          },
+          {
+            "name": "external_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "External Id"
+            }
+          },
+          {
+            "name": "cancel_in_flight_jobs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Cancel In Flight Jobs"
             }
           }
         ],
@@ -11331,6 +13429,35 @@
         "x-auth-role": "authenticated"
       }
     },
+    "/cluster/remote/ping": {
+      "post": {
+        "tags": [
+          "cluster-remote"
+        ],
+        "summary": "Handle Remote Ping",
+        "description": "Handle incoming ping from a federated cluster.\n\nRequires a valid HMAC signature from the paired cluster.\nReturns the local cluster ID to confirm liveness.",
+        "operationId": "handle_remote_ping_cluster_remote_ping_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
     "/cluster/remote/disconnect": {
       "post": {
         "tags": [
@@ -11377,6 +13504,1814 @@
             "BearerAuth": []
           }
         ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/submit": {
+      "post": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Submit Job",
+        "description": "Submit a Ray job asynchronously. Returns immediately with job ID.",
+        "operationId": "submit_job_cluster_jobs_submit_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobSubmitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobSubmitResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/run": {
+      "post": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Run Job",
+        "description": "Submit a Ray job and block until it completes or times out.",
+        "operationId": "run_job_cluster_jobs_run_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRunResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/": {
+      "get": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "List Jobs",
+        "description": "List jobs the caller can see (T5.29 / ENG-4706).\n\nNewest-first; ``limit`` + ``offset`` pagination. Mesh callers see\nonly jobs from their own source cluster — the source_filter\nmatches the per-job isolation property from ``get_status``.\n\nDemo bullet (2): ``kz.cluster.operations()`` builds on this.",
+        "operationId": "list_jobs_cluster_jobs__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 10000,
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JobRecord"
+                  },
+                  "title": "Response List Jobs Cluster Jobs  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/{job_id}/status": {
+      "get": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Get Job Status",
+        "description": "Get current status of a submitted job.",
+        "operationId": "get_job_status_cluster_jobs__job_id__status_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRecord"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/{job_id}/result": {
+      "get": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Get Job Result",
+        "description": "Extract the structured JSON result from a succeeded job's logs.\n\nENG-6699 — passes the caller's gate attributes (X-User-Attributes,\nset by ext-authz) so gated target datasets are record-filtered\nbefore the result is released.",
+        "operationId": "get_job_result_cluster_jobs__job_id__result_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Get Job Result Cluster Jobs  Job Id  Result Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/{job_id}/logs": {
+      "get": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Get Job Logs",
+        "description": "Return stdout/stderr logs for a job.",
+        "operationId": "get_job_logs_cluster_jobs__job_id__logs_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobLogs"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/jobs/{job_id}/cancel": {
+      "post": {
+        "tags": [
+          "cluster-jobs"
+        ],
+        "summary": "Cancel Job",
+        "description": "Cancel a running job.",
+        "operationId": "cancel_job_cluster_jobs__job_id__cancel_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRecord"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/diagnose": {
+      "get": {
+        "tags": [
+          "cluster-diagnose"
+        ],
+        "summary": "Diagnose",
+        "description": "Run cluster health probes and return a structured ClusterDiagnostics.\n\nAdmin-only per §4.2.10 auth table. Probes are fail-soft individually,\nbut a top-level orchestration failure is surfaced as 500 so operators\nnotice a broken diagnose pipeline.",
+        "operationId": "diagnose_cluster_diagnose_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterDiagnostics"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin"
+      }
+    },
+    "/authz/gates/discover": {
+      "post": {
+        "tags": [
+          "authz-gates"
+        ],
+        "summary": "Discover Gate",
+        "description": "Reflect on a Gate classpath and return its metadata.\n\nPer design §4.2.3:\n  - 404 ``classpath_unimportable`` when the module/class can't be\n    loaded (ImportError, AttributeError, ValueError on bad shape).\n  - 400 ``not_a_gate`` when the loaded class isn't an\n    AttributeGate or ExecutionGate subclass.\n  - 400 ``gate_not_constructible`` when the class can't be\n    zero-arg instantiated (ENG-4870).\n  - 403 ``classpath_not_allowed`` when the classpath is outside\n    the configured prefix allowlist (ENG-4861).\n\nAuth (ENG-4861): native-realm only (mesh-origin requests blocked\nby require_native_realm_dep) + ReBAC viewer/owner on the local\ncluster. Native-realm enforcement prevents brokered mesh viewers\nfrom triggering importlib.import_module side effects on the\nreceiver; the cluster-viewer check then layers ReBAC on top.\n\nNo state mutation; safe to call repeatedly. Successful responses are\nmemoized in ``_DISCOVER_CACHE`` for the process lifetime (v0.3.5\nOQ-10) — invalidated by ``_clear_discover_cache()`` from the\ncluster-binding API (T2.4) or a future gate-package install/replace\nflow (M5). Failure responses (404 / 400 / 403) are never cached so an\noperator who fixes a typo or installs the missing extension can\nretry without a pod restart.",
+        "operationId": "discover_gate_authz_gates_discover_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverGateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverGateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/cluster/execution-gate": {
+      "get": {
+        "tags": [
+          "cluster-gate-binding"
+        ],
+        "summary": "Get Execution Gate",
+        "description": "T2.4: read the active ExecutionGate binding for this cluster.\n\nReturns 404 ``not_configured`` when no binding is persisted —\nthe JobGateRunner default (ALLOW local, DENY mesh) is the operating\nposture in that case.",
+        "operationId": "get_execution_gate_cluster_execution_gate_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionGateBindingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      },
+      "put": {
+        "tags": [
+          "cluster-gate-binding"
+        ],
+        "summary": "Set Execution Gate",
+        "description": "T2.4: bind an ExecutionGate to this cluster.\n\nAuth (M3 Proactive Security Checklist §4.4.3.1):\n  - NativeRealmRequired: mesh-origin requests rejected.\n  - AdminUser: cluster-wide execution gate replacement is an admin\n    mutation (parallel to ``kamiwaza/cluster/api.py`` mutators).\n    Any authenticated non-admin would otherwise be able to flip the\n    authz outcome for every job submission on the cluster.\n\nSide effects:\n  - Validates type is an ExecutionGate subclass (else 400 wrong_kind).\n  - Validates config against gate.config_schema() (T2.6).\n  - Writes runtime_config[authz.execution_gate] = {type, config}.\n  - Invalidates the discover cache so the next reflect() call\n    observes the now-active gate (v0.3.5 OQ-10).",
+        "operationId": "set_execution_gate_cluster_execution_gate_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecutionGateBindingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutionGateBindingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin"
+      },
+      "delete": {
+        "tags": [
+          "cluster-gate-binding"
+        ],
+        "summary": "Delete Execution Gate",
+        "description": "T2.4: clear the cluster's ExecutionGate binding.\n\nReturns 404 ``not_configured`` when there is nothing to clear so\nthe caller can distinguish \"deleted X\" from \"nothing was there\".\n\nAuth (M3 Proactive Security Checklist §4.4.3.1):\n  - NativeRealmRequired: mesh-origin requests rejected.\n  - AdminUser: clearing the cluster execution gate is a mutation of\n    cluster-wide authz state. Same justification as the PUT above.",
+        "operationId": "delete_execution_gate_cluster_execution_gate_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Delete Execution Gate Cluster Execution Gate Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin"
+      }
+    },
+    "/authz/subjects/{id_or_username}": {
+      "put": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "Upsert Subject",
+        "description": "T3.5: idempotent upsert at ``PUT /api/authz/subjects/{id_or_username}``.\n\nAuth (M3 Proactive Security Checklist §4.4.3.1):\n  - AdminUser: Keycloak admin role required (subject management is\n    an admin function — subjects ARE the principals ReBAC names,\n    so ReBAC ownership doesn't recurse here).\n  - NativeRealmRequired: mesh-origin rejected. Brokered mesh\n    viewers must not provision subjects on the receiver.",
+        "operationId": "upsert_subject_authz_subjects__id_or_username__put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubjectUpsertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subject"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "get": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "Get Subject",
+        "description": "T3.5: read the Subject by KC UUID or username.\n\nAuth: AdminUser (admin-only in M3). Self-read (a non-admin reading\ntheir own subject) is a separate use case — wires in M3.1+ when\nan end-user surface needs it; the M3 demo author runs setup.py as\nadmin and never hits self-read.",
+        "operationId": "get_subject_authz_subjects__id_or_username__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subject"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "delete": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "Delete Subject",
+        "description": "T3.5: delete the Subject by KC UUID or username.\n\nAuth: AdminUser + NativeRealmRequired.\n\n``?cascade=grants`` forwards ``cascade_grants=True`` to the service\nso the subject's ReBAC tuples are removed BEFORE the KC user delete\nfires (ENG-4937). Any other cascade value is rejected to keep the\nAPI surface tight.",
+        "operationId": "delete_subject_authz_subjects__id_or_username__delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          },
+          {
+            "name": "cascade",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Set to ``grants`` to cascade-remove the subject's ReBAC relations (ENG-4937). Omit to keep grants in place.",
+              "title": "Cascade"
+            },
+            "description": "Set to ``grants`` to cascade-remove the subject's ReBAC relations (ENG-4937). Omit to keep grants in place."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Subject Authz Subjects  Id Or Username  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/authz/subjects/{id_or_username}/grants": {
+      "post": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "Create Grant",
+        "description": "T3.6: bind a ReBAC tuple ``(subject, object, relation)``.\n\nSubject namespace is fixed at ``user`` (corpuser equivalent); the\ncaller-supplied ``object_namespace`` / ``object_id`` / ``relation``\nname the target side and the verb. Delegates to relationship_store.",
+        "operationId": "create_grant_authz_subjects__id_or_username__grants_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_GrantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Grant"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "get": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "List Grants",
+        "description": "T3.6: list all ReBAC tuples bound to this subject.",
+        "operationId": "list_grants_authz_subjects__id_or_username__grants_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Grant"
+                  },
+                  "title": "Response List Grants Authz Subjects  Id Or Username  Grants Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "delete": {
+        "tags": [
+          "authz-subjects"
+        ],
+        "summary": "Delete Grant",
+        "description": "T3.6: remove a ReBAC tuple ``(subject, object, relation)``.\n\nTuple-key body (not path) because relation values can contain\ncharacters that don't path-encode cleanly. Same shape as POST.",
+        "operationId": "delete_grant_authz_subjects__id_or_username__grants_delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_or_username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Username"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_GrantBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Grant Authz Subjects  Id Or Username  Grants Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/authz/gate-packages": {
+      "get": {
+        "tags": [
+          "authz-gate-packages"
+        ],
+        "summary": "List Gate Packages",
+        "description": "List installed gate packages (FR-90 / FR-95).",
+        "operationId": "list_gate_packages_authz_gate_packages_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatePackageList"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin"
+      },
+      "post": {
+        "tags": [
+          "authz-gate-packages"
+        ],
+        "summary": "Install Gate Package",
+        "description": "Install a gate package (FR-89 / FR-95).\n\nHash-pin is mandatory. The pip subprocess runs with --require-hashes\nagainst the chart-configured index URL.",
+        "operationId": "install_gate_package_authz_gate_packages_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GatePackageSpec"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatePackageInstallResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin"
+      }
+    },
+    "/authz/gate-packages/{name}": {
+      "get": {
+        "tags": [
+          "authz-gate-packages"
+        ],
+        "summary": "Get Gate Package",
+        "description": "Get one installed gate-package by name (FR-90).",
+        "operationId": "get_gate_package_authz_gate_packages__name__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatePackageState"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "put": {
+        "tags": [
+          "authz-gate-packages"
+        ],
+        "summary": "Replace Gate Package",
+        "description": "Atomic in-place replace (FR-89a / T7.5).\n\nRefuses with 409 ``classpath_drop`` if the new package would drop a\ncurrently-bound classpath. The replace itself is atomic — at most a\nsub-microsecond filesystem window where the gate code is unavailable\n(gate-runner fails closed during that window per §4.4.5).\n\nMulti-replica caveat (PR #1754 RE-REVIEW round 4 C2 / round 5 M3):\neviction of the cached gate instance + ``sys.modules`` entry happens\n**per replica**. In multi-Ray-Serve / multi-worker deployments, sibling\nreplicas continue to serve the v1 instance until their next pod\nrestart. The ``X-Kamiwaza-Gate-Eviction-Scope: local-replica-only``\nresponse header signals this on every replace response.\n\nTo make the new wheel effective on all replicas, run the rolling\nrestart (operator runbook):\n\n    kubectl rollout restart deployment/core-scheduler -n kamiwaza\n    kubectl rollout restart raycluster/core-raycluster -n kamiwaza\n\nBroadcast invalidation (runtime-config epoch bump in\n``cluster_gate_packages`` checked on every gate lookup) is tracked as\na follow-up so the rolling restart can be eliminated; current shape\nis the light-path \"thinnest end-to-end\" for M5a per design v0.3.9.",
+        "operationId": "replace_gate_package_authz_gate_packages__name__put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GatePackageSpec"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatePackageInstallResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "delete": {
+        "tags": [
+          "authz-gate-packages"
+        ],
+        "summary": "Uninstall Gate Package",
+        "description": "Uninstall (FR-90). Refuses with 409 ``uninstall_blocked`` if any\nactive Cluster.executionGate or Dataset.gate binding references a\nclasspath from the package.",
+        "operationId": "uninstall_gate_package_authz_gate_packages__name__delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/cluster/attribute-schema/{name}": {
+      "put": {
+        "tags": [
+          "attribute-schema"
+        ],
+        "summary": "Declare Attribute",
+        "description": "PUT idempotent declare — registers an attribute in the realm vocabulary.\n\nAuth: AdminUser + NativeRealmRequired (§4.4.3.1 row 1).\nReturns the AttributeSchema in ``declared`` state. Re-declaring with\nan identical shape is a no-op. Shape change on already-declared\nstate returns 400 ``shape_change_on_declared`` — deprecate + withdraw\nfirst to retire the old shape.",
+        "operationId": "declare_attribute_cluster_attribute_schema__name__put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttributeSchemaDeclareRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      },
+      "delete": {
+        "tags": [
+          "attribute-schema"
+        ],
+        "summary": "Delete Attribute Schema",
+        "description": "DELETE — deprecate (default) or withdraw (force=true).\n\nAuth: AdminUser + NativeRealmRequired (§4.4.3.1 row 1).\n\nResponse shape: ``{state, subjects_holding_value}`` so the SDK can\nsurface the post-transition state to the operator.",
+        "operationId": "delete_attribute_schema_cluster_attribute_schema__name__delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When ``false`` (default), transitions declared → deprecated. When ``true``, transitions to withdrawn (KC user-profile entry + mapper removed; refused if subjects_holding_value > 0 unless force=true).",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "When ``false`` (default), transitions declared → deprecated. When ``true``, transitions to withdrawn (KC user-profile entry + mapper removed; refused if subjects_holding_value > 0 unless force=true)."
+          },
+          {
+            "name": "subjects_holding_value",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Caller-supplied count of subjects currently holding a value for this attribute. Default 0. force=true with non-zero count is allowed and audited; force=false with non-zero count returns 409.",
+              "default": 0,
+              "title": "Subjects Holding Value"
+            },
+            "description": "Caller-supplied count of subjects currently holding a value for this attribute. Default 0. force=true with non-zero count is allowed and audited; force=false with non-zero count returns 409."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Attribute Schema Cluster Attribute Schema  Name  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
+    "/cluster/attribute-schema": {
+      "get": {
+        "tags": [
+          "attribute-schema"
+        ],
+        "summary": "List Attribute Schemas",
+        "description": "GET — list the declared vocabulary.\n\nAuth: ViewerUser (admins + ReBAC-allowed viewers can discover the\ncontract surface). Mesh-origin viewers ARE allowed — federation\npeers may need to discover a clusters's vocabulary to plan\ncross-cluster gate compatibility (OQ-13 contract surface).",
+        "operationId": "list_attribute_schemas_cluster_attribute_schema_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "include_deprecated",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include deprecated entries in the response. Withdrawn entries are tombstoned at the KC layer and never appear here.",
+              "default": true,
+              "title": "Include Deprecated"
+            },
+            "description": "Include deprecated entries in the response. Withdrawn entries are tombstoned at the KC layer and never appear here."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeSchemaListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "viewer"
+      }
+    },
+    "/mesh/{cluster_selector}/{path}": {
+      "options": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "head": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "post": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "get": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "patch": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "delete": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "put": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
         "x-auth-role": "authenticated"
       }
     },
@@ -11661,15 +15596,14 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/ingestion/api/dde/connectors/": {
+    "/dde/connectors/": {
       "get": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "List Connectors",
-        "operationId": "list_connectors_ingestion_api_dde_connectors__get",
+        "operationId": "list_connectors_dde_connectors__get",
         "security": [
           {
             "BearerAuth": []
@@ -11775,7 +15709,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectorListResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorListResponse"
                 }
               }
             }
@@ -11795,12 +15729,11 @@
       },
       "post": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "Create Connector",
-        "operationId": "create_connector_ingestion_api_dde_connectors__post",
+        "operationId": "create_connector_dde_connectors__post",
         "security": [
           {
             "BearerAuth": []
@@ -11814,7 +15747,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ConnectorCreate"
+                "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorCreate"
               }
             }
           }
@@ -11825,7 +15758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorResponse"
                 }
               }
             }
@@ -11844,15 +15777,14 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/ingestion/api/dde/connectors/{connector_id}": {
+    "/dde/connectors/{connector_id}": {
       "get": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "Get Connector",
-        "operationId": "get_connector_ingestion_api_dde_connectors__connector_id__get",
+        "operationId": "get_connector_dde_connectors__connector_id__get",
         "security": [
           {
             "BearerAuth": []
@@ -11879,7 +15811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorResponse"
                 }
               }
             }
@@ -11899,12 +15831,11 @@
       },
       "put": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "Update Connector",
-        "operationId": "update_connector_ingestion_api_dde_connectors__connector_id__put",
+        "operationId": "update_connector_dde_connectors__connector_id__put",
         "security": [
           {
             "BearerAuth": []
@@ -11930,7 +15861,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ConnectorUpdate"
+                "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorUpdate"
               }
             }
           }
@@ -11941,7 +15872,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorResponse"
                 }
               }
             }
@@ -11961,12 +15892,11 @@
       },
       "delete": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "Delete Connector",
-        "operationId": "delete_connector_ingestion_api_dde_connectors__connector_id__delete",
+        "operationId": "delete_connector_dde_connectors__connector_id__delete",
         "security": [
           {
             "BearerAuth": []
@@ -11993,7 +15923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorResponse"
                 }
               }
             }
@@ -12012,15 +15942,14 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/ingestion/api/dde/connectors/{connector_id}/trigger_ingest": {
+    "/dde/connectors/{connector_id}/trigger_ingest": {
       "post": {
         "tags": [
-          "ingestion",
           "dde-connectors",
           "dde-connectors"
         ],
         "summary": "Trigger Ingest",
-        "operationId": "trigger_ingest_ingestion_api_dde_connectors__connector_id__trigger_ingest_post",
+        "operationId": "trigger_ingest_dde_connectors__connector_id__trigger_ingest_post",
         "security": [
           {
             "BearerAuth": []
@@ -12066,15 +15995,14 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/ingestion/api/dde/documents/": {
+    "/dde/documents/": {
       "post": {
         "tags": [
-          "ingestion",
           "dde-documents",
           "dde-documents"
         ],
         "summary": "Create Document",
-        "operationId": "create_document_ingestion_api_dde_documents__post",
+        "operationId": "create_document_dde_documents__post",
         "security": [
           {
             "BearerAuth": []
@@ -12119,12 +16047,11 @@
       },
       "get": {
         "tags": [
-          "ingestion",
           "dde-documents",
           "dde-documents"
         ],
         "summary": "List Documents",
-        "operationId": "list_documents_ingestion_api_dde_documents__get",
+        "operationId": "list_documents_dde_documents__get",
         "security": [
           {
             "BearerAuth": []
@@ -12225,15 +16152,14 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/ingestion/api/dde/documents/{document_id}": {
+    "/dde/documents/{document_id}": {
       "get": {
         "tags": [
-          "ingestion",
           "dde-documents",
           "dde-documents"
         ],
         "summary": "Get Document",
-        "operationId": "get_document_ingestion_api_dde_documents__document_id__get",
+        "operationId": "get_document_dde_documents__document_id__get",
         "security": [
           {
             "BearerAuth": []
@@ -12297,15 +16223,23 @@
         ],
         "summary": "Create Retrieval Job",
         "operationId": "create_retrieval_job_retrieval_jobs_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RetrievalRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -12329,6 +16263,16 @@
             }
           }
         },
+        "x-auth-role": "authenticated"
+      },
+      "get": {
+        "tags": [
+          "retrieval",
+          "retrieval"
+        ],
+        "summary": "List Retrieval Jobs",
+        "description": "List retrieval jobs (ENG-4707 / T5.30 / FR-85).\n\nNative admin sees all jobs; non-admin requesters see only their own\n(matches the per-job ownership check on get_status / cancel). Mesh\ncallers are scoped to their own requester URN — preserves the\nisolation property the existing retrieval endpoints use.",
+        "operationId": "list_retrieval_jobs_retrieval_jobs_get",
         "security": [
           {
             "BearerAuth": []
@@ -12337,6 +16281,108 @@
             "OAuth2Login": []
           }
         ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RetrievalJob"
+                  },
+                  "title": "Response List Retrieval Jobs Retrieval Jobs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/retrieval/jobs/{job_id}/cancel": {
+      "post": {
+        "tags": [
+          "retrieval",
+          "retrieval"
+        ],
+        "summary": "Cancel Retrieval Job",
+        "description": "Cancel a retrieval job (ENG-4709 / T5.32 / FR-84).\n\nMarks the job as CANCELED in the DB. Ownership is enforced — a\nnon-admin requester can only cancel their own jobs. Returns the\nupdated job status.",
+        "operationId": "cancel_retrieval_job_retrieval_jobs__job_id__cancel_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetrievalJobStatus"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
         "x-auth-role": "authenticated"
       }
     },
@@ -16032,7 +20078,7 @@
           "ontology-operations"
         ],
         "summary": "Search Knowledge",
-        "description": "Search the knowledge graph for relevant facts.\n\nArgs:\n    ontology_id: Ontology instance UUID\n    request: Search request with query and group_ids\n\nReturns:\n    KnowledgeSearchResult with matching facts",
+        "description": "Search the knowledge graph for relevant facts.\n\nArgs:\n    ontology_id: Ontology instance UUID\n    request: Search request with query and group_ids\n\nReturns:\n    KnowledgeSearchResult with matching facts\n\nCross-workroom guard: this route is addressed by ontology id only, so\nthe caller's authorized ``X-Workroom-ID`` need not match the workroom\nthe ontology actually belongs to. Without a guard, an ontology owned by\nanother workroom slips past header authz and the workroom-scoped\ninstance lookup downstream fails with a swallowed ``ValueError`` that\nsurfaces as a generic 500 — making a denial indistinguishable from a\nreal server error. Derive the ontology's owning workroom from the row\nand authorize the caller against it, collapsing 403 → 404 to hide\nexistence (matching ``get_workroom_subgraph`` / the model-bindings\nroute). A missing ontology collapses to the same 404 so cross-workroom\nand not-found are indistinguishable; 401/503 propagate unchanged\nbecause they carry no resource-existence signal.",
         "operationId": "search_knowledge_context_ontologies__ontology_id__search_post",
         "security": [
           {
@@ -16370,7 +20416,7 @@
           "ontology-operations"
         ],
         "summary": "Update Model Bindings",
-        "description": "Operator-driven pin update for a Graphiti ontology's chat / embedding bindings.\n\nPin a chat or embedding capability to a specific deployment by ID, or\nclear an existing pin (``deployment_id=null``) and let the binding\nreconciler resume auto-resolution. See system design Section 4.2.5\nfor the full state matrix.\n\nAuthorization is path-scoped: the workroom is derived from\n``DBOntologyInstance.workroom_id`` (not from ``X-Workroom-ID``) so\nthe caller cannot escalate by sending a foreign header. Admins\nbypass; non-admins must hold workroom membership.\n\nValidation order (each step's failure short-circuits the next):\n\n1. Authentication (``ContextWriter`` — admin OR user).\n2. Ontology existence + workroom derivation. Any pre-authz lookup\n   failure (missing, foreign workroom, global-scoped) collapses to\n   **404** so the existence of an ontology in another workroom can\n   neither be probed nor confirmed by an unprivileged caller. This\n   mirrors the path-scoped pattern in ``get_workroom_subgraph``\n   (system design Section 4.4.5 / OWASP A01).\n3. Workroom authorization for the path-derived workroom id.\n4. Capability classification (chat vs embedding) for each\n   requested deployment_id. 422 on mismatch.\n5. Embedding identity check against the existing pin. 422 on\n   cross-model attempt.\n6. Reconciler runs: probes route, persists ``_managed_bindings``,\n   patches K8s extension env. Successful K8s rollout → 200.\n   K8s rollout failure → reconciler rolls back the binding and\n   raises ``ModelRouteUnavailableError`` → 503 + ``Retry-After``.\n   Operator-pinned deployment unroutable → 503 + ``Retry-After``.",
+        "description": "Operator-driven pin update for a Graphiti ontology's chat / embedding bindings.\n\nPin a chat or embedding capability to a specific deployment by ID, or\nclear an existing pin (``deployment_id=null``) and let the binding\nreconciler resume auto-resolution. See system design Section 4.2.5\nfor the full state matrix.\n\nAuthorization is path-scoped: the workroom is derived from\n``DBOntologyInstance.workroom_id`` (not from ``X-Workroom-ID``) so\nthe caller cannot escalate by sending a foreign header. Admins\nbypass; because this is a write/operator action (it patches the\nGraphiti extension env via the reconciler), non-admins must hold a\n**write-caliber** relation (owner/editor) on the derived workroom —\nread-only membership (viewer) is not sufficient.\n\nValidation order (each step's failure short-circuits the next):\n\n1. Authentication (``ContextWriter`` — admin OR user).\n2. Ontology existence + workroom derivation. Any pre-authz lookup\n   failure (missing, foreign workroom, global-scoped) collapses to\n   **404** so the existence of an ontology in another workroom can\n   neither be probed nor confirmed by an unprivileged caller. This\n   mirrors the path-scoped pattern in ``get_workroom_subgraph``\n   (system design Section 4.4.5 / OWASP A01).\n3. Workroom authorization for the path-derived workroom id:\n   (a) read membership — non-members collapse to **404** (privacy);\n   (b) write-caliber owner/editor — a confirmed read-only member\n   (viewer) is rejected with **403** (existence already known to\n   them, so not collapsed to 404). Membership outage → **503**.\n4. Capability classification (chat vs embedding) for each\n   requested deployment_id. 422 on mismatch.\n5. Embedding identity check against the existing pin. 422 on\n   cross-model attempt.\n6. Reconciler runs: probes route, persists ``_managed_bindings``,\n   patches K8s extension env. Successful K8s rollout → 200.\n   K8s rollout failure → reconciler rolls back the binding and\n   raises ``ModelRouteUnavailableError`` → 503 + ``Retry-After``.\n   Operator-pinned deployment unroutable → 503 + ``Retry-After``.",
         "operationId": "update_model_bindings_context_ontologies__ontology_id__model_bindings_put",
         "security": [
           {
@@ -17130,6 +21176,169 @@
         "x-auth-role": "authenticated"
       }
     },
+    "/context/download/raw/{file_id}": {
+      "get": {
+        "tags": [
+          "context",
+          "download"
+        ],
+        "summary": "Download Raw File",
+        "description": "Raw-file detail with a browser-reachable (public) presigned download URL.",
+        "operationId": "download_raw_file_context_download_raw__file_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "File Id"
+            }
+          },
+          {
+            "name": "expires_seconds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 3600,
+                  "minimum": 30
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Override pre-signed URL TTL in seconds",
+              "title": "Expires Seconds"
+            },
+            "description": "Override pre-signed URL TTL in seconds"
+          },
+          {
+            "name": "X-Workroom-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Workroom ID for isolation",
+              "title": "X-Workroom-Id"
+            },
+            "description": "Workroom ID for isolation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawFileDetailResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/context/download/documents/{source_urn}": {
+      "get": {
+        "tags": [
+          "context",
+          "download"
+        ],
+        "summary": "Download Document",
+        "description": "Original-document browser-reachable (public) presigned download URL.",
+        "operationId": "download_document_context_download_documents__source_urn__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "source_urn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Source Urn"
+            }
+          },
+          {
+            "name": "X-Workroom-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Workroom ID for isolation",
+              "title": "X-Workroom-Id"
+            },
+            "description": "Workroom ID for isolation"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentDownloadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
     "/context/embedding-model": {
       "put": {
         "tags": [
@@ -17493,7 +21702,7 @@
           "logger"
         ],
         "summary": "List Orphaned Logs",
-        "description": "List all orphaned log files (deployments that no longer exist).",
+        "description": "List all orphaned log files (deployments that no longer exist).\n\nOrphaned log files do not have a deployment row available for owner or\nworkroom verification, so this route is admin-only.",
         "operationId": "list_orphaned_logs_logger_deployments_orphaned_get",
         "responses": {
           "200": {
@@ -17525,7 +21734,7 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/logger/deployments/{deployment_type}/{deployment_id}": {
@@ -17590,7 +21799,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       },
       "delete": {
         "tags": [
@@ -17729,7 +21938,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/logger/stats": {
@@ -17770,7 +21979,7 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/logger/cleanup": {
@@ -17906,7 +22115,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/logger/deployment/{deployment_id}/logs/patterns": {
@@ -17959,7 +22168,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/logger/engine/{engine_type}": {
@@ -18011,7 +22220,7 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "admin"
       }
     },
     "/apps/config/ephemeral_forced": {
@@ -18965,6 +23174,165 @@
           }
         ],
         "x-auth-role": "admin"
+      }
+    },
+    "/apps/app_templates/catalog/overlay/{name}": {
+      "put": {
+        "tags": [
+          "app_templates"
+        ],
+        "summary": "Put Catalog Overlay",
+        "description": "Shadow a catalog template with a local dev build (ENG-6802).\n\nWritten by `kz-ext dev` so new workrooms launch the in-development build.\nThe shadow survives remote catalog syncs until removed via DELETE.\n\nAuth parity with the extension deploy surface (`create_extension` /\n`patch_extension`): anyone who can hot-swap the shared dev instance via\n`kz-ext dev` can already affect what every user sees, and the issue's\nsemantics require the overlay write to work for whoever runs the dev\nloop. Writes are audit-logged with actor attribution; shadowing is\nrestricted to Kamiwaza-sourced templates and fully reversible.",
+        "operationId": "put_catalog_overlay_apps_app_templates_catalog_overlay__name__put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 120,
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogOverlayEntry"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogOverlayApplyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "delete": {
+        "tags": [
+          "app_templates"
+        ],
+        "summary": "Delete Catalog Overlay",
+        "description": "Remove a local dev shadow, restoring the upstream catalog template.\n\nAuth parity with put_catalog_overlay — unload is the less-privileged\ndirection (it restores upstream content).",
+        "operationId": "delete_catalog_overlay_apps_app_templates_catalog_overlay__name__delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 120,
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogOverlayRemoveResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/apps/app_templates/catalog/overlay": {
+      "get": {
+        "tags": [
+          "app_templates"
+        ],
+        "summary": "List Catalog Overlays",
+        "description": "List active local dev shadows (consumed by `kz-ext status`).",
+        "operationId": "list_catalog_overlays_apps_app_templates_catalog_overlay_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TemplateShadow"
+                  },
+                  "type": "array",
+                  "title": "Response List Catalog Overlays Apps App Templates Catalog Overlay Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated"
       }
     },
     "/apps/remote/status": {
@@ -20409,6 +24777,67 @@
         "x-auth-role": "authenticated"
       }
     },
+    "/extensions/upgrade-all": {
+      "post": {
+        "tags": [
+          "extensions"
+        ],
+        "summary": "Upgrade All Extensions",
+        "description": "Re-render every template-driven deployed extension whose template digest\ndiffers from its running CR. Admin-only — enforced by ``AdminUser`` so\nFastAPI rejects non-admin callers before the route runs. Pod rolls are\nobserved via the operator + k8s rolling update; this endpoint returns once\neach CR has either been PATCHed, recognized as up-to-date, or recorded\nwith an error.",
+        "operationId": "upgrade_all_extensions_extensions_upgrade_all_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "names",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated extension (CR) names to scope the upgrade.",
+              "title": "Names"
+            },
+            "description": "Comma-separated extension (CR) names to scope the upgrade."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpgradeAllResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin"
+      }
+    },
     "/security/public/config": {
       "get": {
         "tags": [
@@ -20489,14 +24918,24 @@
           "connectors"
         ],
         "summary": "List Connectors",
-        "description": "List all configured connectors.",
+        "description": "List all configured connector configs (admin only).",
         "operationId": "list_connectors_connectors__get",
-        "security": [
+        "parameters": [
           {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -20505,7 +24944,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExternalConnectorListResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorListResponse"
                 }
               }
             }
@@ -20521,6 +24960,14 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "x-auth-role": "authenticated"
       },
       "post": {
@@ -20529,7 +24976,7 @@
           "connectors"
         ],
         "summary": "Create Connector",
-        "description": "Create a new connector configuration (admin only).",
+        "description": "Create a new connector configuration (admin only).\n\nFor a connector type that ships a deployable manifest, the workload is\nprovisioned in the background after the row is created, so the connector\nreaches ``ready`` on its own (the card shows not_deployed -> deploying ->\nready) instead of needing a separate sync.",
         "operationId": "create_connector_connectors__post",
         "parameters": [
           {
@@ -20554,7 +25001,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExternalConnectorCreate"
+                "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorCreate"
               }
             }
           }
@@ -20565,7 +25012,327 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExternalConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/subscriptions": {
+      "post": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Subscribe Connector",
+        "description": "Subscribe a connector by manifest + endpoint (admin only).",
+        "operationId": "subscribe_connector_connectors_subscriptions_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorSubscriptionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/catalog": {
+      "get": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "List Connector Catalog",
+        "description": "List connectors available to subscribe from the published catalog (admin).\n\nParity with the App Garden apps/tools catalog: connector manifests are\nfetched from the remote template catalog (or a file:// override) so an admin\ncan browse and subscribe a connector without hand-supplying its manifest.",
+        "operationId": "list_connector_catalog_connectors_catalog_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogConnectorListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/register": {
+      "post": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Register Connector",
+        "description": "Self-registration: register a connector already running at an endpoint (admin).\n\nCore fetches the connector's self-describing manifest from\n``GET {endpoint}/manifest`` and subscribes it with the supplied config.",
+        "operationId": "register_connector_connectors_register_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorRegisterRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/available": {
+      "get": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "List Available Connectors",
+        "description": "List enabled connector metadata safe for user account connection flows.",
+        "operationId": "list_available_connectors_connectors_available_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailableConnectorListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/types": {
+      "get": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "List Connector Types",
+        "description": "List registered connector types with their config schema (admin add form).",
+        "operationId": "list_connector_types_connectors_types_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorTypeListResponse"
                 }
               }
             }
@@ -20599,16 +25366,8 @@
           "connectors"
         ],
         "summary": "Get Connector",
-        "description": "Get a connector by ID.",
+        "description": "Get a connector config by ID (admin only).",
         "operationId": "get_connector_connectors__connector_id__get",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
         "parameters": [
           {
             "name": "connector_id",
@@ -20619,6 +25378,22 @@
               "format": "uuid",
               "title": "Connector Id"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -20627,7 +25402,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExternalConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
                 }
               }
             }
@@ -20643,6 +25418,14 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "x-auth-role": "authenticated"
       },
       "put": {
@@ -20686,7 +25469,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExternalConnectorUpdate"
+                "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorUpdate"
               }
             }
           }
@@ -20697,7 +25480,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExternalConnectorResponse"
+                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
                 }
               }
             }
@@ -20785,15 +25568,15 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/connectors/m365/{connector_id}/device-code/start": {
+    "/connectors/{connector_id}/deploy": {
       "post": {
         "tags": [
           "connectors",
           "connectors"
         ],
-        "summary": "Start Device Code Flow",
-        "description": "Start the device code authentication flow.",
-        "operationId": "start_device_code_flow_connectors_m365__connector_id__device_code_start_post",
+        "summary": "Deploy Connector Workload",
+        "description": "Run a subscribed connector as a type:connector extension (admin only).\n\nProvisions the connector's workload identity, applies its CR (no public\ningress, no external egress), and binds the workload principal so the\nmint/proxy authorization recognizes the running pod. 202: the workload is\nscheduled; the extension-operator reconciles it to running asynchronously.",
+        "operationId": "deploy_connector_workload_connectors__connector_id__deploy_post",
         "parameters": [
           {
             "name": "connector_id",
@@ -20823,12 +25606,12 @@
           }
         ],
         "responses": {
-          "200": {
+          "202": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeviceCodeStartResponse"
+                  "$ref": "#/components/schemas/ConnectorDeploymentResponse"
                 }
               }
             }
@@ -20855,164 +25638,77 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/connectors/m365/{connector_id}/device-code/poll": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Poll Device Code Flow",
-        "description": "Poll for device code authentication completion.\n\nRate limited to 1 request per 5 seconds per flow to prevent abuse.",
-        "operationId": "poll_device_code_flow_connectors_m365__connector_id__device_code_poll_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "flow_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Flow Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeviceCodePollResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/status": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Get Connection Status",
-        "description": "Get the connection status for the current user.",
-        "operationId": "get_connection_status_connectors_m365__connector_id__status_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__m365__ConnectionStatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/disconnect": {
+    "/connectors/remote/sync": {
       "post": {
         "tags": [
           "connectors",
           "connectors"
         ],
-        "summary": "Disconnect",
-        "description": "Disconnect the current user from M365.",
-        "operationId": "disconnect_connectors_m365__connector_id__disconnect_post",
+        "summary": "Sync Declared Connectors",
+        "description": "Subscribe every catalog connector so admins can deploy them (admin only).\n\nSubscribes every connector published to the catalog, making it available to\nadmins. Mirrors ``apps``/``tool`` ``/remote/sync``; the chart's\npost-install/post-upgrade templates-sync Job calls this on every deploy so a\ngreenfield or updated cluster discovers its connectors with no manual step.\nSafe to re-run -- already-subscribed connectors are no-ops. Sync never\ndeploys a workload; standing one up is an explicit operator action.",
+        "operationId": "sync_declared_connectors_connectors_remote_sync_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Sync Declared Connectors Connectors Remote Sync Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/{connector_id}/connect": {
+      "post": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Connect Account",
+        "description": "Begin connecting the caller's account, per the connector's manifest flow.\n\nReturns ``{\"auth_url\": ...}`` for redirect (authorization-code) connectors, or\n``{\"device_code\": {...}}`` for device-code connectors; the client branches.",
+        "operationId": "connect_account_connectors__connector_id__connect_post",
         "parameters": [
           {
             "name": "connector_id",
@@ -21049,7 +25745,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Disconnect Connectors M365  Connector Id  Disconnect Post"
+                  "title": "Response Connect Account Connectors  Connector Id  Connect Post"
                 }
               }
             }
@@ -21076,15 +25772,234 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/connectors/m365/{connector_id}/verify": {
+    "/connectors/{connector_id}/connect/poll": {
+      "post": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Poll Device Connection",
+        "description": "Poll a device-code connect (returns status: pending | connected | expired).",
+        "operationId": "poll_device_connection_connectors__connector_id__connect_poll_post",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Poll Device Connection Connectors  Connector Id  Connect Poll Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/{connector_id}/connection": {
+      "get": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Get User Connection",
+        "description": "The caller's connection status for a connector.",
+        "operationId": "get_user_connection_connectors__connector_id__connection_get",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get User Connection Connectors  Connector Id  Connection Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/{connector_id}/disconnect": {
+      "post": {
+        "tags": [
+          "connectors",
+          "connectors"
+        ],
+        "summary": "Disconnect Account",
+        "description": "Disconnect the caller's account from a connector.",
+        "operationId": "disconnect_account_connectors__connector_id__disconnect_post",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2Login": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/connectors/{connector_id}/verify": {
       "post": {
         "tags": [
           "connectors",
           "connectors"
         ],
         "summary": "Verify Connection",
-        "description": "Verify the connection by testing all capabilities.",
-        "operationId": "verify_connection_connectors_m365__connector_id__verify_post",
+        "description": "Verify the caller's connection by probing through the deployed connector.",
+        "operationId": "verify_connection_connectors__connector_id__verify_post",
         "parameters": [
           {
             "name": "connector_id",
@@ -21119,968 +26034,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectionVerificationResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/profile": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "Get Profile",
-        "description": "Get the authenticated user's profile.",
-        "operationId": "get_profile_connectors_m365__connector_id__profile_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/sites": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "List Sites",
-        "description": "List SharePoint sites.",
-        "operationId": "list_sites_connectors_m365__connector_id__sites_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Search query",
-              "default": "*",
-              "title": "Search"
-            },
-            "description": "Search query"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Pagination token",
-              "title": "Page Token"
-            },
-            "description": "Pagination token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SitesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/drives": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "List Drives",
-        "description": "List drives for a site or OneDrive.",
-        "operationId": "list_drives_connectors_m365__connector_id__drives_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "site_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Site ID or 'me' for OneDrive",
-              "title": "Site Id"
-            },
-            "description": "Site ID or 'me' for OneDrive"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DrivesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/list": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "List Files",
-        "description": "List/browse files in a drive folder.",
-        "operationId": "list_files_connectors_m365__connector_id__list_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "drive_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Drive ID",
-              "title": "Drive Id"
-            },
-            "description": "Drive ID"
-          },
-          {
-            "name": "parent_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Parent folder ID",
-              "default": "root",
-              "title": "Parent Id"
-            },
-            "description": "Parent folder ID"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 100,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/search": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "Search Files",
-        "description": "Search for files.",
-        "operationId": "search_files_connectors_m365__connector_id__search_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 200,
-              "description": "Search query",
-              "title": "Q"
-            },
-            "description": "Search query"
-          },
-          {
-            "name": "drive_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Scope to specific drive",
-              "title": "Drive Id"
-            },
-            "description": "Scope to specific drive"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 200,
-              "minimum": 1,
-              "default": 50,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/content/{item_id}": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "Download Content",
-        "description": "Download file content.",
-        "operationId": "download_content_connectors_m365__connector_id__content__item_id__get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "item_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Item Id"
-            }
-          },
-          {
-            "name": "drive_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Drive ID",
-              "title": "Drive Id"
-            },
-            "description": "Drive ID"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/mail": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "List Mail",
-        "description": "List mail messages.",
-        "operationId": "list_mail_connectors_m365__connector_id__mail_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "folder",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Mail folder",
-              "default": "inbox",
-              "title": "Folder"
-            },
-            "description": "Mail folder"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 25,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MailResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/mail/{message_id}": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "Get Mail",
-        "description": "Get a specific mail message.",
-        "operationId": "get_mail_connectors_m365__connector_id__mail__message_id__get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "message_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Message Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MailDetailResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/m365/{connector_id}/events": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors",
-          "m365-proxy"
-        ],
-        "summary": "List Events",
-        "description": "List calendar events.",
-        "operationId": "list_events_connectors_m365__connector_id__events_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "start_date",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Start date (ISO format)",
-              "title": "Start Date"
-            },
-            "description": "Start date (ISO format)"
-          },
-          {
-            "name": "end_date",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "End date (ISO format)",
-              "title": "End Date"
-            },
-            "description": "End date (ISO format)"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 25,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "page_token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventsResponse"
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Verify Connection Connectors  Connector Id  Verify Post"
                 }
               }
             }
@@ -22636,309 +26592,23 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/connectors/google/{connector_id}/auth/start": {
-      "post": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Start Google Oauth",
-        "description": "Start Google OAuth flow - returns auth URL to redirect user to.\n\nSecurity:\n- Uses POST to prevent CSRF via image tags or preload attacks\n- Server-side state storage for CSRF protection per RFC 6749 Section 10.12\n\nNote:\n- redirect_uri is read from connector configuration\n- If not configured, falls back to deriving from request (not recommended)\n- Google requires redirect_uri to be a registered domain (not IP address)",
-        "operationId": "start_google_oauth_connectors_google__connector_id__auth_start_post",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Start Google Oauth Connectors Google  Connector Id  Auth Start Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/google/{connector_id}/status": {
-      "get": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Get Google Connection Status",
-        "description": "Get Google connection status for current user.",
-        "operationId": "get_google_connection_status_connectors_google__connector_id__status_get",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Get Google Connection Status Connectors Google  Connector Id  Status Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/google/{connector_id}/disconnect": {
-      "post": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Disconnect Google",
-        "description": "Disconnect Google account for current user.",
-        "operationId": "disconnect_google_connectors_google__connector_id__disconnect_post",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Disconnect Google Connectors Google  Connector Id  Disconnect Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/google/{connector_id}/verify": {
-      "post": {
-        "tags": [
-          "connectors",
-          "connectors"
-        ],
-        "summary": "Verify Google Connection",
-        "description": "Verify Google connection by testing configured capabilities.",
-        "operationId": "verify_google_connection_connectors_google__connector_id__verify_post",
-        "parameters": [
-          {
-            "name": "connector_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Connector Id"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConnectionVerificationResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2Login": []
-          },
-          {
-            "BearerAuth": []
-          }
-        ],
-        "x-auth-role": "authenticated"
-      }
-    },
-    "/connectors/public/google/callback": {
+    "/connectors/public/{provider}/callback": {
       "get": {
         "tags": [
           "connectors-public",
           "connectors-public"
         ],
-        "summary": "Google Oauth Callback",
-        "description": "Handle Google OAuth callback.\n\nThis endpoint receives the authorization code from Google\nand exchanges it for access/refresh tokens.",
-        "operationId": "google_oauth_callback_connectors_public_google_callback_get",
+        "summary": "Connector Oauth Callback",
+        "description": "Public OAuth callback: exchange the code, store the user's tokens, notify the opener.\n\nNo auth — the request is the provider's redirect. The single-use ``state``\nidentifies connector + user; ``provider`` is cosmetic (lets the redirect URI read\n``/google/callback`` etc.). Routing is entirely state-driven.",
+        "operationId": "connector_oauth_callback_connectors_public__provider__callback_get",
         "parameters": [
           {
-            "name": "state",
-            "in": "query",
+            "name": "provider",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "State"
+              "title": "Provider"
             }
           },
           {
@@ -22946,15 +26616,19 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "type": "string",
+              "default": "",
               "title": "Code"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "State"
             }
           },
           {
@@ -22962,31 +26636,9 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "type": "string",
+              "default": "",
               "title": "Error"
-            }
-          },
-          {
-            "name": "error_description",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Error Description"
             }
           }
         ],
@@ -23011,7 +26663,7 @@
           }
         },
         "x-auth-exempt": true,
-        "x-auth-exempt-reason": "OAuth return leg — Google redirects here cross-site, SameSite=Strict cookies not sent"
+        "x-auth-exempt-reason": "OAuth return leg — the provider redirects here cross-site (state-validated, not session-authed); SameSite=Strict cookies not sent"
       }
     },
     "/oauth-broker/apps/": {
@@ -24024,15 +27676,80 @@
         "x-auth-role": "authenticated"
       }
     },
-    "/oauth-broker/proxy/{provider}/{service}/{operation}/{resource_id}": {
+    "/oauth-broker/tokens/connectors/{connector_id}/mint": {
       "post": {
+        "tags": [
+          "oauth-broker",
+          "ephemeral-tokens",
+          "oauth-broker-tokens"
+        ],
+        "summary": "Mint Connector Token",
+        "description": "Mint a scope-restricted provider token for a connector.\n\nThe caller authenticates as the connector's workload (service-account)\nidentity; only the principal bound to the subscription\n(``workload_principal_id``) may mint. The credential source follows the\nconnector's declared auth model: ``per_user_oauth`` brokers a verified\nsubject's per-user token (refreshed in core), only for a subject whose\npresented acting-user token verifies (its ``sub``) and that holds a connected\nconnection; ``service_token`` returns the connector's admin-configured shared\ncredential, role-entitlement gated, for a verified subject -- or, when the\nconnector opts in via ``allow_subjectless``, with no triggering subject (an\nautonomous machine identity accountable via its workload binding). The minted\ntoken is the provider access token -- the refresh token and client secret\nnever leave core; the mint is lease-tracked for revoke-on-disconnect.\nData-plane half of the contract.",
+        "operationId": "mint_connector_token_oauth_broker_tokens_connectors__connector_id__mint_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorMintRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorMintResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/oauth-broker/proxy/{provider}/{service}/{operation}/{resource_id}": {
+      "get": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get",
         "parameters": [
           {
             "name": "provider",
@@ -24102,7 +27819,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
+                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Get"
                 }
               }
             }
@@ -24128,14 +27845,14 @@
         ],
         "x-auth-role": "authenticated"
       },
-      "get": {
+      "post": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get",
         "parameters": [
           {
             "name": "provider",
@@ -24205,7 +27922,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
+                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Get"
                 }
               }
             }
@@ -24233,14 +27950,14 @@
       }
     },
     "/oauth-broker/proxy/{provider}/{service}/{operation}": {
-      "post": {
+      "get": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get",
         "parameters": [
           {
             "name": "provider",
@@ -24301,7 +28018,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
+                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Get"
                 }
               }
             }
@@ -24327,14 +28044,14 @@
         ],
         "x-auth-role": "authenticated"
       },
-      "get": {
+      "post": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get",
         "parameters": [
           {
             "name": "provider",
@@ -24395,7 +28112,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
+                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Get"
                 }
               }
             }
@@ -24419,6 +28136,136 @@
             "BearerAuth": []
           }
         ],
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/oauth-broker/connectors/{connector_id}/proxy": {
+      "post": {
+        "tags": [
+          "oauth-broker",
+          "connector-proxy",
+          "connector-proxy"
+        ],
+        "summary": "Proxy Connector Request",
+        "description": "Execute a subscribed connector's request through core (P1, core-proxied).\n\nThe caller authenticates as the connector's workload identity; only the bound\n``workload_principal_id`` may proxy. Core authorizes the call as the mint does\n(verified acting subject, connection ownership, scope least-privilege), enforces\nthe connector's egress allowlist, attaches the provider access token, executes\nthe upstream call, and returns the response. The provider token never leaves\ncore; the connector never egresses to the SaaS directly. See\ncontracts/proxy-execute.md.",
+        "operationId": "proxy_connector_request_oauth_broker_connectors__connector_id__proxy_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorProxyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorProxyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      }
+    },
+    "/oauth-broker/connectors/{connector_id}/identity-proxy": {
+      "post": {
+        "tags": [
+          "oauth-broker",
+          "connector-proxy",
+          "connector-proxy"
+        ],
+        "summary": "Proxy Connector Identity",
+        "description": "Fetch a connector's account identity through core (the OAuth-callback whoami).\n\nThe connector pod has no external egress, so at the OAuth callback it asks core to\ncall the provider's identity endpoint with the freshly-minted access token. Core\nauthorizes the bound workload and enforces the egress allowlist -- the same trust\nboundary as the execute proxy, minus the connection/subject that don't exist yet.",
+        "operationId": "proxy_connector_identity_oauth_broker_connectors__connector_id__identity_proxy_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Connector Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorIdentityProxyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorProxyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
         "x-auth-role": "authenticated"
       }
     },
@@ -24930,7 +28777,7 @@
           "workrooms"
         ],
         "summary": "Create Workroom",
-        "description": "Create a new workroom associated with the calling user.\n\nUses ``require_non_global_write_context`` (not\n``require_workroom_write_context``) because the route mints a brand-new\nworkroom and does not write into the caller's currently-bound workroom.\nA viewer/member who is navigating a shared workroom they do not own\nmust still be able to create an unrelated new workroom; only the\nENG-2065 Global-admin restriction applies here.",
+        "description": "Create a new workroom associated with the calling user.\n\nThis route mints new state unrelated to the currently bound workroom, so it\nshould block non-admin Global writes without requiring write-caliber access\nto whatever shared workroom the caller happens to be viewing.",
         "operationId": "create_workroom_workrooms__post",
         "security": [
           {
@@ -26898,9 +30745,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "description": "Confirm that any active workroom sessions for the member should be terminated",
               "default": false,
               "title": "Confirm Active Sessions"
-            }
+            },
+            "description": "Confirm that any active workroom sessions for the member should be terminated"
           }
         ],
         "responses": {
@@ -27660,8 +31509,25 @@
           "workrooms"
         ],
         "summary": "Leave Workroom",
-        "description": "Unbind the calling user from their current workroom.\n\nReturns the session to the Global Workroom scope.",
+        "description": "Unbind the calling user from their current workroom.\n\nReturns the session to no-workroom scope.",
         "operationId": "leave_workroom_workrooms_leave_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LeaveWorkroomRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Data"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -28133,6 +31999,36 @@
             "type": "array",
             "title": "Messages",
             "description": "Messages to process"
+          },
+          "entity_types": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/EntityTypeSchema"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Types",
+            "description": "Optional entity-type schema to constrain extraction to a known type system. Omit for unconstrained extraction (default, backward-compatible behavior)."
+          },
+          "excluded_entity_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Excluded Entity Types",
+            "description": "Entity types to suppress, e.g. [\"Entity\"] to drop Graphiti's built-in catch-all so extraction is constrained to the supplied types rather than merely biased toward them."
           }
         },
         "type": "object",
@@ -28507,6 +32403,19 @@
             ],
             "title": "Collection Names",
             "description": "Backward-compatible collection list. Only a single collection is supported for agentic retrieval."
+          },
+          "collection_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection Name",
+            "description": "Single target collection, parity with /search and /retrieve. Takes precedence over the 'collection' default; a one-item collection_names list still wins. Agentic retrieval targets exactly one collection."
           },
           "group_ids": {
             "anyOf": [
@@ -28894,6 +32803,18 @@
             "title": "Compose Yml",
             "description": "The docker-compose YML from the template"
           },
+          "template_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Name",
+            "description": "Resolved source template name for template-backed deployments."
+          },
           "runtime_artifacts": {
             "anyOf": [
               {
@@ -28981,6 +32902,15 @@
             ],
             "title": "Image Status",
             "description": "Runtime information about container image pull status"
+          },
+          "services": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Services",
+            "description": "Runtime per-service status snapshot for K8s-backed deployments"
           }
         },
         "type": "object",
@@ -29807,6 +33737,222 @@
           "template_type": "app"
         }
       },
+      "AttributeGateBindingRequest": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "AttributeGateBindingRequest",
+        "description": "PUT body for /api/catalog/datasets/{urn}/gate."
+      },
+      "AttributeGateBindingResponse": {
+        "properties": {
+          "dataset_urn": {
+            "type": "string",
+            "title": "Dataset Urn"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config"
+          },
+          "gate_name": {
+            "type": "string",
+            "title": "Gate Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dataset_urn",
+          "type",
+          "config",
+          "gate_name",
+          "kind"
+        ],
+        "title": "AttributeGateBindingResponse",
+        "description": "Response shape for PUT/GET on /api/catalog/datasets/{urn}/gate."
+      },
+      "AttributeSchema": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "int",
+              "bool",
+              "string[]"
+            ],
+            "title": "Type"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "declared",
+              "deprecated",
+              "withdrawn"
+            ],
+            "title": "State"
+          },
+          "authority": {
+            "type": "string",
+            "enum": [
+              "local_admin",
+              "self",
+              "mesh_peer",
+              "system"
+            ],
+            "title": "Authority",
+            "default": "local_admin"
+          },
+          "sensitive": {
+            "type": "boolean",
+            "title": "Sensitive",
+            "default": false
+          },
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version",
+            "default": "1.0"
+          },
+          "declared_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Declared At"
+          },
+          "deprecated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deprecated At"
+          },
+          "withdrawn_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Withdrawn At"
+          },
+          "declared_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Declared By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "state",
+          "declared_at"
+        ],
+        "title": "AttributeSchema",
+        "description": "Full attribute-schema response shape (§4.2.18).\n\nRound-trips through KC realm user-profile annotations. Fields that\nonly apply in specific states (``deprecated_at``, ``withdrawn_at``)\nare ``None`` outside those states."
+      },
+      "AttributeSchemaDeclareRequest": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "string",
+              "int",
+              "bool",
+              "string[]"
+            ],
+            "title": "Type"
+          },
+          "sensitive": {
+            "type": "boolean",
+            "title": "Sensitive",
+            "default": false
+          },
+          "authority": {
+            "type": "string",
+            "enum": [
+              "local_admin",
+              "self",
+              "mesh_peer",
+              "system"
+            ],
+            "title": "Authority",
+            "default": "local_admin"
+          },
+          "schema_version": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Schema Version",
+            "default": "1.0"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "AttributeSchemaDeclareRequest",
+        "description": "PUT body for ``/api/cluster/attribute-schema/{name}``.\n\nIdempotent on identical shape. Shape change on a ``declared``-state\nattribute returns 400 ``shape_change_on_declared`` (operator must\ndeprecate first; this prevents silent semantic drift on existing\nsubject values)."
+      },
+      "AttributeSchemaListResponse": {
+        "properties": {
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/AttributeSchema"
+            },
+            "type": "array",
+            "title": "Attributes"
+          },
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version",
+            "default": "v0.3.6"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attributes"
+        ],
+        "title": "AttributeSchemaListResponse",
+        "description": "GET ``/api/cluster/attribute-schema`` response.\n\nWraps the vocabulary list with a top-level ``schema_version`` so\ncross-cluster compatibility checks (v1.1 work) have a place to land.\n``include_deprecated`` controls whether deprecated entries appear;\nwithdrawn entries are tombstoned (always omitted) — the API surface\ndoes not expose them."
+      },
       "AudioReadinessResponse": {
         "properties": {
           "ready": {
@@ -29845,6 +33991,78 @@
           "message"
         ],
         "title": "AudioReadinessResponse"
+      },
+      "AvailableConnectorListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AvailableConnectorResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "AvailableConnectorListResponse",
+        "description": "Schema for listing user-visible connector availability."
+      },
+      "AvailableConnectorResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "connector_type": {
+            "type": "string",
+            "title": "Connector Type"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Workload readiness (see ConnectorResponse.status); gates the UI 'Test' button.",
+            "default": "unknown"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "connector_type",
+          "enabled",
+          "scopes"
+        ],
+        "title": "AvailableConnectorResponse",
+        "description": "User-safe connector metadata for account connection flows."
       },
       "BindingState": {
         "properties": {
@@ -29960,7 +34178,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
@@ -30060,7 +34278,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
@@ -30180,17 +34398,34 @@
         "title": "CallbackConfig",
         "description": "Configuration for pipeline job callbacks."
       },
-      "CapabilityCheckResult": {
+      "CatalogConnectorListResponse": {
         "properties": {
-          "capability": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogConnectorResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "CatalogConnectorListResponse",
+        "description": "Connectors available to subscribe from the catalog."
+      },
+      "CatalogConnectorResponse": {
+        "properties": {
+          "connector_type": {
             "type": "string",
-            "title": "Capability",
-            "description": "Name of capability (profile, onedrive, etc)"
+            "title": "Connector Type"
           },
-          "status": {
-            "$ref": "#/components/schemas/CapabilityStatus"
+          "provider_label": {
+            "type": "string",
+            "title": "Provider Label"
           },
-          "message": {
+          "icon": {
             "anyOf": [
               {
                 "type": "string"
@@ -30199,9 +34434,85 @@
                 "type": "null"
               }
             ],
-            "title": "Message"
+            "title": "Icon"
           },
-          "sample_data": {
+          "already_subscribed": {
+            "type": "boolean",
+            "title": "Already Subscribed",
+            "default": false
+          },
+          "manifest": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Manifest"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector_type",
+          "provider_label",
+          "manifest"
+        ],
+        "title": "CatalogConnectorResponse",
+        "description": "A connector available to subscribe, sourced from the remote/file catalog.\n\n``manifest`` is the connector's self-describing ``ConnectorSpec.to_manifest()``;\nan admin subscribes it (adding the provider config) to install the connector.\n``already_subscribed`` flags types this deployment already has."
+      },
+      "CatalogOverlayApplyResponse": {
+        "properties": {
+          "shadow": {
+            "$ref": "#/components/schemas/TemplateShadow",
+            "description": "The overlay shadow that was applied to the catalog template"
+          },
+          "template_created": {
+            "type": "boolean",
+            "title": "Template Created",
+            "description": "True when no upstream template existed and one was created"
+          },
+          "running_deployments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Running Deployments",
+            "description": "Names of active deployments still on the pre-shadow build"
+          }
+        },
+        "type": "object",
+        "required": [
+          "shadow",
+          "template_created"
+        ],
+        "title": "CatalogOverlayApplyResponse",
+        "description": "Result of publishing an overlay entry."
+      },
+      "CatalogOverlayEntry": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "maxLength": 40,
+            "title": "Version",
+            "description": "Shadow version, e.g. 0.4.0-dev.feat-x.f9b70f6"
+          },
+          "compose_yml": {
+            "type": "string",
+            "title": "Compose Yml",
+            "description": "Transformed docker-compose YAML"
+          },
+          "env_defaults": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Env Defaults",
+            "description": "Default environment variables"
+          },
+          "env_metadata": {
             "anyOf": [
               {
                 "additionalProperties": true,
@@ -30211,28 +34522,305 @@
                 "type": "null"
               }
             ],
-            "title": "Sample Data",
-            "description": "Sample data showing what was accessed"
+            "title": "Env Metadata",
+            "description": "UI metadata for env vars"
+          },
+          "template_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TemplateType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Extension type: app, tool, or service"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name",
+            "description": "Human-readable name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Template description"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category",
+            "description": "Template category"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags",
+            "description": "Tags for search"
+          },
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Author",
+            "description": "Template author/organization"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License",
+            "description": "Software license"
+          },
+          "homepage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Homepage",
+            "description": "Homepage/repository URL"
+          },
+          "image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image",
+            "description": "Docker image reference"
+          },
+          "capabilities": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capabilities",
+            "description": "Capabilities provided by this template"
+          },
+          "required_env_vars": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Required Env Vars",
+            "description": "Required environment variables"
+          },
+          "kamiwaza_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kamiwaza Version",
+            "description": "Kamiwaza version constraint"
+          },
+          "strip_path_prefix": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strip Path Prefix",
+            "description": "Whether Traefik strips the path prefix"
+          },
+          "preferred_model_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Model Type",
+            "description": "Preferred model type"
+          },
+          "fail_if_model_type_unavailable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fail If Model Type Unavailable",
+            "description": "Fail deployment if preferred model type unavailable"
+          },
+          "preferred_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Model Name",
+            "description": "Specific model name to prefer"
+          },
+          "fail_if_model_name_unavailable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fail If Model Name Unavailable",
+            "description": "Fail deployment if preferred model name not found"
+          },
+          "shadow": {
+            "$ref": "#/components/schemas/CatalogOverlayShadowMeta",
+            "description": "Provenance of the dev build"
           }
         },
         "type": "object",
         "required": [
-          "capability",
-          "status"
+          "version",
+          "compose_yml"
         ],
-        "title": "CapabilityCheckResult",
-        "description": "Result of a single capability check."
+        "title": "CatalogOverlayEntry",
+        "description": "Overlay entry shadowing a catalog template with a local dev build.\n\nThe compose_yml is applied verbatim (no image relocation rewrite) — the\npublisher (kz-ext dev) already computed cluster-resolvable image refs."
       },
-      "CapabilityStatus": {
-        "type": "string",
-        "enum": [
-          "pending",
-          "success",
-          "failure",
-          "skipped"
+      "CatalogOverlayRemoveResponse": {
+        "properties": {
+          "template_name": {
+            "type": "string",
+            "title": "Template Name",
+            "description": "Name of the template the overlay was removed from"
+          },
+          "restored_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restored Version",
+            "description": "Upstream version restored, when a snapshot existed"
+          },
+          "template_removed": {
+            "type": "boolean",
+            "title": "Template Removed",
+            "description": "True when the template row was deleted (no upstream existed)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_name",
+          "template_removed"
         ],
-        "title": "CapabilityStatus",
-        "description": "Status values for capability checks."
+        "title": "CatalogOverlayRemoveResponse",
+        "description": "Result of removing an overlay entry."
+      },
+      "CatalogOverlayShadowMeta": {
+        "properties": {
+          "git_sha": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 40
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Sha",
+            "description": "Git commit SHA"
+          },
+          "git_branch": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 120
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Branch",
+            "description": "Git branch"
+          },
+          "dirty": {
+            "type": "boolean",
+            "title": "Dirty",
+            "description": "Built from a dirty working tree",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "CatalogOverlayShadowMeta",
+        "description": "Provenance of a local dev build published via the catalog overlay."
       },
       "CheckRequest": {
         "properties": {
@@ -30241,7 +34829,7 @@
           },
           "relation": {
             "type": "string",
-            "pattern": "^(can_access|cleared_for|connector_operator|editor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$",
+            "pattern": "^(can_access|cleared_for|connector_operator|editor|executor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$",
             "title": "Relation"
           },
           "object": {
@@ -30713,6 +35301,40 @@
         "title": "Cluster",
         "description": "Pydantic model representing a cluster in the system."
       },
+      "ClusterDiagnostics": {
+        "properties": {
+          "cluster_id": {
+            "type": "string",
+            "title": "Cluster Id"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnoseIssue"
+            },
+            "type": "array",
+            "title": "Issues",
+            "default": []
+          },
+          "has_issues": {
+            "type": "boolean",
+            "title": "Has Issues",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "cluster_id",
+          "timestamp"
+        ],
+        "title": "ClusterDiagnostics",
+        "description": "Aggregate result of a cluster diagnose run."
+      },
       "ClusterFederation": {
         "properties": {
           "id": {
@@ -30820,6 +35442,60 @@
             "format": "date-time",
             "title": "Updated At",
             "description": "Last update time"
+          },
+          "peer_kc_issuer_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Kc Issuer Url",
+            "description": "Peer Keycloak realm issuer URL (e.g. https://host/realms/kamiwaza)"
+          },
+          "peer_kc_jwks_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Kc Jwks Url",
+            "description": "Peer Keycloak JWKs URL for IdP signature verification"
+          },
+          "peer_broker_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Broker Client Id",
+            "description": "Peer-side client_id pre-provisioned at install for cross-realm brokering"
+          },
+          "peer_broker_client_secret_urn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Broker Client Secret Urn",
+            "description": "DataHub secret URN for peer broker client_secret (not the raw secret)"
+          },
+          "brokering_enabled": {
+            "type": "boolean",
+            "title": "Brokering Enabled",
+            "description": "Whether KC IdP brokering is active for this federation",
+            "default": true
           }
         },
         "type": "object",
@@ -31106,39 +35782,6 @@
         "title": "ConnectionStatusResponse",
         "description": "Response for connection status check."
       },
-      "ConnectionVerificationResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "checks": {
-            "items": {
-              "$ref": "#/components/schemas/CapabilityCheckResult"
-            },
-            "type": "array",
-            "title": "Checks"
-          },
-          "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Message"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "checks"
-        ],
-        "title": "ConnectionVerificationResponse",
-        "description": "Response for connection verification with capability checks."
-      },
       "ConnectorCapabilities": {
         "properties": {
           "browse_supported": {
@@ -31211,6 +35854,17 @@
           "provider_label": {
             "type": "string",
             "title": "Provider Label"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
           },
           "connector_type": {
             "type": "string",
@@ -31381,113 +36035,203 @@
         "title": "ConnectorContentHandle",
         "description": "Opaque handle Kaizen can use to fetch connector content via Core."
       },
-      "ConnectorCreate": {
+      "ConnectorDeploymentResponse": {
         "properties": {
-          "name": {
+          "deployment_id": {
             "type": "string",
-            "title": "Name"
+            "format": "uuid",
+            "title": "Deployment Id"
           },
-          "source_type": {
+          "workload_principal_id": {
             "type": "string",
-            "title": "Source Type"
-          },
-          "connector_type": {
-            "type": "string",
-            "title": "Connector Type"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Tags"
-          },
-          "allowed_roles": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Allowed Roles"
-          },
-          "require_encryption": {
-            "type": "boolean",
-            "title": "Require Encryption",
-            "default": true
-          },
-          "system_high": {
-            "type": "string",
-            "title": "System High",
-            "description": "System-high classification for this connector",
-            "default": "UNCLASSIFIED"
-          },
-          "default_security_marking": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Security Marking",
-            "description": "Default ICISM/CAPCO marking applied when documents lack explicit markings"
-          },
-          "connection_config": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Connection Config"
+            "title": "Workload Principal Id"
           }
         },
         "type": "object",
         "required": [
-          "name",
-          "source_type",
-          "connector_type",
-          "connection_config"
+          "deployment_id",
+          "workload_principal_id"
         ],
-        "title": "ConnectorCreate"
+        "title": "ConnectorDeploymentResponse",
+        "description": "Result of deploying a subscribed connector as a type:connector workload."
       },
-      "ConnectorListResponse": {
+      "ConnectorIdentityProxyRequest": {
         "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ConnectorResponse"
-            },
-            "type": "array",
-            "title": "Items"
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST"
+            ],
+            "title": "Method",
+            "description": "HTTP method",
+            "default": "GET"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "Absolute URL; its host must be in the connector's egress allowlist"
           },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
+          "params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Params",
+            "description": "Query parameters"
           },
-          "offset": {
-            "type": "integer",
-            "title": "Offset"
+          "body": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "description": "JSON body (POST)"
+          },
+          "response_format": {
+            "type": "string",
+            "const": "json",
+            "title": "Response Format",
+            "description": "JSON-only",
+            "default": "json"
+          },
+          "access_token": {
+            "type": "string",
+            "title": "Access Token",
+            "description": "Freshly-minted provider token; core attaches it as the bearer"
           }
         },
         "type": "object",
         "required": [
-          "items",
-          "total",
-          "limit",
-          "offset"
+          "url",
+          "access_token"
         ],
-        "title": "ConnectorListResponse"
+        "title": "ConnectorIdentityProxyRequest",
+        "description": "A connector's pre-connection identity fetch for core to execute.\n\nUsed only by the ``/v1/whoami`` OAuth-callback path. Unlike\n``ConnectorProxyRequest`` there is no connection or acting subject yet, so core\ncan't mint a scoped credential from storage -- the connector supplies the\nfreshly-minted provider ``access_token`` (which core just handed it) and core\nperforms the egress the connector pod cannot, enforcing the same workload\nbinding + egress allowlist. The token never leaves the deployment mesh and is\nkept out of logs/reprs."
+      },
+      "ConnectorMintRequest": {
+        "properties": {
+          "subject_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Token",
+            "description": "Acting user's bearer token; its verified `sub` is authoritative"
+          },
+          "subject_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Id",
+            "description": "Self-asserted subject; honored only under the env-gated PoC fallback"
+          },
+          "subject_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Type",
+            "description": "Audit hint only (e.g. user / group / npe); NOT a trust input"
+          },
+          "scope_subset": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope Subset",
+            "description": "Optional subset of the subject's granted scopes (defaults to all)"
+          },
+          "lease_duration": {
+            "type": "integer",
+            "maximum": 900,
+            "minimum": 60,
+            "title": "Lease Duration",
+            "description": "Broker lease TTL in seconds (1-15 min, default 5 min)",
+            "default": 300
+          }
+        },
+        "type": "object",
+        "title": "ConnectorMintRequest",
+        "description": "Request to mint a credential for a connector's acting subject."
+      },
+      "ConnectorMintResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token",
+            "description": "Provider access token (use directly against the provider API)"
+          },
+          "lease_id": {
+            "type": "string",
+            "title": "Lease Id",
+            "description": "Lease identifier for tracking / revocation"
+          },
+          "granted_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Granted Scopes",
+            "description": "Scopes the minted token is restricted to"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In",
+            "description": "Provider token expiry in seconds (refreshed in core)"
+          },
+          "broker_lease_expires_in": {
+            "type": "integer",
+            "title": "Broker Lease Expires In",
+            "description": "Broker lease expiry in seconds"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "description": "Token type",
+            "default": "Bearer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "lease_id",
+          "granted_scopes",
+          "expires_in",
+          "broker_lease_expires_in"
+        ],
+        "title": "ConnectorMintResponse",
+        "description": "Response carrying a short-lived provider access token."
       },
       "ConnectorNode": {
         "properties": {
@@ -31704,6 +36448,145 @@
         "title": "ConnectorNodesResponse",
         "description": "Normalized browse/search response."
       },
+      "ConnectorProxyRequest": {
+        "properties": {
+          "subject_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Token",
+            "description": "Acting user's bearer token; its verified `sub` is authoritative"
+          },
+          "subject_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Id",
+            "description": "Self-asserted subject; honored only under the env-gated PoC fallback"
+          },
+          "subject_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject Type",
+            "description": "Audit hint only (e.g. user / group / npe); NOT a trust input"
+          },
+          "scope_subset": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope Subset",
+            "description": "Optional subset of the subject's granted scopes (defaults to all)"
+          },
+          "lease_duration": {
+            "type": "integer",
+            "maximum": 900,
+            "minimum": 60,
+            "title": "Lease Duration",
+            "description": "Broker lease TTL in seconds (1-15 min, default 5 min)",
+            "default": 300
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST"
+            ],
+            "title": "Method",
+            "description": "HTTP method (v1: GET or POST)",
+            "default": "GET"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "Absolute URL; its host must be in the connector's egress allowlist"
+          },
+          "params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Params",
+            "description": "Query parameters"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "description": "JSON body (POST)"
+          },
+          "response_format": {
+            "type": "string",
+            "enum": [
+              "json",
+              "binary"
+            ],
+            "title": "Response Format",
+            "description": "How core returns the upstream body: parsed JSON (default), or base64-wrapped bytes for binary content such as file downloads",
+            "default": "json"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "ConnectorProxyRequest",
+        "description": "A connector's raw request for core to execute on its behalf.\n\n``Authorization`` is injected by core and never accepted from the caller."
+      },
+      "ConnectorProxyResponse": {
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "title": "Status Code",
+            "description": "Upstream HTTP status code"
+          },
+          "body": {
+            "title": "Body",
+            "description": "Parsed JSON response body (v1 is JSON-only)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status_code"
+        ],
+        "title": "ConnectorProxyResponse",
+        "description": "The upstream response, returned to the connector."
+      },
       "ConnectorReauthMetadata": {
         "properties": {
           "connector_settings_url": {
@@ -31744,156 +36627,45 @@
         "title": "ConnectorReauthMetadata",
         "description": "Deep-link targets for reauthentication or workroom setup."
       },
-      "ConnectorResponse": {
+      "ConnectorRegisterRequest": {
         "properties": {
-          "id": {
+          "endpoint": {
             "type": "string",
-            "format": "uuid",
-            "title": "Id"
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Endpoint"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config"
           },
-          "source_type": {
-            "type": "string",
-            "title": "Source Type"
-          },
-          "connector_type": {
-            "type": "string",
-            "title": "Connector Type"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "tags": {
+          "scopes": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Tags"
+            "title": "Scopes"
           },
-          "allowed_roles": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Allowed Roles"
-          },
-          "require_encryption": {
-            "type": "boolean",
-            "title": "Require Encryption"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
-          },
-          "system_high": {
-            "type": "string",
-            "title": "System High"
-          },
-          "default_security_marking": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Security Marking"
-          },
-          "last_ingestion_at": {
+          "workload_principal_id": {
             "anyOf": [
               {
                 "type": "string",
-                "format": "date-time"
+                "maxLength": 512
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Last Ingestion At"
-          },
-          "last_success_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Success At"
-          },
-          "error_count": {
-            "type": "integer",
-            "title": "Error Count"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "created_by": {
-            "type": "string",
-            "title": "Created By"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "updated_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated By"
+            "title": "Workload Principal Id"
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "name",
-          "source_type",
-          "connector_type",
-          "description",
-          "tags",
-          "allowed_roles",
-          "require_encryption",
-          "enabled",
-          "system_high",
-          "default_security_marking",
-          "last_ingestion_at",
-          "last_success_at",
-          "error_count",
-          "created_at",
-          "created_by",
-          "updated_at",
-          "updated_by"
+          "endpoint"
         ],
-        "title": "ConnectorResponse"
+        "title": "ConnectorRegisterRequest",
+        "description": "Self-registration: register a connector already running at an endpoint.\n\nCore fetches the connector's manifest from ``{endpoint}/manifest`` and\nsubscribes it. ``config`` is the provider secret config (stored encrypted).\n\n``workload_principal_id`` is the connector workload's own identity (its\n``azp``/OIDC client id). Routing and verify gate on a non-null principal, so a\nself-registered connector is reachable only once it is supplied; omit it to\nregister the connector without making it routable yet."
       },
       "ConnectorRoutingMetadata": {
         "properties": {
@@ -31973,6 +36745,57 @@
         "title": "ConnectorSourceRef",
         "description": "Provider-specific identifiers round-tripped through the generic contract."
       },
+      "ConnectorSubscriptionCreate": {
+        "properties": {
+          "manifest": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Manifest",
+            "description": "The connector's self-describing manifest (ConnectorSpec.to_manifest())."
+          },
+          "endpoint": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Endpoint",
+            "description": "HTTP/MCP endpoint where the connector is reached."
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config",
+            "description": "Provider-specific secret config (e.g. a service token), stored encrypted. Empty for connectors that need no stored credential."
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes",
+            "description": "Scopes this connector is granted. The mint enforces requested scope_subset ⊆ these; a service_token connector needs them to mint. May be empty for per-user OAuth connectors (scopes come per user)."
+          },
+          "workload_principal_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workload Principal Id",
+            "description": "Service-account principal permitted to mint per-user tokens for this connector. Bound at install; compared against the authenticated caller's principal at mint time. Null for connectors that never mint per-user tokens."
+          }
+        },
+        "type": "object",
+        "required": [
+          "manifest",
+          "endpoint"
+        ],
+        "title": "ConnectorSubscriptionCreate",
+        "description": "Subscribe a connector by its manifest + endpoint."
+      },
       "ConnectorSurfaceCapability": {
         "properties": {
           "surface": {
@@ -32038,127 +36861,66 @@
         "title": "ConnectorSurfaceCapability",
         "description": "Capability metadata for one logical browse surface."
       },
-      "ConnectorType": {
-        "type": "string",
-        "enum": [
-          "m365",
-          "google",
-          "confluence"
-        ],
-        "title": "ConnectorType",
-        "description": "Supported connector types."
-      },
-      "ConnectorUpdate": {
+      "ConnectorTypeListResponse": {
         "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tags"
-          },
-          "allowed_roles": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Allowed Roles"
-          },
-          "require_encryption": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Require Encryption"
-          },
-          "enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Enabled"
-          },
-          "connection_config": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Connection Config"
-          },
-          "system_high": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "System High"
-          },
-          "default_security_marking": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default Security Marking"
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorTypeResponse"
+            },
+            "type": "array",
+            "title": "Items"
           }
         },
         "type": "object",
-        "title": "ConnectorUpdate"
+        "required": [
+          "items"
+        ],
+        "title": "ConnectorTypeListResponse",
+        "description": "Registered connector types (with config schema) for the admin add form."
+      },
+      "ConnectorTypeResponse": {
+        "properties": {
+          "connector_type": {
+            "type": "string",
+            "title": "Connector Type"
+          },
+          "provider_id": {
+            "type": "string",
+            "title": "Provider Id"
+          },
+          "provider_label": {
+            "type": "string",
+            "title": "Provider Label"
+          },
+          "auth_model": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Auth Model"
+          },
+          "egress_allowlist": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Egress Allowlist",
+            "default": []
+          },
+          "config_schema": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config Schema"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connector_type",
+          "provider_id",
+          "provider_label",
+          "auth_model",
+          "config_schema"
+        ],
+        "title": "ConnectorTypeResponse",
+        "description": "A registered connector type's manifest (identity, auth model, config schema).\n\n``config_schema`` is the admin-form JSON Schema the UI renders to collect this\nconnector's configuration."
       },
       "ConsentAcceptResponse": {
         "properties": {
@@ -33132,7 +37894,7 @@
             },
             "type": "array",
             "title": "Remote Ips",
-            "description": "List of remote IPs with primary flag. Required for initiator, optional for receiver."
+            "description": "List of remote endpoints. Each entry: {'ip': <connect address>, 'primary': bool, 'hostname': <optional istio-routable FQDN>}. ENG-7427: when 'hostname' is set the platform connects to 'ip' but sends Host + TLS SNI = hostname (so the istio gateway routes by FQDN); without it, routing falls back to 'ip' (direct-IP deployments). Required for initiator, optional for receiver."
           },
           "preshared_key": {
             "type": "string",
@@ -33160,6 +37922,54 @@
             "title": "Role",
             "description": "Federation role: 'initiator' or 'receiver'. Receiver creates a WAITING record.",
             "default": "initiator"
+          },
+          "local_kc_issuer_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Kc Issuer Url",
+            "description": "Optional Keycloak realm issuer URL for THIS cluster's brokering identity (e.g. https://host/realms/kamiwaza). When set, overrides the cluster's own auth issuer (AUTH_GATEWAY_JWT_ISSUER) for this pair."
+          },
+          "local_kc_jwks_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Kc Jwks Url",
+            "description": "Optional Keycloak JWKS URL for THIS cluster's brokering identity. When set, overrides the issuer-derived brokering JWKS URL for this pair."
+          },
+          "local_broker_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Broker Client Id",
+            "description": "Optional Keycloak client ID THIS cluster uses for token-exchange brokering. When set, overrides KAMIWAZA_KC_BROKER_CLIENT_ID env at pair time."
+          },
+          "local_broker_client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Broker Client Secret",
+            "description": "DataHub secret URN (e.g. urn:li:dataHubSecret:...) for the Keycloak broker client secret. **URN-only at this API ingress** — raw secrets are refused so the operator's payload never lands in API request logs or the local override DB row in plaintext. Operators store the raw secret in DataHub first (via the secrets API) and supply the URN here. Wire-level disposition: at pair time the server resolves the URN via CatalogService and ships the raw secret to the peer's KC over the federation pair channel. That channel is HTTPS (`AUTH_GATEWAY_TLS_INSECURE` is an explicit dev escape hatch) and the body is PSK-HMAC-signed (cluster_trust.sign_federation_request) — same wire posture as the pre-existing env-driven path (KAMIWAZA_KC_BROKER_CLIENT_SECRET). The URN-only claim applies to API ingress + local override storage, not to the receiver's `peer_broker_client_secret_urn` DB row (which despite its name has always stored the raw value in the env-driven path — see column comment in models/cluster.py)."
           }
         },
         "type": "object",
@@ -33168,7 +37978,23 @@
           "preshared_key"
         ],
         "title": "CreateClusterFederation",
-        "description": "Pydantic model for creating a new cluster federation."
+        "description": "Pydantic model for creating a new cluster federation.",
+        "example": {
+          "callback_hostname": "edge.lyra.example.com",
+          "local_broker_client_id": "kamiwaza-broker",
+          "local_broker_client_secret": "urn:li:dataHubSecret:kamiwaza-broker-secret",
+          "local_kc_issuer_url": "https://lyra.example.com/realms/kamiwaza",
+          "local_kc_jwks_url": "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs",
+          "preshared_key": "00000000-0000-0000-0000-000000000000",
+          "remote_cluster_name": "ORION",
+          "remote_ips": [
+            {
+              "ip": "192.0.2.10",
+              "primary": true
+            }
+          ],
+          "role": "initiator"
+        }
       },
       "CreateCollection": {
         "properties": {
@@ -33234,10 +38060,11 @@
             "enum": [
               "app",
               "tool",
-              "service"
+              "service",
+              "connector"
             ],
             "title": "Type",
-            "description": "Extension type: 'app', 'tool', or 'service'"
+            "description": "Extension type: 'app', 'tool', 'service', or 'connector'"
           },
           "version": {
             "type": "string",
@@ -33981,26 +38808,28 @@
           "vram_allocation": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Vram Allocation",
-            "description": "Not user-settable (ignored); The VRAM allocation, in bytes of vram for each copy of the deployed model"
+            "description": "Optional explicit override of the VRAM allocation, in bytes of vram for each copy of the deployed model. When omitted, the platform computes it from the VRAM estimate. An explicit value is honored on both the profiled and estimate-unavailable paths; on the estimate-unavailable path it is honored only alongside an explicit gpu_allocation (gpu_allocation is what makes the deployment schedulable). Because it is byte-denominated, a value below 1 byte is ignored rather than truncated to 0."
           },
           "gpu_allocation": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Gpu Allocation",
-            "description": "Not user-settable (ignored); The GPU allocation, as a percentage of the the total VRAM available on the highest vram node, for ray serve allocation"
+            "description": "Optional explicit override of the GPU allocation, as a fraction of a node GPU for ray serve allocation. When omitted, the platform computes it from the VRAM estimate. An explicit value is honored even when the estimate is unavailable (e.g. an unprofiled model), so it can be used to deploy a model the platform cannot size automatically. A value of 0 means CPU."
           },
           "active_req_per_replica": {
             "type": "integer",
@@ -34043,6 +38872,28 @@
             ],
             "title": "Deployment Target",
             "description": "Target environment: 'auto' (default), 'host', 'docker', 'k8s'. Controls where inference runs."
+          },
+          "runtime_env": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Env",
+            "description": "ENG-4068: per-deployment runtime environment overrides. Highest precedence layer above admin overrides and the platform GPU cascade. Keys are env var names. Values are strings (set), or null (suppress a lower-layer key). Reserved keys (LD_LIBRARY_PATH, etc.) are adapter-owned and cannot be set from this layer; attempts log at WARN and are dropped."
           }
         },
         "type": "object",
@@ -34559,7 +39410,10 @@
           },
           "registration_type": {
             "type": "string",
-            "maxLength": 40,
+            "enum": [
+              "personal",
+              "service_account"
+            ],
             "title": "Registration Type",
             "default": "personal"
           },
@@ -35287,6 +40141,7 @@
           "vllm",
           "llamacpp",
           "mlx",
+          "diffusion",
           "ampere",
           "whispercpp",
           "app_garden",
@@ -35296,12 +40151,32 @@
         "title": "DeploymentType",
         "description": "Types of deployments that can have logs"
       },
-      "DeviceCodePollResponse": {
+      "DiagnoseIssue": {
         "properties": {
-          "status": {
-            "$ref": "#/components/schemas/DeviceCodeStatus"
+          "id": {
+            "type": "string",
+            "title": "Id"
           },
-          "external_email": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warning",
+              "info"
+            ],
+            "title": "Severity"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "detail": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Detail",
+            "default": {}
+          },
+          "fix_endpoint": {
             "anyOf": [
               {
                 "type": "string"
@@ -35310,88 +40185,35 @@
                 "type": "null"
               }
             ],
-            "title": "External Email"
+            "title": "Fix Endpoint"
           },
-          "expires_at": {
+          "fix_payload": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "additionalProperties": true,
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Fix Payload"
           },
-          "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Message"
+          "auto_fixable": {
+            "type": "boolean",
+            "title": "Auto Fixable",
+            "default": false
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
-          "status"
+          "id",
+          "severity",
+          "summary"
         ],
-        "title": "DeviceCodePollResponse",
-        "description": "Response when polling device code flow."
-      },
-      "DeviceCodeStartResponse": {
-        "properties": {
-          "flow_id": {
-            "type": "string",
-            "title": "Flow Id",
-            "description": "Unique ID for this flow"
-          },
-          "user_code": {
-            "type": "string",
-            "title": "User Code",
-            "description": "Code to enter at verification URL"
-          },
-          "verification_uri": {
-            "type": "string",
-            "title": "Verification Uri",
-            "description": "URL to visit for authentication"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message",
-            "description": "User-friendly message with instructions"
-          },
-          "expires_in": {
-            "type": "integer",
-            "title": "Expires In",
-            "description": "Seconds until code expires"
-          }
-        },
-        "type": "object",
-        "required": [
-          "flow_id",
-          "user_code",
-          "verification_uri",
-          "message",
-          "expires_in"
-        ],
-        "title": "DeviceCodeStartResponse",
-        "description": "Response when starting device code flow."
-      },
-      "DeviceCodeStatus": {
-        "type": "string",
-        "enum": [
-          "pending",
-          "connected",
-          "expired",
-          "error"
-        ],
-        "title": "DeviceCodeStatus",
-        "description": "Status values for device code polling."
+        "title": "DiagnoseIssue",
+        "description": "A single cluster-health issue surfaced by a diagnose probe.\n\nStable ``id`` matches the design's enumerated issue ids\n(``admin_missing_baseline_rebac``, ``missing_token_exchange_permission``,\netc.) so SDK callers can match programmatically.\n\n``fix_endpoint`` + ``fix_payload`` point at the operator-callable fix\nwhen ``auto_fixable=True``; ``None`` when manual remediation is\nrequired."
       },
       "DimensionMismatchDetail": {
         "properties": {
@@ -35461,6 +40283,64 @@
         "title": "DimensionMismatchDetail",
         "description": "Body of a 409 response when ``force=False`` and the embedding model\nwould change in a way that may invalidate stored vectors.\n\nDetection is by model identity (model name inequality), not actual\ndimension comparison — the live deployment surface does not expose\ndimensions without an embeddings probe round-trip. The\n``current_dimensions`` and ``requested_dimensions`` fields are\npopulated when known (typically from the existing binding row when it\nhas dimensions persisted) and are otherwise null. Treat the model-name\nfields as the authoritative diff signal in this milestone."
       },
+      "DiscoverGateRequest": {
+        "properties": {
+          "classpath": {
+            "type": "string",
+            "title": "Classpath"
+          }
+        },
+        "type": "object",
+        "required": [
+          "classpath"
+        ],
+        "title": "DiscoverGateRequest",
+        "description": "POST body — single classpath to reflect on."
+      },
+      "DiscoverGateResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "required_attributes": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Required Attributes"
+          },
+          "config_schema": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config Schema"
+          },
+          "classpath": {
+            "type": "string",
+            "title": "Classpath"
+          },
+          "location": {
+            "type": "string",
+            "title": "Location"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "kind",
+          "required_attributes",
+          "config_schema",
+          "classpath",
+          "location"
+        ],
+        "title": "DiscoverGateResponse",
+        "description": "Reflection payload returned by `discover_gate`.\n\n``kind`` is either ``\"execution\"`` or ``\"attribute\"`` (one of the two\nGate ABCs). ``config_schema`` is an additive contract — gates that\ndon't declare it surface as ``{}``."
+      },
       "DiscoveredModel": {
         "properties": {
           "id": {
@@ -35476,7 +40356,7 @@
               "azure_foundry"
             ],
             "title": "Protocol",
-            "description": "Chat-endpoint discriminator value the registration UI should pre-fill on the persisted config. Driven by the base URL's host shape: Azure OpenAI Service hosts → 'azure_openai', Azure AI Foundry hosts → 'azure_foundry', anything else → 'openai_compatible'."
+            "description": "Chat-endpoint discriminator value the registration UI should pre-fill on the persisted config. Driven by the base URL's host shape: Azure OpenAI Service hosts → 'azure_openai', Azure AI Foundry hosts → 'azure_foundry', anything else → 'openai_compatible' — except a non-Azure-shaped host the operator explicitly registers as Azure (discover 'provider=azure'), which resolves to 'azure_foundry'."
           },
           "api_version": {
             "anyOf": [
@@ -35821,76 +40701,6 @@
         ],
         "title": "DocumentRecord"
       },
-      "DriveItem": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "driveType": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Drivetype"
-          },
-          "webUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weburl"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "DriveItem",
-        "description": "Drive (document library) item."
-      },
-      "DrivesResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/DriveItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "DrivesResponse",
-        "description": "Response for listing drives."
-      },
       "EmbeddingModelBindingResponse": {
         "properties": {
           "group_id": {
@@ -36098,6 +40908,36 @@
         "title": "EnterWorkroomResponse",
         "description": "Response from entering a workroom (session binding)."
       },
+      "EntityTypeSchema": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "What this entity type represents; guides extraction"
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fields",
+            "description": "Optional extra attributes to extract, as {field_name: field_description}"
+          }
+        },
+        "type": "object",
+        "required": [
+          "description"
+        ],
+        "title": "EntityTypeSchema",
+        "description": "One custom entity type used to constrain Graphiti extraction.\n\nTransported as a plain JSON object because Pydantic model *classes* cannot\ncross HTTP; the Graphiti server reconstructs the actual model from this shape\n(``description`` guides the extraction prompt, each field becomes an optional\nattribute)."
+      },
       "EphemeralConfigResponse": {
         "properties": {
           "ephemeral_forced": {
@@ -36262,107 +41102,55 @@
         "title": "EvaluatedImportOptionsResponse",
         "description": "Import options plus Context validation for selected sources."
       },
-      "EventItem": {
+      "ExecutionGateBindingRequest": {
         "properties": {
-          "id": {
+          "type": {
             "type": "string",
-            "title": "Id"
+            "title": "Type"
           },
-          "subject": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subject"
-          },
-          "start": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Start"
-          },
-          "end": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "End"
-          },
-          "location": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Location"
-          },
-          "organizer": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Organizer"
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config",
+            "default": {}
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "id"
+          "type"
         ],
-        "title": "EventItem",
-        "description": "Calendar event item."
+        "title": "ExecutionGateBindingRequest",
+        "description": "PUT body for /api/cluster/execution-gate.\n\n``type`` is the gate classpath; ``config`` is the per-gate config dict\nthat the binding API validates against the gate's ``config_schema()``\nbefore persisting to runtime_config."
       },
-      "EventsResponse": {
+      "ExecutionGateBindingResponse": {
         "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/EventItem"
-            },
-            "type": "array",
-            "title": "Items"
+          "type": {
+            "type": "string",
+            "title": "Type"
           },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config"
+          },
+          "gate_name": {
+            "type": "string",
+            "title": "Gate Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
           }
         },
         "type": "object",
         "required": [
-          "items"
+          "type",
+          "config",
+          "gate_name",
+          "kind"
         ],
-        "title": "EventsResponse",
-        "description": "Response for listing calendar events."
+        "title": "ExecutionGateBindingResponse",
+        "description": "Response shape for PUT/GET on /api/cluster/execution-gate."
       },
       "ExportManifestItem": {
         "properties": {
@@ -36432,6 +41220,18 @@
             "type": "string",
             "title": "Name",
             "description": "Extension CR name"
+          },
+          "template_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Name",
+            "description": "Source template name (``spec.extensionRef.name``). Distinct from ``name`` because CR names get a deterministic suffix for workroom isolation. Clients join against this key to look up template-side data (e.g. the ``services_image`` map on the sync response)."
           },
           "type": {
             "type": "string",
@@ -36546,6 +41346,18 @@
             ],
             "title": "Internal",
             "description": "Cluster-internal service URL"
+          },
+          "runtime_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Path",
+            "description": "Backend-owned runtime route path primitive for browser access. Clients mount this onto their current public origin/prefix instead of reconstructing runtime paths from raw external URLs."
           }
         },
         "type": "object",
@@ -36580,7 +41392,7 @@
               }
             ],
             "title": "First Seen",
-            "description": "Timestamp when this event was first observed"
+            "description": "Timestamp when the event was first observed"
           },
           "last_seen": {
             "anyOf": [
@@ -36593,12 +41405,12 @@
               }
             ],
             "title": "Last Seen",
-            "description": "Timestamp when this event was most recently observed"
+            "description": "Timestamp when the event was most recently observed"
           },
           "count": {
             "type": "integer",
             "title": "Count",
-            "description": "Observed occurrence count for the event",
+            "description": "Number of times the event occurred",
             "default": 1
           }
         },
@@ -36823,6 +41635,30 @@
             ],
             "title": "Message",
             "description": "Human-readable status message"
+          },
+          "image_tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Tag",
+            "description": "Container image tag from CR spec (e.g. '2.3.1-dev')"
+          },
+          "image_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Digest",
+            "description": "Container image digest from CR spec when present (e.g. 'sha256:0fdf043b…')"
           }
         },
         "type": "object",
@@ -36842,7 +41678,7 @@
           "phase": {
             "type": "string",
             "title": "Phase",
-            "description": "Overall extension lifecycle phase"
+            "description": "Top-level deployment phase"
           },
           "url": {
             "anyOf": [
@@ -36854,7 +41690,7 @@
               }
             ],
             "title": "Url",
-            "description": "Primary access URL when the extension exposes one"
+            "description": "Primary public URL when the extension exposes one"
           },
           "services": {
             "items": {
@@ -36862,12 +41698,12 @@
             },
             "type": "array",
             "title": "Services",
-            "description": "Per-service rollout and health details"
+            "description": "Per-service deployment status details"
           },
           "rolling_update": {
             "type": "boolean",
             "title": "Rolling Update",
-            "description": "Whether the extension is currently rolling to a new revision",
+            "description": "Whether the extension is currently rolling out",
             "default": false
           },
           "events": {
@@ -36876,7 +41712,7 @@
             },
             "type": "array",
             "title": "Events",
-            "description": "Recent Kubernetes events relevant to the extension"
+            "description": "Recent Kubernetes events relevant to rollout"
           }
         },
         "type": "object",
@@ -36886,180 +41722,6 @@
         ],
         "title": "ExtensionStatus",
         "description": "Rich deployment status response."
-      },
-      "ExternalConnectorCreate": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name"
-          },
-          "connector_type": {
-            "$ref": "#/components/schemas/ConnectorType",
-            "description": "Type of connector"
-          },
-          "config": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Config",
-            "description": "Provider-specific configuration"
-          },
-          "scopes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "minItems": 1,
-            "title": "Scopes",
-            "description": "OAuth scopes"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled",
-            "default": true
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "connector_type",
-          "config",
-          "scopes"
-        ],
-        "title": "ExternalConnectorCreate",
-        "description": "Schema for creating a new connector."
-      },
-      "ExternalConnectorListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ExternalConnectorResponse"
-            },
-            "type": "array",
-            "title": "Items"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "ExternalConnectorListResponse",
-        "description": "Schema for listing connectors."
-      },
-      "ExternalConnectorResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "connector_type": {
-            "type": "string",
-            "title": "Connector Type"
-          },
-          "enabled": {
-            "type": "boolean",
-            "title": "Enabled"
-          },
-          "scopes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Scopes"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "connector_type",
-          "enabled",
-          "scopes",
-          "created_at"
-        ],
-        "title": "ExternalConnectorResponse",
-        "description": "Schema for connector response (excludes sensitive config)."
-      },
-      "ExternalConnectorUpdate": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "config": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Config"
-          },
-          "scopes": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array",
-                "minItems": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scopes"
-          },
-          "enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Enabled"
-          }
-        },
-        "type": "object",
-        "title": "ExternalConnectorUpdate",
-        "description": "Schema for updating a connector."
       },
       "ExternalEndpointDiscoverError": {
         "properties": {
@@ -37128,6 +41790,23 @@
             ],
             "title": "Credential Secret Urn",
             "description": "Reference to an already-stored Catalog secret. The route handler resolves this server-side (CatalogService.get_secret_value) and uses the resulting plaintext to probe the provider — the URN value never round-trips through the client."
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "azure",
+                  "openai",
+                  "other"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider",
+            "description": "Vendor the operator selected in the wizard. Lets discovery honor that choice for a host the URL-suffix map can't classify — e.g. an Azure inference proxy on a private/sovereign network is probed as Azure instead of falling back to the generic /v1/models path. Optional; when unset the strategy is derived from the URL alone."
           }
         },
         "type": "object",
@@ -37231,7 +41910,7 @@
             "minimum": 100,
             "title": "Omniparse Max Tokens",
             "description": "OmniParse max tokens per chunk (if omniparse_chunking=True)",
-            "default": 800
+            "default": 500
           },
           "omniparse_overlap": {
             "type": "integer",
@@ -37423,6 +42102,78 @@
             "type": "array",
             "title": "Local Ips",
             "description": "List of local IPs with primary flag"
+          },
+          "admin_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Admin User Id",
+            "description": "Admin user who initiated pairing (for ReBAC seeding on target)"
+          },
+          "local_ca_cert": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Ca Cert",
+            "description": "PEM-encoded root CA certificate for TLS verification of this cluster"
+          },
+          "peer_kc_issuer_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Kc Issuer Url",
+            "description": "Peer Keycloak realm issuer URL (e.g. https://host/realms/kamiwaza)"
+          },
+          "peer_kc_jwks_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Kc Jwks Url",
+            "description": "Peer Keycloak JWKs URL for IdP signature verification"
+          },
+          "peer_broker_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Broker Client Id",
+            "description": "Peer-side client_id pre-provisioned at install for cross-realm brokering"
+          },
+          "peer_broker_client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peer Broker Client Secret",
+            "description": "Peer-side client_secret matching peer_broker_client_id"
           }
         },
         "type": "object",
@@ -37481,7 +42232,7 @@
               }
             ],
             "title": "Source Urn",
-            "description": "Source URN (e.g., SharePoint item URN)"
+            "description": "Source URN (a stable provider-owned item URN)"
           },
           "metadata": {
             "additionalProperties": true,
@@ -37498,150 +42249,6 @@
         "title": "FileInput",
         "description": "Input file for pipeline processing."
       },
-      "FileItem": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size"
-          },
-          "mimeType": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mimetype"
-          },
-          "webUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weburl"
-          },
-          "createdDateTime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Createddatetime"
-          },
-          "lastModifiedDateTime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lastmodifieddatetime"
-          },
-          "createdBy": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Createdby"
-          },
-          "lastModifiedBy": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lastmodifiedby"
-          },
-          "parentReference": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Parentreference"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "type"
-        ],
-        "title": "FileItem",
-        "description": "File or folder item."
-      },
-      "FilesResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/FileItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "FilesResponse",
-        "description": "Response for listing files."
-      },
       "FreshnessStatus": {
         "type": "string",
         "enum": [
@@ -37651,6 +42258,180 @@
         ],
         "title": "FreshnessStatus",
         "description": "Post-import freshness comparison state."
+      },
+      "GatePackageInstallResult": {
+        "properties": {
+          "package": {
+            "$ref": "#/components/schemas/GatePackageState"
+          },
+          "install_duration_seconds": {
+            "type": "number",
+            "title": "Install Duration Seconds"
+          },
+          "audit_event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Event Id"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "package",
+          "install_duration_seconds"
+        ],
+        "title": "GatePackageInstallResult",
+        "description": "Response model for POST install. Carries the install duration and\naudit-event identifier alongside the new ``GatePackageState`` row."
+      },
+      "GatePackageList": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/GatePackageState"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page",
+            "default": 1
+          },
+          "per_page": {
+            "type": "integer",
+            "title": "Per Page",
+            "default": 20
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "title": "GatePackageList",
+        "description": "Response model for the list endpoint."
+      },
+      "GatePackageSpec": {
+        "properties": {
+          "package_spec": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Package Spec"
+          },
+          "hash_digest": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Hash Digest"
+          },
+          "index_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Url"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "package_spec",
+          "hash_digest"
+        ],
+        "title": "GatePackageSpec",
+        "description": "Request body for POST and PUT gate-package endpoints.\n\nPer FR-89 + FR-89a, ``hash_digest`` is REQUIRED at MVP. Server-side\nvalidation rejects requests without it via HTTP 400 + ``detail.reason\n= \"hash_required\"`` (the SDK surfaces this as\n``GatePackageHashRequiredError``)."
+      },
+      "GatePackageState": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "package_spec": {
+            "type": "string",
+            "title": "Package Spec"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "hash_digest": {
+            "type": "string",
+            "title": "Hash Digest"
+          },
+          "index_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index Url"
+          },
+          "installed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Installed At"
+          },
+          "installed_by": {
+            "type": "string",
+            "title": "Installed By"
+          },
+          "last_replaced_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Replaced At"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "uninstalling",
+              "failed"
+            ],
+            "title": "Status",
+            "default": "active"
+          },
+          "classpaths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Classpaths"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "name",
+          "package_spec",
+          "version",
+          "hash_digest",
+          "installed_at",
+          "installed_by"
+        ],
+        "title": "GatePackageState",
+        "description": "Response model — mirrors ``DBGatePackage`` row.\n\n``from_attributes=True`` lets the API handler call\n``GatePackageState.model_validate(db_row)`` on a SQLAlchemy row\ndirectly per the ``.ai/rules/python-standards.md`` Pydantic v2\nconvention."
       },
       "GetMemoryRequest": {
         "properties": {
@@ -37721,6 +42502,30 @@
           "client_secret"
         ],
         "title": "GoogleConfig"
+      },
+      "Grant": {
+        "properties": {
+          "object_namespace": {
+            "type": "string",
+            "title": "Object Namespace"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_namespace",
+          "object_id",
+          "relation"
+        ],
+        "title": "Grant",
+        "description": "One ReBAC relation tuple bound to a subject."
       },
       "GraphEdge": {
         "properties": {
@@ -37809,6 +42614,155 @@
         ],
         "title": "GraphNode",
         "description": "A single entity node in the bounded-subgraph response (T3.2).\n\nPer system design v0.1.6 §4.2.11. Embedding fields (``name_embedding``)\nare stripped at the substrate layer (RETURN n {.*, embedding: null})\nbefore this representation is constructed."
+      },
+      "GreymatterRouteBackendRequest": {
+        "properties": {
+          "service_name": {
+            "type": "string",
+            "title": "Service Name",
+            "description": "Kubernetes Service name"
+          },
+          "namespace": {
+            "type": "string",
+            "title": "Namespace",
+            "description": "Kubernetes namespace for the backend"
+          },
+          "port": {
+            "type": "integer",
+            "maximum": 65535,
+            "minimum": 1,
+            "title": "Port",
+            "description": "Backend service port"
+          },
+          "host": {
+            "type": "string",
+            "title": "Host",
+            "description": "Optional fully-qualified backend host",
+            "default": ""
+          },
+          "target_listener": {
+            "type": "string",
+            "title": "Target Listener",
+            "description": "Optional Greymatter listener/service key for this backend",
+            "default": ""
+          },
+          "raw": {
+            "type": "boolean",
+            "title": "Raw",
+            "description": "Whether the backend is a raw IP/host target rather than a service",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "service_name",
+          "namespace",
+          "port"
+        ],
+        "title": "GreymatterRouteBackendRequest",
+        "description": "Backend target for an internal Greymatter route intent."
+      },
+      "GreymatterRouteIntentRequest": {
+        "properties": {
+          "route_id": {
+            "type": "string",
+            "title": "Route Id",
+            "description": "Stable generated route id"
+          },
+          "owner_kind": {
+            "type": "string",
+            "title": "Owner Kind",
+            "description": "Source object kind, e.g. extension"
+          },
+          "owner_id": {
+            "type": "string",
+            "title": "Owner Id",
+            "description": "Source object id"
+          },
+          "public_path": {
+            "type": "string",
+            "title": "Public Path",
+            "description": "External path prefix"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/GreymatterRouteBackendRequest",
+            "description": "Backend service target that Greymatter should route to"
+          },
+          "rewrite_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rewrite Path",
+            "description": "Optional upstream rewrite path"
+          },
+          "auth_mode": {
+            "$ref": "#/components/schemas/RouteAuthMode",
+            "description": "Whether the route is protected by gateway auth",
+            "default": "protected"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Headers",
+            "description": "Request headers injected by the gateway route"
+          }
+        },
+        "type": "object",
+        "required": [
+          "route_id",
+          "owner_kind",
+          "owner_id",
+          "public_path",
+          "backend"
+        ],
+        "title": "GreymatterRouteIntentRequest",
+        "description": "Internal desired route state submitted by platform controllers."
+      },
+      "GreymatterRouteStatusResponse": {
+        "properties": {
+          "route_id": {
+            "type": "string",
+            "title": "Route Id",
+            "description": "Stable generated route id"
+          },
+          "state": {
+            "type": "string",
+            "title": "State",
+            "description": "Route writer result state"
+          },
+          "commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commit Sha",
+            "description": "Git commit SHA produced by the route writer, when available"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "Optional detail explaining the route writer result",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "route_id",
+          "state"
+        ],
+        "title": "GreymatterRouteStatusResponse",
+        "description": "Observed state returned after writing a Greymatter route intent."
       },
       "GrpcHandshake": {
         "properties": {
@@ -38078,7 +43032,7 @@
               }
             ],
             "title": "Registry",
-            "description": "Optional container registry override for the patched image"
+            "description": "Container registry hostname override"
           },
           "repository": {
             "anyOf": [
@@ -38090,7 +43044,7 @@
               }
             ],
             "title": "Repository",
-            "description": "Optional container repository override for the patched image"
+            "description": "Repository override without the tag component"
           },
           "digest": {
             "anyOf": [
@@ -38534,6 +43488,26 @@
         "title": "InlineData",
         "description": "Inline payload returned when dataset fits in HTTP response."
       },
+      "JobLogs": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          },
+          "logs": {
+            "type": "string",
+            "title": "Logs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "logs"
+        ],
+        "title": "JobLogs",
+        "description": "Ray job stdout/stderr logs."
+      },
       "JobProgress": {
         "properties": {
           "bytes_processed": {
@@ -38573,6 +43547,408 @@
         "type": "object",
         "title": "JobProgress",
         "description": "Progress metrics for a retrieval job."
+      },
+      "JobRecord": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "ray_job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ray Job Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatus"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "source_cluster_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Cluster Id"
+          },
+          "source_cluster_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Cluster Name"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "entrypoint": {
+            "type": "string",
+            "title": "Entrypoint"
+          },
+          "runtime_env": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Env"
+          },
+          "metadata_": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout Seconds"
+          },
+          "timed_out": {
+            "type": "boolean",
+            "title": "Timed Out",
+            "default": false
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "submitted_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Submitted At"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "ended_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ended At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "source",
+          "user_id",
+          "entrypoint",
+          "submitted_at",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "JobRecord",
+        "description": "Persisted job record returned by status/list endpoints."
+      },
+      "JobRunRequest": {
+        "properties": {
+          "entrypoint": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entrypoint",
+            "description": "Shell command to execute (e.g. 'python script.py')"
+          },
+          "runtime_env": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Env",
+            "description": "Ray runtime_env dict. Only the env_vars key is honored; execution-environment keys (pip, working_dir, py_modules, conda) are stripped server-side as a supply-chain safeguard (ENG-3782)."
+          },
+          "timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 86400,
+                "exclusiveMinimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout Seconds",
+            "description": "Max seconds before auto-cancel (1–86400)."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Arbitrary key-value metadata attached to the job record."
+          }
+        },
+        "type": "object",
+        "required": [
+          "entrypoint"
+        ],
+        "title": "JobRunRequest",
+        "description": "Request to submit and synchronously wait for a Ray job result.\n\nInherits all fields from JobSubmitRequest. The caller blocks until\nthe job completes, fails, or times out."
+      },
+      "JobRunResult": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          },
+          "ray_job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ray Job Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatus"
+          },
+          "result": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "timed_out": {
+            "type": "boolean",
+            "title": "Timed Out",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "title": "JobRunResult",
+        "description": "Response returned by the synchronous /run endpoint."
+      },
+      "JobStatus": {
+        "type": "string",
+        "enum": [
+          "PENDING",
+          "RUNNING",
+          "SUCCEEDED",
+          "FAILED",
+          "STOPPED"
+        ],
+        "title": "JobStatus",
+        "description": "Status values for a federated job."
+      },
+      "JobSubmitRequest": {
+        "properties": {
+          "entrypoint": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entrypoint",
+            "description": "Shell command to execute (e.g. 'python script.py')"
+          },
+          "runtime_env": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Env",
+            "description": "Ray runtime_env dict. Only the env_vars key is honored; execution-environment keys (pip, working_dir, py_modules, conda) are stripped server-side as a supply-chain safeguard (ENG-3782)."
+          },
+          "timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 86400,
+                "exclusiveMinimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout Seconds",
+            "description": "Max seconds before auto-cancel (1–86400)."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Arbitrary key-value metadata attached to the job record."
+          }
+        },
+        "type": "object",
+        "required": [
+          "entrypoint"
+        ],
+        "title": "JobSubmitRequest",
+        "description": "Request to submit a Ray job asynchronously."
+      },
+      "JobSubmitResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Job Id"
+          },
+          "ray_job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ray Job Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatus"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "title": "JobSubmitResponse",
+        "description": "Response returned after async job submission."
       },
       "KamiwazaIntegrationSpec": {
         "properties": {
@@ -38734,6 +44110,26 @@
         "title": "LeaseStatusResponse",
         "description": "Status of a token lease."
       },
+      "LeaveWorkroomRequest": {
+        "properties": {
+          "expected_workroom_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Workroom Id",
+            "description": "If provided, the leave only succeeds when the caller is still bound to this workroom."
+          }
+        },
+        "type": "object",
+        "title": "LeaveWorkroomRequest",
+        "description": "Optional scoped contract for leaving the currently bound workroom."
+      },
       "LeaveWorkroomResponse": {
         "properties": {
           "workroom_id": {
@@ -38751,7 +44147,7 @@
               }
             ],
             "title": "Access Token",
-            "description": "Re-minted JWT scoped to Global (Lite/SAML mode only)"
+            "description": "Re-minted JWT scoped to no-workroom access (Lite/SAML mode only)"
           },
           "expires_in": {
             "anyOf": [
@@ -38768,7 +44164,7 @@
           "message": {
             "type": "string",
             "title": "Message",
-            "default": "Returned to Global Workroom"
+            "default": "Returned to no-workroom scope"
           }
         },
         "type": "object",
@@ -38776,7 +44172,7 @@
           "workroom_id"
         ],
         "title": "LeaveWorkroomResponse",
-        "description": "Response from leaving a workroom (return to Global)."
+        "description": "Response from leaving a workroom (return to no-workroom scope)."
       },
       "LocalUserCreateRequest": {
         "properties": {
@@ -39493,195 +44889,6 @@
         ],
         "title": "MCPEmitRequest",
         "description": "Request model for emitting a single MCP."
-      },
-      "MailDetailResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "subject": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subject"
-          },
-          "from": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "From"
-          },
-          "toRecipients": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Torecipients"
-          },
-          "body": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Body"
-          },
-          "receivedDateTime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiveddatetime"
-          },
-          "attachments": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Attachments"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "title": "MailDetailResponse",
-        "description": "Detailed mail message."
-      },
-      "MailItem": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "subject": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subject"
-          },
-          "from": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "From"
-          },
-          "receivedDateTime": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Receiveddatetime"
-          },
-          "hasAttachments": {
-            "type": "boolean",
-            "title": "Hasattachments",
-            "default": false
-          },
-          "isRead": {
-            "type": "boolean",
-            "title": "Isread",
-            "default": false
-          },
-          "bodyPreview": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bodypreview"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "title": "MailItem",
-        "description": "Mail message item."
-      },
-      "MailResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/MailItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "MailResponse",
-        "description": "Response for listing mail."
       },
       "MemoryResult": {
         "properties": {
@@ -40758,6 +45965,43 @@
             ],
             "title": "Download Cancelled At",
             "description": "The timestamp when the download was cancelled."
+          },
+          "storage_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Digest",
+            "description": "OCI content digest (sha256) recorded at push time for content trust verification."
+          },
+          "last_push_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Push Error",
+            "description": "ENG-4385: last error from a per-file OCI push attempt. When set, the file failed to OCI-push and storage_type fell back to file/SCRATCH. Cleared on successful push."
+          },
+          "last_push_error_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Push Error At",
+            "description": "ENG-4385: timestamp of the last_push_error."
           }
         },
         "type": "object",
@@ -41973,7 +47217,7 @@
         },
         "type": "object",
         "title": "NodeListNode",
-        "description": "Node schema for a ray node in the cluster\n\n    "
+        "description": "Node schema for a ray node in the cluster"
       },
       "NodeStatus": {
         "properties": {
@@ -42226,6 +47470,18 @@
         "title": "OntologyBackend",
         "description": "Supported Knowledge Graph backends."
       },
+      "OntologyIngestionStatus": {
+        "type": "string",
+        "enum": [
+          "none",
+          "queued",
+          "running",
+          "failed",
+          "done"
+        ],
+        "title": "OntologyIngestionStatus",
+        "description": "Knowledge-graph ingestion status for an ontology instance.\n\nDistinct from :class:`OntologyStatus`, which describes the backend\nruntime/lifecycle state. An instance can be ``running`` at the backend\nlevel while never having had any knowledge ingested. This status makes\nthat distinction explicit so consumers render a true state instead of\ninferring ingestion progress from graph node counts (the source of the\nphantom \"Ingestion in progress\" empty state)."
+      },
       "OntologyInstance": {
         "properties": {
           "id": {
@@ -42267,6 +47523,36 @@
             ],
             "title": "Status Details",
             "description": "Structured runtime diagnostics for a non-running status"
+          },
+          "ingestion_status": {
+            "$ref": "#/components/schemas/OntologyIngestionStatus",
+            "description": "Explicit knowledge-graph ingestion status, independent of the backend runtime ``status``. ``none`` means no knowledge has ever been ingested into this instance (e.g. one auto-provisioned at workroom creation), so consumers can show an actionable empty state instead of inferring a phantom 'in progress' from an empty-but-running backend.",
+            "default": "none"
+          },
+          "ingestion_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingestion Error",
+            "description": "Error message for the most recent failed ingestion, if any."
+          },
+          "ingestion_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingestion Updated At",
+            "description": "UTC timestamp of the last ingestion-status change, if any."
           },
           "endpoint": {
             "anyOf": [
@@ -42708,7 +47994,7 @@
             "type": "array",
             "minItems": 1,
             "title": "Services",
-            "description": "Service-level patch operations to apply to the extension"
+            "description": "One or more service patches to apply"
           },
           "annotations": {
             "anyOf": [
@@ -42749,7 +48035,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional image patch to apply to this service"
+            "description": "Optional image override for the service"
           },
           "env": {
             "anyOf": [
@@ -42765,7 +48051,7 @@
               }
             ],
             "title": "Env",
-            "description": "Optional environment variable patch list for this service"
+            "description": "Optional list of environment variable patch objects"
           },
           "replicas": {
             "anyOf": [
@@ -42778,7 +48064,7 @@
               }
             ],
             "title": "Replicas",
-            "description": "Optional replica count override for this service"
+            "description": "Desired replica count override for the service"
           }
         },
         "type": "object",
@@ -42799,10 +48085,16 @@
             "description": "Chunking configuration"
           },
           "embedding_model": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Embedding Model",
-            "description": "Embedding model to use",
-            "default": "all-MiniLM-L6-v2"
+            "description": "Optional embedding model alias to use for this import. When omitted, the platform resolves the default configured embedding deployment."
           },
           "collection_name": {
             "anyOf": [
@@ -42832,10 +48124,16 @@
             "description": "Chunking configuration"
           },
           "embedding_model": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Embedding Model",
-            "description": "Embedding model to use",
-            "default": "all-MiniLM-L6-v2"
+            "description": "Optional embedding model alias to use for this import. When omitted, the platform resolves the default configured embedding deployment."
           },
           "collection_name": {
             "anyOf": [
@@ -42962,12 +48260,14 @@
           "source_provider": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SourceProvider"
+                "type": "string",
+                "minLength": 1
               },
               {
                 "type": "null"
               }
             ],
+            "title": "Source Provider",
             "description": "Provider recorded for replayable source imports."
           },
           "connector_id": {
@@ -43522,7 +48822,7 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "Kubernetes pod name"
+            "description": "Kubernetes pod name for this service instance"
           },
           "phase": {
             "type": "string",
@@ -43532,12 +48832,12 @@
           "ready": {
             "type": "boolean",
             "title": "Ready",
-            "description": "Whether the pod is reporting ready"
+            "description": "Whether the pod reports Ready"
           },
           "restart_count": {
             "type": "integer",
             "title": "Restart Count",
-            "description": "Total container restarts observed",
+            "description": "Total container restart count observed for the pod",
             "default": 0
           },
           "started_at": {
@@ -43595,53 +48895,6 @@
         ],
         "title": "PortMapping",
         "description": "Port-mapping specification for app deployment requests."
-      },
-      "ProfileResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "displayName": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Displayname"
-          },
-          "mail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mail"
-          },
-          "userPrincipalName": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Userprincipalname"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "title": "ProfileResponse",
-        "description": "User profile from Microsoft Graph."
       },
       "PromptElement": {
         "properties": {
@@ -44448,7 +49701,7 @@
           },
           "relation": {
             "type": "string",
-            "pattern": "^(can_access|cleared_for|connector_operator|editor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$",
+            "pattern": "^(can_access|cleared_for|connector_operator|editor|executor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$",
             "title": "Relation"
           },
           "object": {
@@ -44484,7 +49737,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "^(can_access|cleared_for|connector_operator|editor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$"
+                "pattern": "^(can_access|cleared_for|connector_operator|editor|executor|includes|member|mission|mission_member|mission_owner|operator|owner|viewer)$"
               },
               {
                 "type": "null"
@@ -44518,8 +49771,10 @@
       "RemoteSourceRef": {
         "properties": {
           "provider": {
-            "$ref": "#/components/schemas/SourceProvider",
-            "description": "Canonical remote provider identifier."
+            "type": "string",
+            "minLength": 1,
+            "title": "Provider",
+            "description": "Canonical remote provider identifier (connector provider_id)."
           },
           "kind": {
             "anyOf": [
@@ -44531,7 +49786,7 @@
               }
             ],
             "title": "Kind",
-            "description": "Legacy alias for provider retained for M365 compatibility."
+            "description": "Legacy alias for provider retained for backward compatibility."
           },
           "connector_id": {
             "type": "string",
@@ -44556,7 +49811,7 @@
               }
             ],
             "title": "Item Id",
-            "description": "Legacy M365 alias for source_ref."
+            "description": "Legacy alias for source_ref."
           },
           "source_type": {
             "type": "string",
@@ -44586,7 +49841,7 @@
               }
             ],
             "title": "Drive Id",
-            "description": "Legacy M365 drive identifier mirrored from provider_metadata for compatibility."
+            "description": "Legacy drive identifier mirrored from provider_metadata.drive_id for backward compatibility."
           },
           "url": {
             "anyOf": [
@@ -45023,6 +50278,19 @@
             "title": "Query",
             "description": "User query for RAG"
           },
+          "collection_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection Name",
+            "description": "Single collection to search, parity with /search. Honored only when collection_names is not provided. An explicit collection is searched directly, which is required to reach worker-written raw collections that the managed enumeration does not surface."
+          },
           "collection_names": {
             "anyOf": [
               {
@@ -45047,12 +50315,18 @@
             "default": 5
           },
           "score_threshold": {
-            "type": "number",
-            "maximum": 1,
-            "minimum": 0,
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Score Threshold",
-            "description": "Minimum relevance score",
-            "default": 0.7
+            "description": "Minimum relevance score; None applies no floor (parity with /search)."
           },
           "max_context_length": {
             "type": "integer",
@@ -45179,6 +50453,15 @@
         ],
         "title": "RolloutOutcomeOut",
         "description": "Wire shape for :class:`RolloutOutcome` from the K8s patch adapter."
+      },
+      "RouteAuthMode": {
+        "type": "string",
+        "enum": [
+          "protected",
+          "bypass"
+        ],
+        "title": "RouteAuthMode",
+        "description": "Auth behavior requested for a generated edge route."
       },
       "RoutingConfigResponse": {
         "properties": {
@@ -45811,6 +51094,17 @@
             ],
             "title": "Vectordb Id",
             "description": "Optional VectorDB instance to target explicitly"
+          },
+          "search_mode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "semantic",
+              "exact"
+            ],
+            "title": "Search Mode",
+            "description": "Search interpretation: auto detects exact marker/quoted queries, semantic preserves pure vector search, exact filters returned candidates to chunks containing the literal query needle.",
+            "default": "auto"
           }
         },
         "type": "object",
@@ -45819,34 +51113,6 @@
         ],
         "title": "SearchRequest",
         "description": "Request for semantic search."
-      },
-      "SearchResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/FileItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "SearchResponse",
-        "description": "Response for file search."
       },
       "SearchResult": {
         "properties": {
@@ -45869,6 +51135,84 @@
           "metadata": {
             "$ref": "#/components/schemas/ChunkMetadata",
             "description": "Chunk metadata"
+          },
+          "source_type": {
+            "type": "string",
+            "title": "Source Type",
+            "description": "Result provenance: 'document' for indexed chunks or 'knowledge_graph' for ontology facts. Lets graph enrichment stay distinguishable from document chunks after normalization.",
+            "default": "document"
+          },
+          "from_graph": {
+            "type": "boolean",
+            "title": "From Graph",
+            "description": "True when the hit originated from the knowledge graph, even if it carries document provenance and is therefore displayed as source_type='document'. Lets graph enrichment be counted consistently with the per-iteration graph counts.",
+            "default": false
+          },
+          "match_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Type",
+            "description": "Exact-search match type: exact or semantic_neighbor"
+          },
+          "contains_exact_query": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contains Exact Query",
+            "description": "Whether this chunk contains an exact search needle verbatim"
+          },
+          "contains_normalized_query": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contains Normalized Query",
+            "description": "Whether this chunk contains a normalized non-verbatim needle"
+          },
+          "matched_needles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Matched Needles",
+            "description": "Exact query needles found verbatim in this chunk"
+          },
+          "matched_span": {
+            "anyOf": [
+              {
+                "prefixItems": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ],
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Span",
+            "description": "First verbatim match span in chunk content"
           }
         },
         "type": "object",
@@ -45926,6 +51270,45 @@
             "type": "array",
             "title": "Partial Failures",
             "description": "Collections that failed to search, with error details"
+          },
+          "search_mode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "semantic",
+              "exact"
+            ],
+            "title": "Search Mode",
+            "description": "Search mode requested by the caller",
+            "default": "auto"
+          },
+          "is_exact_query": {
+            "type": "boolean",
+            "title": "Is Exact Query",
+            "description": "True when exact-match filtering was applied",
+            "default": false
+          },
+          "exact_match_count": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Exact Match Count",
+            "description": "Number of candidate chunks containing an exact needle",
+            "default": 0
+          },
+          "semantic_neighbor_count": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Semantic Neighbor Count",
+            "description": "Number of candidate chunks that were related but non-exact",
+            "default": 0
+          },
+          "semantic_neighbors": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array",
+            "title": "Semantic Neighbors",
+            "description": "Non-exact candidates retained only for diagnostics"
           }
         },
         "type": "object",
@@ -46189,55 +51572,6 @@
         "title": "SecuritySpec",
         "description": "Security classification and pod security settings."
       },
-      "SelectedGranularity": {
-        "properties": {
-          "mode": {
-            "$ref": "#/components/schemas/SelectedGranularityMode",
-            "description": "Provider-neutral selection mode.",
-            "default": "item"
-          },
-          "option": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option",
-            "description": "UI-selected granularity option preserved for handoff/debugging."
-          },
-          "recursive": {
-            "type": "boolean",
-            "title": "Recursive",
-            "description": "Whether child items should be included recursively.",
-            "default": false
-          },
-          "include_children": {
-            "type": "boolean",
-            "title": "Include Children",
-            "description": "Whether direct child items should be included.",
-            "default": false
-          },
-          "query": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Query",
-            "description": "Optional saved query or search text for query selections."
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "SelectedGranularity",
-        "description": "How a source was selected for staging/import."
-      },
       "SelectedGranularity-Output": {
         "properties": {
           "mode": {
@@ -46287,16 +51621,6 @@
         "title": "SelectedGranularity",
         "description": "How a source was selected for staging/import."
       },
-      "SelectedGranularityMode": {
-        "type": "string",
-        "enum": [
-          "item",
-          "container",
-          "query"
-        ],
-        "title": "SelectedGranularityMode",
-        "description": "Selection modes supported by provider-neutral source staging."
-      },
       "SelectedGranularityMode-Output": {
         "type": "string",
         "enum": [
@@ -46312,12 +51636,12 @@
           "name": {
             "type": "string",
             "title": "Name",
-            "description": "Service name within the extension"
+            "description": "Service name"
           },
           "image_tag": {
             "type": "string",
             "title": "Image Tag",
-            "description": "Resolved image tag currently deployed (empty string when the CR specifies only a digest with no tag)."
+            "description": "Resolved container image tag currently deployed (empty string when the CR specifies only a digest with no tag)."
           },
           "image_digest": {
             "type": "string",
@@ -46328,19 +51652,19 @@
           "ready_replicas": {
             "type": "integer",
             "title": "Ready Replicas",
-            "description": "Number of ready replicas",
+            "description": "Number of ready replicas for the service",
             "default": 0
           },
           "replicas": {
             "type": "integer",
             "title": "Replicas",
-            "description": "Desired or observed replica count",
+            "description": "Desired replica count",
             "default": 0
           },
           "restart_count": {
             "type": "integer",
             "title": "Restart Count",
-            "description": "Aggregate restart count across pods for this service",
+            "description": "Aggregated restart count across service pods",
             "default": 0
           },
           "pods": {
@@ -46349,7 +51673,7 @@
             },
             "type": "array",
             "title": "Pods",
-            "description": "Pod-level details for the service"
+            "description": "Per-pod status details for the service"
           }
         },
         "type": "object",
@@ -46466,76 +51790,6 @@
         ],
         "title": "SetEmbeddingModelRequest",
         "description": "Body for ``PUT /api/v1/context/embedding-model``."
-      },
-      "SiteItem": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "displayName": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Displayname"
-          },
-          "webUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Weburl"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "SiteItem",
-        "description": "SharePoint site item."
-      },
-      "SitesResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/SiteItem"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "next_page_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Page Token"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items"
-        ],
-        "title": "SitesResponse",
-        "description": "Response for listing SharePoint sites."
       },
       "SkillLibraryDetailResponse": {
         "properties": {
@@ -46799,7 +52053,9 @@
       "SourceDescriptor-Input": {
         "properties": {
           "provider": {
-            "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__source_contracts__SourceProvider",
+            "type": "string",
+            "minLength": 1,
+            "title": "Provider",
             "description": "Canonical provider identifier."
           },
           "connector_id": {
@@ -46825,7 +52081,7 @@
             "description": "Provider-neutral source type."
           },
           "selected_granularity": {
-            "$ref": "#/components/schemas/SelectedGranularity",
+            "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__source_contracts__SelectedGranularity-Input",
             "description": "Granularity chosen when the item was staged."
           },
           "last_modified": {
@@ -46863,7 +52119,9 @@
       "SourceDescriptor-Output": {
         "properties": {
           "provider": {
-            "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__source_contracts__SourceProvider",
+            "type": "string",
+            "minLength": 1,
+            "title": "Provider",
             "description": "Canonical provider identifier."
           },
           "connector_id": {
@@ -46923,15 +52181,6 @@
         ],
         "title": "SourceDescriptor",
         "description": "Canonical staged source descriptor for remote source import."
-      },
-      "SourceProvider": {
-        "type": "string",
-        "enum": [
-          "m365",
-          "google_drive"
-        ],
-        "title": "SourceProvider",
-        "description": "Provider identifiers accepted by Context's provider-neutral import contract."
       },
       "SourceRef": {
         "properties": {
@@ -47061,9 +52310,55 @@
           "s3",
           "gcs",
           "azureblob",
-          "scratch"
+          "scratch",
+          "oci"
         ],
         "title": "StorageType"
+      },
+      "Subject": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          },
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/Grant"
+            },
+            "type": "array",
+            "title": "Grants"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "username",
+          "attributes",
+          "grants",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "Subject",
+        "description": "Full Subject response — KC identifiers, attributes, grants, timestamps."
       },
       "SubjectModel": {
         "properties": {
@@ -47088,6 +52383,139 @@
           "id"
         ],
         "title": "SubjectModel"
+      },
+      "SubjectUpsertRequest": {
+        "properties": {
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attributes"
+        ],
+        "title": "SubjectUpsertRequest",
+        "description": "PUT body for ``/api/authz/subjects/{id_or_username}`` (v0.3.5 OQ-11).\n\nIdempotent upsert: caller supplies the subject identifier in the URL,\nthe body specifies ``attributes`` and an optional initial ``password``\nfor create-time bootstrap."
+      },
+      "TemplateShadow": {
+        "properties": {
+          "template_name": {
+            "type": "string",
+            "title": "Template Name",
+            "description": "Name of the shadowed template"
+          },
+          "shadow_version": {
+            "type": "string",
+            "title": "Shadow Version",
+            "description": "Version of the dev build holding the template row"
+          },
+          "git_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Sha",
+            "description": "Git commit SHA of the dev build"
+          },
+          "git_branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Branch",
+            "description": "Git branch of the dev build"
+          },
+          "dirty": {
+            "type": "boolean",
+            "title": "Dirty",
+            "description": "Built from a dirty working tree",
+            "default": false
+          },
+          "shadows_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shadows Version",
+            "description": "Upstream catalog version being shadowed"
+          },
+          "shadows_stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shadows Stage",
+            "description": "Catalog stage of the shadowed upstream entry"
+          },
+          "upstream_exists": {
+            "type": "boolean",
+            "title": "Upstream Exists",
+            "description": "False when the template only exists because of the shadow"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "When the shadow was first applied"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "When the shadow was last refreshed (staleness source)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_name",
+          "shadow_version",
+          "upstream_exists"
+        ],
+        "title": "TemplateShadow",
+        "description": "Active overlay shadow as reported by the catalog overlay API."
       },
       "TemplateSource": {
         "type": "string",
@@ -48231,26 +53659,28 @@
           "vram_allocation": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Vram Allocation",
-            "description": "Not user-settable (ignored); The VRAM allocation, in bytes of vram for each copy of the deployed model"
+            "description": "Optional explicit override of the VRAM allocation, in bytes of vram for each copy of the deployed model. When omitted, the platform computes it from the VRAM estimate. An explicit value is honored on both the profiled and estimate-unavailable paths; on the estimate-unavailable path it is honored only alongside an explicit gpu_allocation (gpu_allocation is what makes the deployment schedulable). Because it is byte-denominated, a value below 1 byte is ignored rather than truncated to 0."
           },
           "gpu_allocation": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Gpu Allocation",
-            "description": "Not user-settable (ignored); The GPU allocation, as a percentage of the the total VRAM available on the highest vram node, for ray serve allocation"
+            "description": "Optional explicit override of the GPU allocation, as a fraction of a node GPU for ray serve allocation. When omitted, the platform computes it from the VRAM estimate. An explicit value is honored even when the estimate is unavailable (e.g. an unprofiled model), so it can be used to deploy a model the platform cannot size automatically. A value of 0 means CPU."
           },
           "active_req_per_replica": {
             "type": "integer",
@@ -48294,11 +53724,57 @@
             "title": "Deployment Target",
             "description": "Target environment: 'auto' (default), 'host', 'docker', 'k8s'. Controls where inference runs."
           },
+          "runtime_env": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runtime Env",
+            "description": "ENG-4068: per-deployment runtime environment overrides. Highest precedence layer above admin overrides and the platform GPU cascade. Keys are env var names. Values are strings (set), or null (suppress a lower-layer key). Reserved keys (LD_LIBRARY_PATH, etc.) are adapter-owned and cannot be set from this layer; attempts log at WARN and are dropped."
+          },
           "id": {
             "type": "string",
             "format": "uuid",
             "title": "Id",
             "description": "The UUID of the deployment"
+          },
+          "owner_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner User Id",
+            "description": "User that requested the deployment. None for legacy rows."
+          },
+          "workroom_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workroom Id",
+            "description": "Verified non-global workroom scope for this deployment, if any."
           },
           "requested_at": {
             "type": "string",
@@ -48494,6 +53970,127 @@
             "title": "Tensor Parallel Size",
             "description": "Tensor parallelism size as computed or passed by the user (read-only)"
           },
+          "topology": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Topology",
+            "description": "Install topology: 'managed_cluster' or 'standalone_cluster' (None pre-v0.4.0)"
+          },
+          "sub_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sub Mode",
+            "description": "TP-2 sub-mode: 'linux_native' or 'macos_hybrid' (None on TP-1)"
+          },
+          "hardware_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hardware Class",
+            "description": "Hardware class: hardware_isolated / software_shared / unified_memory"
+          },
+          "sharing_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sharing Class",
+            "description": "GPU sharing class (e.g. time_slicing_4replicas, mps, whole_gpu, metal_spawner)"
+          },
+          "node_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Name",
+            "description": "Node the deployment landed on (operator placement decision)"
+          },
+          "gpu_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpu Index",
+            "description": "Selected GPU index on the node (None for whole-node/spawner)"
+          },
+          "gpu_vendor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpu Vendor",
+            "description": "Vendor of the selected GPU: 'nvidia' / 'amd' (None for CPU/metal)"
+          },
+          "gpu_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpu Id",
+            "description": "Stable GPU identifier (UUID/serial) from node labels, when known"
+          },
+          "allocated_capacity_gb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allocated Capacity Gb",
+            "description": "Per-copy capacity reserved on the GPU in GB (the vram-gb request)"
+          },
+          "spawner_process": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spawner Process",
+            "description": "TP-2.macos spawner process record: {pid, rss_bytes, started_at, healthy}"
+          },
           "m_name": {
             "anyOf": [
               {
@@ -48517,6 +54114,31 @@
             ],
             "title": "M Config Name",
             "description": "Name of the model configuration used for deployment"
+          },
+          "canonical_model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canonical Model Id",
+            "description": "Model id a client should present in requests to this deployment. External: the provider's canonical model id (e.g. 'anthropic.claude-sonnet-4-6-v1:0', 'gpt-4o'; for Azure, the provider-published model backing the operator-named deployment) — restores the identity the deployment alias erases for name-keyed SDK/LiteLLM feature gates. Local: the engine's served name (curated alias/served_model_name, else the servable model name) — NOT the HF repo id, which local engines would reject. Consumers use this without distinguishing local from external."
+          },
+          "tool_calling": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calling",
+            "description": "Optional provider/model-specific tool-calling guidance for clients that configure agentic runtimes. Example: {'mode': 'native_only'} means prompt-based tool calling is known unsupported."
           },
           "host_ip": {
             "anyOf": [
@@ -48653,6 +54275,17 @@
             "title": "Vectordb Ids",
             "description": "Multiple VectorDB instance UUIDs for agentic search"
           },
+          "search_mode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "semantic",
+              "exact"
+            ],
+            "title": "Search Mode",
+            "description": "Search interpretation: auto detects exact marker/quoted queries, semantic preserves vector search, exact filters returned candidates to chunks containing the literal query needle.",
+            "default": "auto"
+          },
           "format_context": {
             "type": "boolean",
             "title": "Format Context",
@@ -48777,6 +54410,45 @@
             "title": "Partial Failures",
             "description": "Collections that failed to search, with error details"
           },
+          "search_mode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "semantic",
+              "exact"
+            ],
+            "title": "Search Mode",
+            "description": "Search mode requested by the caller",
+            "default": "auto"
+          },
+          "is_exact_query": {
+            "type": "boolean",
+            "title": "Is Exact Query",
+            "description": "True when exact-match filtering was applied",
+            "default": false
+          },
+          "exact_match_count": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Exact Match Count",
+            "description": "Number of candidate chunks containing an exact needle",
+            "default": 0
+          },
+          "semantic_neighbor_count": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Semantic Neighbor Count",
+            "description": "Number of candidate chunks that were related but non-exact",
+            "default": 0
+          },
+          "semantic_neighbors": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array",
+            "title": "Semantic Neighbors",
+            "description": "Non-exact candidates retained only for diagnostics"
+          },
           "context": {
             "anyOf": [
               {
@@ -48815,6 +54487,33 @@
             ],
             "title": "Citations",
             "description": "Structured citations with source provenance (when synthesize=True)"
+          },
+          "graph_results": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Graph Results",
+            "description": "Count of knowledge-graph facts surfaced into the result set (when enable_graph_search=True). Zero when graph search ran but found nothing; None when graph search was not requested."
+          },
+          "graph_facts": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SearchResult"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Graph Facts",
+            "description": "Knowledge-graph facts surfaced into the result set, kept distinguishable from document chunks (when enable_graph_search=True)."
           },
           "iterations": {
             "anyOf": [
@@ -49457,6 +55156,91 @@
         "title": "UpdateWorkroomMemberRequest",
         "description": "Request to change a member role."
       },
+      "UpgradeAllResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/UpgradeAllResult"
+            },
+            "type": "array",
+            "title": "Results",
+            "description": "Per-extension outcome rows. One entry per CR the operation considered (filtered by ``?names=`` if supplied). Raw extensions without a deployment-id annotation are excluded silently."
+          }
+        },
+        "type": "object",
+        "title": "UpgradeAllResponse",
+        "description": "Aggregate response shape for POST /extensions/upgrade-all."
+      },
+      "UpgradeAllResult": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Extension (CR) name"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "upgraded",
+              "no-change",
+              "error"
+            ],
+            "title": "Status",
+            "description": "upgraded = CR patched to a new digest; no-change = template digest matched the running CR; error = render or PATCH failed (see ``error``)"
+          },
+          "old_digests": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Old Digests",
+            "description": "Per-service digests on the CR before the operation"
+          },
+          "new_digests": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "New Digests",
+            "description": "Per-service digests on the CR after the operation"
+          },
+          "old_tags": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Old Tags",
+            "description": "Per-service image tags on the CR before the operation. Surfaced alongside digests so the UI can fall back to tag-only display for catalogs without digest pinning (and pre-ENG-4857 installs whose CR carries no digest)."
+          },
+          "new_tags": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "New Tags",
+            "description": "Per-service image tags on the CR after the operation."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error",
+            "description": "Error message when ``status == 'error'``"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "status"
+        ],
+        "title": "UpgradeAllResult",
+        "description": "Per-extension outcome of an Upgrade All operation."
+      },
       "UserInfo": {
         "properties": {
           "username": {
@@ -49523,6 +55307,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -49977,6 +55768,11 @@
             "type": "array",
             "title": "Recent Events"
           },
+          "shared_credentials_enabled": {
+            "type": "boolean",
+            "title": "Shared Credentials Enabled",
+            "default": false
+          },
           "credential_registrations": {
             "items": {
               "$ref": "#/components/schemas/WorkroomCredentialRegistrationResponse"
@@ -50257,6 +56053,43 @@
             ],
             "title": "Credential Source"
           },
+          "credential_path": {
+            "type": "string",
+            "enum": [
+              "user",
+              "workroom",
+              "platform",
+              "none"
+            ],
+            "title": "Credential Path"
+          },
+          "credential_outcome": {
+            "type": "string",
+            "enum": [
+              "allowed",
+              "denied",
+              "credential_required",
+              "unsupported"
+            ],
+            "title": "Credential Outcome"
+          },
+          "credential_requirement_source": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "workroom",
+                  "platform",
+                  "none"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Requirement Source"
+          },
           "credential_owner_user_id": {
             "anyOf": [
               {
@@ -50299,6 +56132,8 @@
         "required": [
           "connector_key",
           "resolution_state",
+          "credential_path",
+          "credential_outcome",
           "explanation"
         ],
         "title": "WorkroomCredentialResolutionResponse",
@@ -50673,10 +56508,46 @@
       },
       "WorkroomManagerPathResponse": {
         "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "description": "Legacy alias for ui_enabled; true only when the core Workroom Manager UI route is enabled.",
+            "default": true
+          },
+          "ui_enabled": {
+            "type": "boolean",
+            "title": "Ui Enabled",
+            "description": "Whether the core Workroom Manager UI route is enabled.",
+            "default": true
+          },
+          "extension_enabled": {
+            "type": "boolean",
+            "title": "Extension Enabled",
+            "description": "Whether the retired Workroom Manager runtime extension launch surface is available. Always false for the core Workroom Manager UI consolidation.",
+            "default": false
+          },
+          "launch_enabled": {
+            "type": "boolean",
+            "title": "Launch Enabled",
+            "description": "Whether the server advertises a direct Workroom Manager launch path. Retired runtime extension launch paths are intentionally not advertised by the core Workroom Manager capability.",
+            "default": false
+          },
           "primary_path": {
             "type": "string",
             "title": "Primary Path",
             "description": "Canonical public path for Workroom Manager."
+          },
+          "launch_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Launch Path",
+            "description": "Preferred launch path for the currently enabled manager surface."
           },
           "alias_paths": {
             "items": {
@@ -50684,7 +56555,7 @@
             },
             "type": "array",
             "title": "Alias Paths",
-            "description": "Compatibility lookup paths associated with Workroom Manager. These aliases are retained for runtime resolution and stale-row compatibility; they are not guaranteed to all be public ingress routes."
+            "description": "Compatibility public paths associated with Workroom Manager. Retired runtime aliases are intentionally excluded."
           }
         },
         "type": "object",
@@ -50995,6 +56866,57 @@
               }
             ],
             "title": "Credential Source"
+          },
+          "credential_path": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "workroom",
+                  "platform",
+                  "none"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Path"
+          },
+          "credential_outcome": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "allowed",
+                  "denied",
+                  "credential_required",
+                  "unsupported"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Outcome"
+          },
+          "credential_requirement_source": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "workroom",
+                  "platform",
+                  "none"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Requirement Source"
           },
           "created_at": {
             "type": "string",
@@ -51423,7 +57345,7 @@
           "access_state"
         ],
         "title": "WorkroomRuntimeContextResponse",
-        "description": "Authoritative runtime context contract for collaborative workroom UX."
+        "description": "Authoritative runtime context contract for collaborative workroom UX.\n\nAlso exported as ``WorkroomAppContextResponse`` for app-consumer parity;\nthe two names share an identical contract today. If app-consumer behavior\nneeds to diverge, replace the alias with a dedicated subclass."
       },
       "WorkroomRuntimePresenceResponse": {
         "properties": {
@@ -51466,6 +57388,18 @@
             "title": "Session Count",
             "default": 0
           },
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen At"
+          },
           "last_heartbeat_at": {
             "anyOf": [
               {
@@ -51477,6 +57411,17 @@
               }
             ],
             "title": "Last Heartbeat At"
+          },
+          "focused_thread_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focused Thread Key"
           },
           "current_user": {
             "type": "boolean",
@@ -51931,6 +57876,13 @@
             "type": "integer",
             "title": "Active Session Count",
             "default": 0
+          },
+          "presence": {
+            "items": {
+              "$ref": "#/components/schemas/WorkroomRuntimePresenceResponse"
+            },
+            "type": "array",
+            "title": "Presence"
           }
         },
         "type": "object",
@@ -52258,13 +58210,134 @@
         "title": "WorkroomType",
         "description": "Workroom type determines lifecycle behavior.\n\n- ephemeral: purges on session end (logout/timeout)\n- persistent: requires explicit delete"
       },
-      "kamiwaza__services__connectors__schemas__m365__ConnectionStatusResponse": {
+      "_GrantBody": {
         "properties": {
-          "status": {
+          "object_namespace": {
             "type": "string",
-            "title": "Status"
+            "title": "Object Namespace"
           },
-          "external_email": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_namespace",
+          "object_id",
+          "relation"
+        ],
+        "title": "_GrantBody",
+        "description": "Body shape for POST/DELETE /api/authz/subjects/{x}/grants."
+      },
+      "kamiwaza__services__connectors__schemas__connector__ConnectorCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "connector_type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Connector Type",
+            "description": "Connector type (a registered connector_type)"
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config",
+            "description": "Provider-specific configuration"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes",
+            "description": "OAuth scopes"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "connector_type",
+          "config"
+        ],
+        "title": "ConnectorCreate",
+        "description": "Schema for creating a new connector."
+      },
+      "kamiwaza__services__connectors__schemas__connector__ConnectorListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__connector__ConnectorResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "ConnectorListResponse",
+        "description": "Schema for listing connectors."
+      },
+      "kamiwaza__services__connectors__schemas__connector__ConnectorResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "connector_type": {
+            "type": "string",
+            "title": "Connector Type"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "redirect_uri": {
             "anyOf": [
               {
                 "type": "string"
@@ -52273,7 +58346,66 @@
                 "type": "null"
               }
             ],
-            "title": "External Email"
+            "title": "Redirect Uri",
+            "description": "Non-secret OAuth redirect URI, echoed for edit prefill. Never includes client_id/client_secret."
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon",
+            "description": "Self-described connector logo (a data: URI from the manifest/provider spec), for the UI card."
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Workload readiness, for the UI to gate 'Test connection'. One of: not_deployed (no workload yet -- verify would 503), deploying (pods not all ready), ready (pods running -- verify is safe), degraded (workload failed), unknown (could not determine).",
+            "default": "unknown"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "connector_type",
+          "enabled",
+          "scopes",
+          "created_at"
+        ],
+        "title": "ConnectorResponse",
+        "description": "Schema for connector response (excludes sensitive config)."
+      },
+      "kamiwaza__services__connectors__schemas__connector__ConnectorUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Config"
           },
           "scopes": {
             "anyOf": [
@@ -52281,7 +58413,8 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "minItems": 1
               },
               {
                 "type": "null"
@@ -52289,31 +58422,30 @@
             ],
             "title": "Scopes"
           },
-          "expires_at": {
+          "enabled": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "type": "boolean"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Enabled"
+          }
+        },
+        "type": "object",
+        "title": "ConnectorUpdate",
+        "description": "Schema for updating a connector."
+      },
+      "kamiwaza__services__connectors__schemas__source_contracts__SelectedGranularity-Input": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/kamiwaza__services__connectors__schemas__source_contracts__SelectedGranularityMode",
+            "description": "Provider-neutral selection mode.",
+            "default": "item"
           },
-          "connected_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Connected At"
-          },
-          "message": {
+          "option": {
             "anyOf": [
               {
                 "type": "string"
@@ -52322,24 +58454,48 @@
                 "type": "null"
               }
             ],
-            "title": "Message"
+            "title": "Option",
+            "description": "UI-selected granularity option preserved for handoff/debugging."
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Whether child items should be included recursively.",
+            "default": false
+          },
+          "include_children": {
+            "type": "boolean",
+            "title": "Include Children",
+            "description": "Whether direct child items should be included.",
+            "default": false
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Query",
+            "description": "Optional saved query or search text for query selections."
           }
         },
+        "additionalProperties": false,
         "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "ConnectionStatusResponse",
-        "description": "Response for connection status check."
+        "title": "SelectedGranularity",
+        "description": "How a source was selected for staging/import."
       },
-      "kamiwaza__services__connectors__schemas__source_contracts__SourceProvider": {
+      "kamiwaza__services__connectors__schemas__source_contracts__SelectedGranularityMode": {
         "type": "string",
         "enum": [
-          "m365",
-          "google_drive"
+          "item",
+          "container",
+          "query"
         ],
-        "title": "SourceProvider",
-        "description": "Providers supported by the provider-neutral source contract."
+        "title": "SelectedGranularityMode",
+        "description": "Selection modes supported by provider-neutral source staging."
       },
       "kamiwaza__services__context__schemas__pipeline__SelectedGranularity": {
         "properties": {
@@ -52394,6 +58550,377 @@
         ],
         "title": "SelectedGranularityMode",
         "description": "Selection modes supported for staged remote sources."
+      },
+      "kamiwaza__services__dde__schemas__ConnectorCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "source_type": {
+            "type": "string",
+            "title": "Source Type"
+          },
+          "connector_type": {
+            "type": "string",
+            "title": "Connector Type"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "allowed_roles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allowed Roles"
+          },
+          "require_encryption": {
+            "type": "boolean",
+            "title": "Require Encryption",
+            "default": true
+          },
+          "system_high": {
+            "type": "string",
+            "title": "System High",
+            "description": "System-high classification for this connector",
+            "default": "UNCLASSIFIED"
+          },
+          "default_security_marking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Security Marking",
+            "description": "Default ICISM/CAPCO marking applied when documents lack explicit markings"
+          },
+          "connection_config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Connection Config"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "source_type",
+          "connector_type",
+          "connection_config"
+        ],
+        "title": "ConnectorCreate"
+      },
+      "kamiwaza__services__dde__schemas__ConnectorListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/kamiwaza__services__dde__schemas__ConnectorResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ConnectorListResponse"
+      },
+      "kamiwaza__services__dde__schemas__ConnectorResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "source_type": {
+            "type": "string",
+            "title": "Source Type"
+          },
+          "connector_type": {
+            "type": "string",
+            "title": "Connector Type"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "allowed_roles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allowed Roles"
+          },
+          "require_encryption": {
+            "type": "boolean",
+            "title": "Require Encryption"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "system_high": {
+            "type": "string",
+            "title": "System High"
+          },
+          "default_security_marking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Security Marking"
+          },
+          "last_ingestion_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Ingestion At"
+          },
+          "last_success_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Success At"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "source_type",
+          "connector_type",
+          "description",
+          "tags",
+          "allowed_roles",
+          "require_encryption",
+          "enabled",
+          "system_high",
+          "default_security_marking",
+          "last_ingestion_at",
+          "last_success_at",
+          "error_count",
+          "created_at",
+          "created_by",
+          "updated_at",
+          "updated_by"
+        ],
+        "title": "ConnectorResponse"
+      },
+      "kamiwaza__services__dde__schemas__ConnectorUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "allowed_roles": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Roles"
+          },
+          "require_encryption": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Require Encryption"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "connection_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Connection Config"
+          },
+          "system_high": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "System High"
+          },
+          "default_security_marking": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Security Marking"
+          }
+        },
+        "type": "object",
+        "title": "ConnectorUpdate"
       },
       "ChunkTextListResponse": {
         "type": "array",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1344,7 +1344,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_get",
+        "operationId": "saml_sls_auth_saml_sls_get_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1363,7 +1363,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_get",
+        "operationId": "saml_sls_auth_saml_sls_get_post",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3815,6 +3815,14 @@
               ],
               "title": "X-Forwarded-Proto"
             }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3926,6 +3934,14 @@
                 }
               ],
               "title": "X-Forwarded-Proto"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -4039,6 +4055,14 @@
               ],
               "title": "X-Forwarded-Proto"
             }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4150,6 +4174,14 @@
                 }
               ],
               "title": "X-Forwarded-Proto"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -4263,6 +4295,14 @@
               ],
               "title": "X-Forwarded-Proto"
             }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4374,6 +4414,14 @@
                 }
               ],
               "title": "X-Forwarded-Proto"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -14921,7 +14969,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_options",
         "security": [
           {
             "BearerAuth": []
@@ -14978,7 +15026,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_head",
         "security": [
           {
             "BearerAuth": []
@@ -15035,7 +15083,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_post",
         "security": [
           {
             "BearerAuth": []
@@ -15092,7 +15140,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_get",
         "security": [
           {
             "BearerAuth": []
@@ -15149,7 +15197,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_patch",
         "security": [
           {
             "BearerAuth": []
@@ -15206,7 +15254,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_delete",
         "security": [
           {
             "BearerAuth": []
@@ -15263,7 +15311,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_put",
         "security": [
           {
             "BearerAuth": []
@@ -27749,7 +27797,7 @@
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get_get",
         "parameters": [
           {
             "name": "provider",
@@ -27852,7 +27900,7 @@
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get_post",
         "parameters": [
           {
             "name": "provider",
@@ -27957,7 +28005,7 @@
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get_get",
         "parameters": [
           {
             "name": "provider",
@@ -28051,7 +28099,7 @@
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get_post",
         "parameters": [
           {
             "name": "provider",


### PR DESCRIPTION
## What
One-off refresh of the committed `docs/api/openapi.json` (+ `openapi-metadata.json`), regenerated from **kamiwaza develop @ 8b8f95057** via the from-source generator (`create_app().openapi()`).

## Why + churn
The committed spec was last synced **2026-05-11** (v0.13.0) and had drifted ~7 weeks. Real churn (not just the net):
- **+51 added / −24 removed (net +27)**, 339 → 366 paths.
- Removals: the `/connectors/google/*` and `/connectors/m365/*` groups (19 endpoints, moved out of core) plus the `/ingestion/api/dde/*` group — the latter **relocated** to `/dde/*` (5 endpoints), not dropped.
- `/cluster/cluster_capabilities` corrected: `x-auth-role: admin` → **`authenticated`** (the route became `AuthenticatedUser` + an imperative viewer gate; the old snapshot predated it).

## Known spec-validity defects (upstream — NOT fixed here)
The regenerated spec faithfully reproduces two OpenAPI 3.1 defects from the platform's Starlette catch-all routes: `/auth/forward/validate/{path}` omits the `{path}` parameter declaration, and `/mesh/{cluster_selector}/{path}` shares one `operationId` across its 7 methods. These are platform-generator bugs — hand-editing them here would diverge the docs artifact from its source. Filed as **ENG-7967**.

## Notes
- Large diff by nature (full spec regeneration).
- `info.version` stays `0.13.0` (docs package version, by design). True source provenance is `openapi-metadata.json` `sourceCommit` (`8b8f95057`); `originalApiVersion: 0.1.0` is the FastAPI default (the platform doesn't set an API version), not a meaningful version string.
- Ongoing refreshes are automated by the on-merge workflow (kamiwaza-internal/kamiwaza#2221) once its docs GitHub App is provisioned; the `sync-openapi.ts` from-source fix is #159.
- Follow-up: the hand-written `docs/docs/data-engine.md` still documents the old `/ingestion/api/dde/...` paths (now `/dde/...`).

Only `docs/api/` changed.
