### PR TITLE
fix(docs): point version banner at 1.0.0 GA (ENG-8031)

### DIFF
--- a/docs/src/theme/DocVersionBanner/index.tsx
+++ b/docs/src/theme/DocVersionBanner/index.tsx
@@ -20,7 +20,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is the next release of Kamiwaza. For the current GA release, see{' '}
-          <Link to="/"><b>0.9.3</b></Link>.
+          <Link to="/"><b>1.0.0</b></Link>.
         </div>
       </div>
     );
@@ -38,7 +38,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is no longer actively maintained. For the current GA release, see{' '}
-          <Link to="/"><b>0.9.3</b></Link>.
+          <Link to="/"><b>1.0.0</b></Link>.
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Addresses **finding #2** from the PR #170 review. The swizzled `DocVersionBanner` hardcoded `0.9.3` as the current GA release in **both** the `unreleased` and `unmaintained` branches (`docs/src/theme/DocVersionBanner/index.tsx:23,41`). With 1.0.0 now GA (latest in `versions.json`), archived / next-release pages were pointing readers at a stale GA version.

- Both labels updated `0.9.3 → 1.0.0`; link target `/` unchanged (already correct).
- Feeds into the release/1.0.0 → main promotion (#170).

## Ticket

ENG-8031

🤖 Generated with [Claude Code](https://claude.com/claude-code)