### PR TITLE
Wire orphaned docs into sidebar: redhat_uninstall + federation (ENG-8131)

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
 				"installation/windows_installation_guide",
 				"installation/redhat_online_install",
 				"installation/redhat_offline_install",
+				"installation/redhat_uninstall",
 				"installation/gpu_setup_guide",
 				"installation/nvidia-secure-boot",
 				"installation/two-node-deployment",
@@ -75,6 +76,9 @@ const sidebars: SidebarsConfig = {
 				"federation/retrieval",
 				"federation/job-submission",
 				"federation/operations",
+				"federation/execution-gates",
+				"federation/gate-packages",
+				"federation/api-reference",
 			],
 		},
 		{

--- a/docs/versioned_sidebars/version-1.0.0-sidebars.json
+++ b/docs/versioned_sidebars/version-1.0.0-sidebars.json
@@ -20,6 +20,7 @@
         "installation/windows_installation_guide",
         "installation/redhat_online_install",
         "installation/redhat_offline_install",
+        "installation/redhat_uninstall",
         "installation/gpu_setup_guide",
         "installation/nvidia-secure-boot",
         "installation/two-node-deployment"
@@ -62,7 +63,10 @@
         "federation/setup",
         "federation/retrieval",
         "federation/job-submission",
-        "federation/operations"
+        "federation/operations",
+        "federation/execution-gates",
+        "federation/gate-packages",
+        "federation/api-reference"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Wires previously built-but-unlinked docs into the nav so they're reachable from the sidebar, not just by direct URL. Linear: ENG-8131.

Applied to **both** the current `sidebars.ts` and the `version-1.0.0` snapshot sidebar:
- `installation/redhat_uninstall` → **Installation**
- `federation/execution-gates`, `federation/gate-packages`, `federation/api-reference` → **Federation**

## Left orphaned (intentional, per team call)

- `architecture/architecture` — superseded by `architecture/overview` ("Platform Overview")
- `other-topics` — catch-all page
- `federal/cac-overview` — stays out of the default sidebar by design; its build-time exposure is handled separately in ENG-8179 / #165

## Validation

- `npm run build` clean.
- Post-change orphan set in `version-1.0.0` is exactly the three above; the 4 wired docs resolve in nav.

## Note

Sidebar-only change — no doc content edited. Touches only `sidebars.ts` and `versioned_sidebars/version-1.0.0-sidebars.json`, so it's independent of #163 (develop sync) and #165 (federal exclude).