### PR TITLE
Sync develop into release/1.0.0 (connector guide + openapi refresh) (ENG-8031)

### DIFF
--- a/docs/api/openapi-metadata.json
+++ b/docs/api/openapi-metadata.json
@@ -1,8 +1,8 @@
 {
-  "syncedAt": "2026-07-01T01:54:24.043Z",
-  "sourceRemote": "git@github.com:kamiwaza-internal/kamiwaza.git",
+  "syncedAt": "2026-07-02T17:42:28.193Z",
+  "sourceRemote": "https://github.com/kamiwaza-internal/kamiwaza",
   "sourceBranch": "develop",
-  "sourceCommit": "8b8f95057b1a467f787a9aa9bd6a7eb3620138d2",
+  "sourceCommit": "9b6e16a98f5adc2dee635953a3831905fe30fe2a",
   "originalApiVersion": "0.1.0",
   "patchedApiVersion": "0.13.0",
   "endpoints": 366,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1344,7 +1344,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_get_get",
+        "operationId": "saml_sls_auth_saml_sls_post_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1363,7 +1363,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_get_post",
+        "operationId": "saml_sls_auth_saml_sls_post_post",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12569,7 +12569,7 @@
           "cluster"
         ],
         "summary": "Get Cluster Capabilities",
-        "description": "Endpoint to retrieve cluster capabilities for model deployment and platform selection.\n\nReturns hardware information, system type, available platforms, and tool availability\nincluding whether llamacpp is installed and what inference engines are supported.\n\nAuth widened by ENG-4697 / T5.20: viewer or owner on cluster:<local_uuid>\n(admin's install-seeded owner relation still passes). Mesh-origin probes\nwith the baseline federation grant can reach this endpoint per design\n`system-design.md` §4.4.3.\n\nReturns:\n    Dict[str, Any]: A dictionary containing cluster capabilities information.",
+        "description": "Endpoint to retrieve cluster capabilities for model deployment and platform selection.\n\nReturns hardware information, system type, available platforms, and tool availability\nincluding whether llamacpp is installed and what inference engines are supported.\n\nAuth widened by ENG-4697 / T5.20: viewer or owner on cluster:<local_uuid>\n(admin's install-seeded owner relation still passes). NB pairing does NOT\nseed a cluster-viewer grant (ENG-7892): a mesh-origin peer must be granted\ncluster:<local_uuid> viewer explicitly to probe, else 403.\n\nReturns:\n    Dict[str, Any]: A dictionary containing cluster capabilities information.",
         "operationId": "get_cluster_capabilities_cluster_cluster_capabilities_get",
         "responses": {
           "200": {
@@ -13148,7 +13148,7 @@
           "cluster"
         ],
         "summary": "List Federation Users",
-        "description": "List all brokered users on a federation's allowlist.",
+        "description": "List all brokered users on a federation's allowlist.\n\nCarries ``NativeRealmRequired`` (ENG-7890): the allowlist (external IDs,\ninitial tuples) is cross-relationship data a mesh-origin peer admin must\nnot be able to enumerate for an arbitrary federation_id.",
         "operationId": "list_federation_users_cluster_federations__federation_id__users_get",
         "security": [
           {
@@ -13383,7 +13383,7 @@
           "cluster"
         ],
         "summary": "Ping Federation",
-        "description": "Health check a federated cluster.\n\nArgs:\n    federation_id: UUID of the federation to ping\n\nReturns:\n    Ping status",
+        "description": "Health check a federated cluster.\n\nCarries ``NativeRealmRequired`` (ENG-7890): ping triggers an outbound\naction against a peer, so a mesh-origin caller must not be able to invoke\nit.\n\nArgs:\n    federation_id: UUID of the federation to ping\n\nReturns:\n    Ping status",
         "operationId": "ping_federation_cluster_federations__federation_id__ping_post",
         "security": [
           {
@@ -14963,241 +14963,13 @@
       }
     },
     "/mesh/{cluster_selector}/{path}": {
-      "options": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_options",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
-      },
-      "head": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_head",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
-      },
-      "post": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_post",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
-      },
-      "get": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_get",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
-      },
       "patch": {
         "tags": [
           "mesh",
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_patch",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_patch",
         "security": [
           {
             "BearerAuth": []
@@ -15254,7 +15026,121 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_delete",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "options": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_options",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "get": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_get",
         "security": [
           {
             "BearerAuth": []
@@ -15311,7 +15197,121 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__options_put",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "post": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated"
+      },
+      "head": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_mesh__cluster_selector___path__patch_head",
         "security": [
           {
             "BearerAuth": []
@@ -17399,7 +17399,7 @@
             }
           },
           "503": {
-            "description": "Service temporarily unavailable. Body matches the shared ``ServiceUnavailable503Detail`` schema (``code``, ``message``, ``retry_after_seconds``); ``code`` is one of ``embedding_deploying``, ``embedding_unavailable``, ``embedding_service_error``, ``pinned_discovery_unavailable``. Retry per the ``Retry-After`` header.",
+            "description": "Service temporarily unavailable. Body matches the shared ``ServiceUnavailable503Detail`` schema (``code``, ``message``, ``retry_after_seconds``); ``code`` is one of ``embedding_deploying``, ``embedding_unavailable``, ``embedding_service_error``, ``pinned_discovery_unavailable``, ``global_ontology_provisioning``. Retry per the ``Retry-After`` header.",
             "content": {
               "application/json": {
                 "schema": {
@@ -24943,7 +24943,7 @@
           "security"
         ],
         "summary": "Get Embed Script",
-        "description": "Get embeddable JavaScript bundle for classification banners and consent gate.\n\nReturns a self-contained JavaScript file that apps can include to\nautomatically display classification banners and enforce consent acceptance.\nThe script:\n- Fetches security configuration from this API\n- Shows consent gate overlay if consent is required and not yet accepted\n- Injects CSS for banner and consent gate styling\n- Creates banner elements at top and bottom of page\n- Implements fail-closed behavior (shows consent gate on config failure)\n- Sanitizes HTML content to prevent XSS attacks\n\nUsage in apps:\n    <script src=\"https://kamiwaza-host/api/security/embed.js\"></script>\n\nSecurity features:\n- Consent acceptance tracked via sessionStorage (per-session)\n- Consent acceptance logged to backend for audit purposes\n- Escape key disabled while consent gate is displayed\n- HTML content sanitized before rendering (strips dangerous tags/attributes)\n- Fail-closed: If config fetch fails, shows consent gate with Retry button\n\nReturns:\n    Response: JavaScript file with content-type application/javascript.\n        Cached for 5 minutes via Cache-Control header.",
+        "description": "Get embeddable JavaScript bundle for classification banners and consent gate.\n\nReturns a self-contained JavaScript file that apps can include to\nautomatically display classification banners and enforce consent acceptance.\nEmbedded apps that must preserve consent while suppressing classification\nbanners can load ``/security/embed.js?classification_banners=0``.\nThe script:\n- Fetches security configuration from this API\n- Shows consent gate overlay if consent is required and not yet accepted\n- Injects CSS for banner and consent gate styling\n- Creates banner elements at top and bottom of page\n- Implements fail-closed behavior (shows consent gate on config failure)\n- Sanitizes HTML content to prevent XSS attacks\n\nUsage in apps:\n    <script src=\"https://kamiwaza-host/api/security/embed.js\"></script>\n\nSecurity features:\n- Consent acceptance tracked via sessionStorage (per-session)\n- Consent acceptance logged to backend for audit purposes\n- Escape key disabled while consent gate is displayed\n- HTML content sanitized before rendering (strips dangerous tags/attributes)\n- Fail-closed: If config fetch fails, shows consent gate with Retry button\n\nReturns:\n    Response: JavaScript file with content-type application/javascript.\n        Cached for 5 minutes via Cache-Control header.",
         "operationId": "get_embed_script_security_embed_js_get",
         "responses": {
           "200": {
@@ -27790,14 +27790,14 @@
       }
     },
     "/oauth-broker/proxy/{provider}/{service}/{operation}/{resource_id}": {
-      "get": {
+      "post": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get_get",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post_post",
         "parameters": [
           {
             "name": "provider",
@@ -27867,7 +27867,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Get"
+                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
                 }
               }
             }
@@ -27893,14 +27893,14 @@
         ],
         "x-auth-role": "authenticated"
       },
-      "post": {
+      "get": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__get_post",
+        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post_get",
         "parameters": [
           {
             "name": "provider",
@@ -27970,7 +27970,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Get"
+                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
                 }
               }
             }
@@ -27998,14 +27998,14 @@
       }
     },
     "/oauth-broker/proxy/{provider}/{service}/{operation}": {
-      "get": {
+      "post": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get_get",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post_post",
         "parameters": [
           {
             "name": "provider",
@@ -28066,7 +28066,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Get"
+                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
                 }
               }
             }
@@ -28092,14 +28092,14 @@
         ],
         "x-auth-role": "authenticated"
       },
-      "post": {
+      "get": {
         "tags": [
           "oauth-broker",
           "proxy-mode"
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__get_post",
+        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post_get",
         "parameters": [
           {
             "name": "provider",
@@ -28160,7 +28160,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Get"
+                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
                 }
               }
             }
@@ -58414,6 +58414,12 @@
             "title": "Status",
             "description": "Workload readiness, for the UI to gate 'Test connection'. One of: not_deployed (no workload yet -- verify would 503), deploying (pods not all ready), ready (pods running -- verify is safe), degraded (workload failed), unknown (could not determine).",
             "default": "unknown"
+          },
+          "configured": {
+            "type": "boolean",
+            "title": "Configured",
+            "description": "True when the stored config satisfies the connector's required fields (e.g. a non-empty client_id/client_secret). A bare, sync-seeded row with an empty config is not configured and is hidden from the connect screen.",
+            "default": false
           }
         },
         "type": "object",

--- a/docs/docs/data-connectors.md
+++ b/docs/docs/data-connectors.md
@@ -27,11 +27,12 @@ Connectors are managed through the Kamiwaza web UI at **Settings** → **Data Co
 1. Navigate to **Settings** → **Data Connectors**
 2. You'll see available connector types:
    - **Microsoft 365** - Connect to SharePoint, OneDrive, Outlook, and Calendar
-   - **Google Workspace** - Connect to Drive, Gmail, and Calendar (Coming Soon)
+   - **Google Workspace** - Connect to Drive, Gmail, and Calendar (read-only)
    - **Dropbox** - Connect to Dropbox storage
 3. Click **Configure** on the connector you want to set up
 4. Fill in the required configuration details:
    - For Microsoft 365: Azure AD application credentials (Client ID, Client Secret, Tenant ID)
+   - For Google Workspace: Google Cloud OAuth credentials (Client ID, Client Secret, Redirect URI) plus the read-only capabilities (Gmail, Drive, Calendar) to request — see [Google Workspace Connector](#google-workspace-connector) for the full walkthrough
    - Service-specific settings and permissions
 5. Click **Save** to complete the configuration
 
@@ -126,7 +127,7 @@ View connector status on the **Settings** → **Data Connectors** page. The stat
 | Connector | Services | Status |
 |-----------|----------|--------|
 | **Microsoft 365** | SharePoint, OneDrive, Outlook, Calendar | Available |
-| **Google Workspace** | Drive, Gmail, Calendar | Coming Soon |
+| **Google Workspace** | Drive, Gmail, Calendar (read-only) | Available |
 | **Dropbox** | Dropbox storage | Coming Soon |
 
 ### Microsoft 365 Connector
@@ -142,6 +143,52 @@ The Microsoft 365 connector allows users to connect their Microsoft accounts to 
 - Client ID and Client Secret
 - Tenant ID (for single-tenant apps)
 - Required API permissions configured in Azure AD
+
+### Google Workspace Connector
+
+The Google Workspace connector lets users connect their Google accounts to access, **read-only**:
+- **Google Drive**: files and folders
+- **Gmail**: email messages
+- **Google Calendar**: calendar events
+
+Administrators register a Google Cloud OAuth client once; each user then connects their own Google account through Google's consent screen. The connector requests **read-only** scopes only — it cannot send mail, modify files, or change calendar events.
+
+**Configuration Requirements**:
+- A Google Cloud project
+- An **OAuth 2.0 Client ID** of type **Web application** (provides the Client ID and Client Secret)
+- The required Google APIs **enabled** in that project: **Gmail API**, **Google Drive API**, **Google Calendar API**
+- An **Authorized redirect URI** that exactly matches Kamiwaza's callback (see Step 2)
+- A configured **OAuth consent screen** (the requested scopes are *sensitive/restricted*, so external apps may require Google verification — see the note below)
+
+#### Step 1 — Create the OAuth client in Google Cloud Console
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com/) and create or select a project.
+2. **Enable the APIs** under **APIs & Services → Library** — enable each capability you plan to offer:
+   - **Gmail API**, **Google Drive API**, **Google Calendar API**
+   - *(If an API is not enabled, that capability fails permanently and affected users are told to reconnect after the admin enables it.)*
+3. Configure the **OAuth consent screen** (**APIs & Services → OAuth consent screen**):
+   - Choose **Internal** (recommended for a single Google Workspace organization) or **External** (requires adding test users, or publishing the app + Google verification).
+   - Add the scopes you will request: `gmail.readonly`, `drive.readonly`, `calendar.readonly`, plus the basic `userinfo.email` and `userinfo.profile` sign-in scopes.
+4. Create the credential under **APIs & Services → Credentials → Create credentials → OAuth client ID**:
+   - **Application type: Web application.**
+   - Under **Authorized redirect URIs**, add Kamiwaza's callback URL (exact match — see Step 2).
+5. Copy the **Client ID** (ends with `.apps.googleusercontent.com`) and the **Client Secret** (starts with `GOCSPX-`).
+
+#### Step 2 — Configure the connector in Kamiwaza
+
+1. Go to **Settings → Data Connectors** and click **Configure** on **Google Workspace**.
+2. Fill in:
+   - **Display Name** — a friendly label for the connector.
+   - **Client ID** and **Client Secret** — from Step 1.
+   - **Redirect URI** — prefilled from your current browser origin as `https://<host>/api/connectors/public/google/callback`. The path `/api/connectors/public/google/callback` is fixed; set the **scheme and host** to the address your end users will use. **This value must exactly match an Authorized redirect URI in your Google Cloud OAuth client** (scheme, host, and path).
+3. Under **Google Workspace Capabilities**, check the services to request — **Gmail (read-only)**, **Google Drive (read-only)**, **Google Calendar (read-only)**. Only check capabilities whose APIs you enabled in Step 1; each checkbox maps to the OAuth scope requested when a user connects their account.
+4. Click **Save**. The connector status changes to **Configured** and users can connect their Google accounts.
+
+> **The Redirect URI must match exactly.** The most common setup error is a mismatch between the Redirect URI entered here and the Authorized redirect URI in Google Cloud Console. If your users reach Kamiwaza at more than one hostname, add each one as an Authorized redirect URI in Google Cloud and set this field to the host they actually use.
+
+> **Sensitive/restricted scopes.** Gmail and Drive read-only are *restricted* Google scopes. With an **Internal** consent screen (same Workspace org) this is fine; for an **External** app, Google may require app verification before users outside your test-user list can grant access.
+
+**Rotating credentials**: To change the Client Secret (or Client ID), open **Configure**, enter the new value(s), and **Save** — leave a field blank to keep its stored value. The non-secret Redirect URI is always saved, so you can rebind the hostname without re-entering secrets.
 
 > Need a connector that isn't listed? Contact Kamiwaza Support to discuss roadmap status or professional-services extensions.
 
@@ -178,6 +225,17 @@ The Microsoft 365 connector allows users to connect their Microsoft accounts to 
 - Verify the redirect URI in Azure AD matches Kamiwaza's callback URL
 - Ensure the Azure AD application permissions are properly configured
 - Check if the application requires admin consent for certain permissions
+
+### Google Workspace: a capability needs reconnect after enabling an API
+
+If users connect successfully but a capability (Drive, Gmail, or Calendar) does not work — or the connection reports that it needs re-authentication with a message naming a Google API — the corresponding API is not enabled in the Google Cloud project:
+
+1. In Google Cloud Console, open **APIs & Services → Library** and enable the named API (**Gmail API**, **Google Drive API**, or **Google Calendar API**).
+2. Ask affected users to **reconnect** their account — re-enabling the API alone does not retroactively repair an existing connection.
+
+### Google Workspace: `redirect_uri_mismatch`
+
+A `redirect_uri_mismatch` error during the Google consent flow means the connector's **Redirect URI** does not exactly match an **Authorized redirect URI** on the Google Cloud OAuth client. Confirm both are identical — scheme, host, and the `/api/connectors/public/google/callback` path — and that you edited the correct OAuth client.
 
 ## Related Documentation
 

--- a/docs/sdk_versioned_docs/version-1.0.0/current/services/context.md
+++ b/docs/sdk_versioned_docs/version-1.0.0/current/services/context.md
@@ -18,6 +18,25 @@ keyword-only argument (e.g. `list_collections`, `create_pipeline_job`, `search`,
 `retrieve`, `upload_file`); others accept it optionally, and when it is omitted
 the server resolves the caller's default workroom.
 
+For PAT/API-key automation that makes several calls against the same workroom,
+derive a local scoped client instead of calling `workrooms.enter()`:
+
+```python
+with client.workroom_scope(my_workroom_id) as scoped:
+    db = scoped.context.create_vectordb(name="project-vdb", engine="milvus")
+    scoped.context.insert_vectors(
+        db["id"],
+        collection_name="project_docs",
+        vectors=[embedding],
+        metadata=[{"source": "seed"}],
+    )
+```
+
+The scoped client only adds the explicit workroom header on SDK requests; it
+does not change the parent client or mutate server-side selected-session state.
+It is not a client-side security boundary; the server must still authorize the
+caller for the requested workroom on every request.
+
 ## Workrooms and the Global Workroom
 
 A **Workroom** is the collaboration and isolation boundary for context: vector

--- a/docs/versioned_docs/version-1.0.0/data-connectors.md
+++ b/docs/versioned_docs/version-1.0.0/data-connectors.md
@@ -27,11 +27,12 @@ Connectors are managed through the Kamiwaza web UI at **Settings** → **Data Co
 1. Navigate to **Settings** → **Data Connectors**
 2. You'll see available connector types:
    - **Microsoft 365** - Connect to SharePoint, OneDrive, Outlook, and Calendar
-   - **Google Workspace** - Connect to Drive, Gmail, and Calendar (Coming Soon)
+   - **Google Workspace** - Connect to Drive, Gmail, and Calendar (read-only)
    - **Dropbox** - Connect to Dropbox storage
 3. Click **Configure** on the connector you want to set up
 4. Fill in the required configuration details:
    - For Microsoft 365: Azure AD application credentials (Client ID, Client Secret, Tenant ID)
+   - For Google Workspace: Google Cloud OAuth credentials (Client ID, Client Secret, Redirect URI) plus the read-only capabilities (Gmail, Drive, Calendar) to request — see [Google Workspace Connector](#google-workspace-connector) for the full walkthrough
    - Service-specific settings and permissions
 5. Click **Save** to complete the configuration
 
@@ -126,7 +127,7 @@ View connector status on the **Settings** → **Data Connectors** page. The stat
 | Connector | Services | Status |
 |-----------|----------|--------|
 | **Microsoft 365** | SharePoint, OneDrive, Outlook, Calendar | Available |
-| **Google Workspace** | Drive, Gmail, Calendar | Coming Soon |
+| **Google Workspace** | Drive, Gmail, Calendar (read-only) | Available |
 | **Dropbox** | Dropbox storage | Coming Soon |
 
 ### Microsoft 365 Connector
@@ -142,6 +143,52 @@ The Microsoft 365 connector allows users to connect their Microsoft accounts to 
 - Client ID and Client Secret
 - Tenant ID (for single-tenant apps)
 - Required API permissions configured in Azure AD
+
+### Google Workspace Connector
+
+The Google Workspace connector lets users connect their Google accounts to access, **read-only**:
+- **Google Drive**: files and folders
+- **Gmail**: email messages
+- **Google Calendar**: calendar events
+
+Administrators register a Google Cloud OAuth client once; each user then connects their own Google account through Google's consent screen. The connector requests **read-only** scopes only — it cannot send mail, modify files, or change calendar events.
+
+**Configuration Requirements**:
+- A Google Cloud project
+- An **OAuth 2.0 Client ID** of type **Web application** (provides the Client ID and Client Secret)
+- The required Google APIs **enabled** in that project: **Gmail API**, **Google Drive API**, **Google Calendar API**
+- An **Authorized redirect URI** that exactly matches Kamiwaza's callback (see Step 2)
+- A configured **OAuth consent screen** (the requested scopes are *sensitive/restricted*, so external apps may require Google verification — see the note below)
+
+#### Step 1 — Create the OAuth client in Google Cloud Console
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com/) and create or select a project.
+2. **Enable the APIs** under **APIs & Services → Library** — enable each capability you plan to offer:
+   - **Gmail API**, **Google Drive API**, **Google Calendar API**
+   - *(If an API is not enabled, that capability fails permanently and affected users are told to reconnect after the admin enables it.)*
+3. Configure the **OAuth consent screen** (**APIs & Services → OAuth consent screen**):
+   - Choose **Internal** (recommended for a single Google Workspace organization) or **External** (requires adding test users, or publishing the app + Google verification).
+   - Add the scopes you will request: `gmail.readonly`, `drive.readonly`, `calendar.readonly`, plus the basic `userinfo.email` and `userinfo.profile` sign-in scopes.
+4. Create the credential under **APIs & Services → Credentials → Create credentials → OAuth client ID**:
+   - **Application type: Web application.**
+   - Under **Authorized redirect URIs**, add Kamiwaza's callback URL (exact match — see Step 2).
+5. Copy the **Client ID** (ends with `.apps.googleusercontent.com`) and the **Client Secret** (starts with `GOCSPX-`).
+
+#### Step 2 — Configure the connector in Kamiwaza
+
+1. Go to **Settings → Data Connectors** and click **Configure** on **Google Workspace**.
+2. Fill in:
+   - **Display Name** — a friendly label for the connector.
+   - **Client ID** and **Client Secret** — from Step 1.
+   - **Redirect URI** — prefilled from your current browser origin as `https://<host>/api/connectors/public/google/callback`. The path `/api/connectors/public/google/callback` is fixed; set the **scheme and host** to the address your end users will use. **This value must exactly match an Authorized redirect URI in your Google Cloud OAuth client** (scheme, host, and path).
+3. Under **Google Workspace Capabilities**, check the services to request — **Gmail (read-only)**, **Google Drive (read-only)**, **Google Calendar (read-only)**. Only check capabilities whose APIs you enabled in Step 1; each checkbox maps to the OAuth scope requested when a user connects their account.
+4. Click **Save**. The connector status changes to **Configured** and users can connect their Google accounts.
+
+> **The Redirect URI must match exactly.** The most common setup error is a mismatch between the Redirect URI entered here and the Authorized redirect URI in Google Cloud Console. If your users reach Kamiwaza at more than one hostname, add each one as an Authorized redirect URI in Google Cloud and set this field to the host they actually use.
+
+> **Sensitive/restricted scopes.** Gmail and Drive read-only are *restricted* Google scopes. With an **Internal** consent screen (same Workspace org) this is fine; for an **External** app, Google may require app verification before users outside your test-user list can grant access.
+
+**Rotating credentials**: To change the Client Secret (or Client ID), open **Configure**, enter the new value(s), and **Save** — leave a field blank to keep its stored value. The non-secret Redirect URI is always saved, so you can rebind the hostname without re-entering secrets.
 
 > Need a connector that isn't listed? Contact Kamiwaza Support to discuss roadmap status or professional-services extensions.
 
@@ -178,6 +225,17 @@ The Microsoft 365 connector allows users to connect their Microsoft accounts to 
 - Verify the redirect URI in Azure AD matches Kamiwaza's callback URL
 - Ensure the Azure AD application permissions are properly configured
 - Check if the application requires admin consent for certain permissions
+
+### Google Workspace: a capability needs reconnect after enabling an API
+
+If users connect successfully but a capability (Drive, Gmail, or Calendar) does not work — or the connection reports that it needs re-authentication with a message naming a Google API — the corresponding API is not enabled in the Google Cloud project:
+
+1. In Google Cloud Console, open **APIs & Services → Library** and enable the named API (**Gmail API**, **Google Drive API**, or **Google Calendar API**).
+2. Ask affected users to **reconnect** their account — re-enabling the API alone does not retroactively repair an existing connection.
+
+### Google Workspace: `redirect_uri_mismatch`
+
+A `redirect_uri_mismatch` error during the Google consent flow means the connector's **Redirect URI** does not exactly match an **Authorized redirect URI** on the Google Cloud OAuth client. Confirm both are identical — scheme, host, and the `/api/connectors/public/google/callback` path — and that you edited the correct OAuth client.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary

Brings develop's post-cut changes into `release/1.0.0` and re-snapshots `version-1.0.0` so the release reflects latest develop. Linear: ENG-8031.

Two develop PRs landed after the 1.0.0 cut (develop @ `8a7c478`):
- **#156** (ENG-7761) — Google Workspace connector setup guide (`data-connectors.md`)
- **#161** (ENG-7897) — OpenAPI re-sync from platform develop (`9b6e16a9`)

## Changes

- **Merge `origin/develop`** — brings the Google Workspace connector guide into current docs.
- **OpenAPI → develop's #161 spec** (platform `9b6e16a9`, 15 commits newer than the cut's from-source regen at `093fcbd7f`; includes connectors fix #2241). `info.version` + `openapi-metadata.patchedApiVersion` re-patched to `1.0.0`. 366 endpoints / 459 schemas (unchanged count).
- **Re-snapshot `version-1.0.0`** from current docs so the frozen 1.0.0 snapshot includes the connector guide (keeps the byte-identical-to-source invariant the cut PR was reviewed on).

## Scope note (please confirm)

The SDK worktree was refreshed to latest `kamiwaza-sdk` develop (`c734767`) for the re-snapshot, so the 1.0.0 SDK snapshot also picks up one newer doc addition — `context.md` workroom-scope guidance for PAT/API-key automation. This is consistent with "release = latest develop," but it's slightly beyond the two docs PRs above. Flagging in case you want the SDK pinned to the cut's `2f04a09` instead.

## Validation

- `npm run build` clean (only pre-existing broken-anchor warnings in historical snapshots).
- Google Workspace guide present in both `docs/docs/data-connectors.md` and `docs/versioned_docs/version-1.0.0/data-connectors.md`.
- `versions.json` / `sdk_versions.json` still lead with `1.0.0`.