### PR TITLE
Exclude federal docs from default build (ENG-8179)

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -132,6 +132,12 @@ const config: Config = {
 				path: "docs",
 				routeBasePath: "/",
 				sidebarPath: require.resolve("./sidebars.ts"),
+				// Exclude federal docs from the default build entirely. The
+				// includeFederal flag only gates the sidebar + search index, so
+				// without this, federal/ pages still build as reachable URLs
+				// (public site + air-gapped container). build:federal
+				// (INCLUDE_FEDERAL_DOCS=true) re-includes them for fed customers.
+				exclude: includeFederal ? [] : ["federal/**"],
 				lastVersion: "current",
 				versions: {
 					current: {


### PR DESCRIPTION
## Summary

`federal/cac-overview` shipped as a publicly reachable page despite `INCLUDE_FEDERAL_DOCS`. That flag only gates the **sidebar** and **search index** — the main docs plugin had no `exclude`, so federal pages still built as reachable URLs on both the public site and the air-gapped container. Linear: ENG-8179.

## Change

One line on the main docs plugin (`docusaurus.config.ts`), gated on the existing flag:

```ts
exclude: includeFederal ? [] : ["federal/**"],
```

## Verified

- **Default `npm run build`** → **0** federal pages in `build/` (was emitting `federal/cac-overview.html` + `1.0.0/federal/cac-overview.html`).
- **`npm run build:federal`** (`INCLUDE_FEDERAL_DOCS=true`) → **8** federal pages present — federal-customer build unaffected.

## Notes

- Ready to merge pending team confirmation that federal content should not ship publicly.
- Should also flow to develop so the exposure doesn't recur on the next cut.
- Out of scope: the doc already existing in the public GitHub repo / history scrubbing.