### PR TITLE
Support serving the docs site under a path-prefix baseUrl

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,7 +29,10 @@ const config: Config = {
 	favicon: "img/favicon.ico",
 
 	url: "https://docs.kamiwaza.ai",
-	baseUrl: "/",
+	// baseUrl is baked at build time. Default "/" matches the public deployment
+	// at docs.kamiwaza.ai. Set DOCS_BASE_URL (e.g. "/docs/") to build the site
+	// for serving under a path prefix instead.
+	baseUrl: process.env.DOCS_BASE_URL || "/",
 	trailingSlash: false,
 
 	markdown: {

--- a/docs/research/agentic-merit-index/index.md
+++ b/docs/research/agentic-merit-index/index.md
@@ -3,18 +3,20 @@ title: Agentic Merit Index
 description: Live leaderboard of KAMI benchmark results tracking enterprise agentic AI performance
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # Agentic Merit Index
 
 The definitive leaderboard for enterprise agentic AI performance, powered by the Kamiwaza Agentic Merit Index (KAMI) benchmark.
 
-<a href="/papers/kami_leaderboard.html" target="_blank">**Open Full Leaderboard in New Tab**</a> (recommended for best experience)
+<a href={useBaseUrl('/papers/kami_leaderboard.html')} target="_blank">**Open Full Leaderboard in New Tab**</a> (recommended for best experience)
 
 ---
 
 ## Live Leaderboard
 
 <iframe
-  src="/papers/kami_leaderboard.html"
+  src={useBaseUrl('/papers/kami_leaderboard.html')}
   width="100%"
   height="2200"
   style={{border: 'none', borderRadius: '12px'}}

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -5,6 +5,8 @@ hide_table_of_contents: false
 image: /img/research/Kamiwaza_AIR.png
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # Kamiwaza Agentic Intelligence Research (AIR)
 
 <div className="research-hero">
@@ -26,7 +28,7 @@ Our work is grounded in real-world applications and informed by our experience b
 
 <div className="research-pillars">
 
-<a href="/research/agentic-merit-index" className="resource-card-link">
+<a href={useBaseUrl('/research/agentic-merit-index')} className="resource-card-link">
 <div>
 
 ### 🏆 Agentic Merit Index
@@ -38,7 +40,7 @@ The definitive leaderboard for enterprise agentic AI performance. Live rankings 
 </div>
 </a>
 
-<a href="/research/executive-insights" className="resource-card-link">
+<a href={useBaseUrl('/research/executive-insights')} className="resource-card-link">
 <div>
 
 ### 💼 Executive Insights
@@ -50,7 +52,7 @@ Business-friendly whitepapers distilling our technical research into actionable 
 </div>
 </a>
 
-<a href="/research/papers" className="resource-card-link">
+<a href={useBaseUrl('/research/papers')} className="resource-card-link">
 <div>
 
 ### 📄 Papers
@@ -62,7 +64,7 @@ Scientific publications from Kamiwaza AIR team, covering topics in agentic AI, s
 </div>
 </a>
 
-<a href="/research/blogs" className="resource-card-link">
+<a href={useBaseUrl('/research/blogs')} className="resource-card-link">
 <div>
 
 ### 📝 Insights
@@ -73,7 +75,7 @@ Shorter, more frequent articles containing insights from our on-going research i
 </div>
 </a>
 
-<a href="/research/datasets" className="resource-card-link">
+<a href={useBaseUrl('/research/datasets')} className="resource-card-link">
 <div>
 
 ### 📊 Datasets

--- a/docs/static/papers/kami_leaderboard.html
+++ b/docs/static/papers/kami_leaderboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KAMI: Kamiwaza Agentic Merit Index (preview)</title>
-    <link rel="icon" href="/img/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
 
     <!-- External Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -1203,7 +1203,7 @@
                     </div>
                     <div class="sidebar-card platinum">
                         <a href="https://signal65.com/" target="_blank" rel="noopener noreferrer">
-                            <img src="/img/research/signal65-logo_color.svg" alt="Signal65" height="40">
+                            <img src="../img/research/signal65-logo_color.svg" alt="Signal65" height="40">
                             <span class="sponsor-description">Signal65 exists to be a source of data in a world where technology markets and product landscapes create complex and distorted views of product truth.</span>
                         </a>
                     </div>


### PR DESCRIPTION
Adds the ability to build the docs site for serving under a path prefix (not just the domain root), without changing the default public build.

- `baseUrl` now reads `process.env.DOCS_BASE_URL` (default `/`), so a build can set e.g. `/docs/` for path-prefix hosting.
- Fixes root-absolute links that assumed domain-root hosting: the Research index cards and the Agentic Merit Index leaderboard link/iframe now use `useBaseUrl()`, and the static leaderboard HTML's image references are relative. These resolve correctly under any baseUrl.

No effect on the default public deployment — `baseUrl` stays `/`, and `useBaseUrl()` yields the same paths there, so the rendered output is unchanged.

Tracking: ENG-8014
