### PR TITLE
Federation identity trust modes docs (1.1, ENG-8213 / ENG-8581)

### DIFF
--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -83,20 +83,33 @@ The mesh proxy forwards requests to remote federated clusters. Every request is 
 
 The `{federation_name}` is the `remote_cluster_name` from the federation record. The `{remote_path}` is the path on the remote cluster (without the `/api` prefix — it's re-added by the proxy).
 
-**Authorization:** The caller must have `operator` relation on the federation (seeded automatically when the federation is paired by an admin; can be granted to other users via the ReBAC API).
+**Authorization:** Mesh egress is **authenticated-only** — any authenticated local
+user may call `/api/mesh/{fed}/*`. There is **no** `federation:operator` gate on the
+egress path (it was removed in 1.1). Cross-cluster authorization is decided entirely
+by the **receiving** cluster (its allowlist, per-resource ReBAC, and per-record gates).
 
 **Request headers forwarded upstream:**
 
 | Header | Source | Purpose |
 |--------|--------|---------|
 | `X-KZ-Mesh-Source-Cluster-Id` | Local cluster ID | Identifies the originating cluster |
-| `X-KZ-Mesh-User-Id` | Local user's `sub` claim | Remote identity resolution |
-| `X-KZ-Mesh-User-Roles` | Local user's roles (CSV) | Remote role-based checks |
+| `X-KZ-Mesh-User-Id` | Local user's `sub` claim | Source-asserted user id (see note) |
+| `X-KZ-Mesh-User-Roles` | Local user's roles (CSV) | Source-asserted roles (see note) |
 | `X-KZ-Mesh-Route` | `{method} {path}` | Bound into the HMAC signature |
 | `X-KZ-Mesh-Signature` | HMAC-SHA256 | Verified on the remote cluster |
 | `X-KZ-Mesh-Signature-Ts` | Unix timestamp | Replay protection (5-minute window) |
 | `X-KZ-Mesh-Correlation-Id` | Per-request UUID | Observability tracing |
-| `X-KZ-Mesh-User-Attributes` | `X-User-Attributes` from source | Passed through to attribute gates |
+| `X-KZ-Mesh-User-Attributes` | Source's `X-User-Attributes` | Source-asserted attributes (see note) |
+
+:::warning Identity-mode-dependent trust
+Whether the receiver **trusts** the source-asserted identity headers
+(`X-KZ-Mesh-User-Id` / `-Roles` / `-Attributes`) depends on the federation's
+[identity mode](./identity-trust-modes.md). In **`shared_idp`** (receiver-controlled)
+the receiver establishes identity and attributes from the caller's **own validated
+shared-realm token**, strips source-asserted cluster roles, and **ignores** the source
+attribute header (F10 — "shared identity ≠ shared authority"). The source-asserted
+headers are trusted only in source-trusted **`peer_kc`** / grandfathered mode.
+:::
 
 **Stripped before forwarding:**
 - `Authorization` (the local token is not valid on the remote cluster)
@@ -118,7 +131,7 @@ The `{federation_name}` is the `remote_cluster_name` from the federation record.
 | Status | Condition |
 |--------|-----------|
 | `401` | Local auth failed (invalid JWT / PAT) |
-| `403` `rebac_denied` | Caller lacks operator on the federation or remote ReBAC blocks the operation |
+| `403` `rebac_denied` | The **receiver's** per-resource ReBAC blocks the operation (there is no source-side `federation:operator` egress gate in 1.1) |
 | `503` | Remote cluster unreachable or HMAC verification failed on the remote side |
 | `504` | Remote request exceeded the proxy timeout |
 
@@ -240,7 +253,7 @@ This grants a relation to a **local** user — one with an account on the cluste
 
 | Scenario | Namespace | Relation | Notes |
 |----------|-----------|----------|-------|
-| User can use a federation | `federation` | `operator` | Required to call `/api/mesh/{fed}/*`; granted to a local user on the **source** cluster |
+| Manage a federation (admin) | `federation` | `operator` | Federation **management** endpoints. **Not** required to call `/api/mesh/{fed}/*` — mesh egress is authenticated-only in 1.1 |
 | Local user can query a dataset | `dataset` | `viewer` | For native (non-mesh) retrieval on this cluster |
 | User can submit jobs | `cluster_jobs` | `executor` | Object id is the constant `"__all__"` |
 | User can own a dataset | `dataset` | `owner` | Can write and manage |
@@ -254,6 +267,14 @@ A federated caller has **no local account** on the target cluster until their fi
 ## Attribute Headers
 
 User attributes flow through ext-authz from JWT claims to domain gates on the retrieval service.
+
+:::note Cross-cluster attributes
+On a **cross-cluster (mesh)** call, the receiver does not blindly forward the
+source's attributes. In `shared_idp` mode it derives `X-User-Attributes` from the
+caller's **own validated shared-realm token** and ignores the source's forwarded
+`X-KZ-Mesh-User-Attributes` (F10); the source-forwarded header is trusted only in
+source-trusted `peer_kc` mode. See [Identity Trust Modes](./identity-trust-modes.md).
+:::
 
 ### X-User-Attributes
 

--- a/docs/docs/federation/identity-trust-modes.md
+++ b/docs/docs/federation/identity-trust-modes.md
@@ -1,0 +1,118 @@
+---
+sidebar_position: 2
+title: Identity Trust Modes
+---
+
+# Identity Trust Modes
+
+When you pair two clusters, you decide **whose identity a cross-cluster caller
+presents to the remote cluster, and how the remote cluster verifies it.** This is
+the federation's **identity mode** — a per-federation setting chosen by the
+cluster that receives the calls (the *grantor*).
+
+Kamiwaza 1.1 ships two identity modes:
+
+| Mode | Trust | Who validates the caller | Use when |
+|---|---|---|---|
+| **`shared_idp`** | Receiver-controlled | The receiver validates the caller's token against a **shared realm** both clusters trust | Both clusters can trust one shared identity provider (single operator, or a tightly-coupled pair) |
+| **`peer_kc`** | Source-trusted (legacy 1.0) | The receiver validates against the **peer cluster's own** Keycloak realm | Grandfathered pairings, or when you explicitly accept the source cluster as an identity authority |
+
+:::note
+A third mode, `receiver_realm`, is planned for a future release and is **not
+available in 1.1**. Only `shared_idp` and `peer_kc` can be configured today.
+:::
+
+## Core principle: shared identity ≠ shared authority
+
+Trusting a shared identity does **not** grant shared authority. When a caller from
+another cluster presents a validated token, that token confers **identity only**:
+
+- **Roles do not cross clusters.** A shared-realm caller's cluster-admin role is
+  stripped; what they can do on the receiver is governed entirely by the
+  **receiver's own** relationship-based access control (ReBAC).
+- **Attributes come from the validated token, never from forwarded headers.**
+  Attributes such as `clearance` or `compartment` are read from the caller's own
+  signature-verified token. The receiver **ignores** any attribute headers the
+  source cluster forwards.
+- **Attributes are read from the token the caller presents**, not fetched live
+  from the identity provider. A downgrade (for example, lowering a `clearance`)
+  takes effect on the caller's **next** token, bounded by the token's lifetime.
+
+This is why `shared_idp` is *receiver-controlled*: the receiver decides who its
+users are (via the shared realm it trusts) **and** what they may do (via its own
+ReBAC and per-record gates).
+
+## `shared_idp` — receiver-controlled
+
+Both clusters trust the **same** realm as an identity provider. A caller
+authenticates against that shared realm and presents its token; the receiver
+validates that token against the realm's published keys (JWKS) before honoring
+the request.
+
+Per-federation configuration (set on the receiver at pairing time):
+
+| Field | Purpose |
+|---|---|
+| `shared_issuer_url` | The shared realm's issuer URL. **Supplying this at create time selects `shared_idp`.** |
+| `shared_jwks_url` | Where the receiver fetches the shared realm's signing keys to validate tokens. |
+| `shared_ca_pem` | (Optional) TLS trust root used to reach the shared realm's JWKS endpoint. |
+
+:::important
+Naming an issuer on a federation is **not sufficient** for the receiver to accept
+its tokens. The receiver only accepts a shared-realm token if that issuer is
+**enrolled in the cluster's trusted-shared-issuers list** (see
+[Cluster policy](#cluster-policy) below). An unenrolled issuer is rejected.
+:::
+
+## `peer_kc` — source-trusted (legacy)
+
+The receiver validates the caller against the **peer cluster's own** Keycloak
+realm — it trusts the source cluster to be the identity authority. This is the
+1.0 model.
+
+- Creating a **new** `peer_kc` federation is **refused** unless the cluster policy
+  `ALLOW_UNTRUSTED_FEDERATION` is enabled (it is **off by default**). See
+  [Cluster policy](#cluster-policy).
+- A new `peer_kc` federation is created in **strict mode** (`require_peer_jwt`):
+  the caller's peer token must validate against the pinned peer realm.
+- A federation created before 1.1 has **no identity mode set** — it is treated as
+  a **grandfathered** `peer_kc` pairing and keeps working after upgrade, exempt
+  from the `ALLOW_UNTRUSTED_FEDERATION` refusal, and surfaced as the weaker
+  posture so operators can see which pairings rest on trusting the source.
+
+## Choosing and configuring a mode
+
+The **grantor** (the cluster receiving the calls) decides the mode from its own
+policy at pairing time. A requester may *propose* a mode, but an inbound proposal
+is not auto-trusted — the receiver's policy decides.
+
+The mode is selected implicitly by what you supply when you create the federation:
+
+- **Supply `shared_issuer_url`** → the federation is `shared_idp`.
+- **Omit it** → the federation is legacy `peer_kc` (subject to
+  `ALLOW_UNTRUSTED_FEDERATION`).
+
+:::warning
+**The identity mode cannot be changed in place.** Switching a federation between
+`peer_kc` and `shared_idp` requires **deleting and re-pairing** it. (Rotatable
+trust details, such as the shared JWKS URL, *can* be updated without re-pairing.)
+:::
+
+See the [Setup Guide](./setup.md) for the concrete pairing steps.
+
+## Cluster policy
+
+Two cluster-level settings govern identity trust across **all** of a cluster's
+federations. Both are operator-configured (via the deploy chart) and default to
+the secure posture.
+
+| Setting | Deploy chart key | Default | Effect |
+|---|---|---|---|
+| `ALLOW_UNTRUSTED_FEDERATION` | `scheduler.allowUntrustedFederation` | `false` | When `false`, creating a **new** `peer_kc` (source-trusted) federation is refused. Existing pairings are grandfathered. |
+| `AUTH_GATEWAY_TRUSTED_SHARED_ISSUERS` | `scheduler.trustedSharedIssuers` | *(empty)* | The comma-separated list of shared-realm issuer URLs this cluster will accept `shared_idp` tokens from. **Empty means no shared issuers are trusted** — a `shared_idp` token is rejected unless its issuer is on this list. |
+
+## Next steps
+
+- [Setup Guide](./setup.md) — pair clusters and choose a mode
+- [Federated Retrieval](./retrieval.md) — cross-cluster retrieval with per-record gating
+- [Overview](./overview.md) — how federation fits together

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -185,19 +185,12 @@ curl -sk -X POST "https://<TARGET_IP>/api/cluster/federations/<FEDERATION_ID>/us
   }'
 ```
 
-For federation **operator** access on the **source** cluster (needed to use the mesh proxy at all) — this is a local user on its home cluster, so `/api/auth/tuples` is the correct path here:
-
-```bash
-# Grant operator on federation namespace (normally seeded during pairing)
-curl -sk -X POST "https://kamiwaza.test/api/auth/tuples" \
-  -H "Authorization: Bearer $LOCAL_ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "subject": {"namespace": "user", "id": "<user-uuid>"},
-    "relation": "operator",
-    "object": {"namespace": "federation", "id": "<federation-id>"}
-  }'
-```
+:::note No longer needed in 1.1
+Earlier releases required a `federation:operator` relation on the source cluster to
+use the mesh proxy. In 1.1 the mesh egress is **authenticated-only** — that grant is
+no longer required, and a mesh `403` now originates from the **receiver's**
+per-resource ReBAC or per-record gate, not a missing source-side operator relation.
+:::
 
 ### CA Trust Errors (TLS)
 
@@ -442,12 +435,20 @@ All cross-cluster mesh requests include these headers. They are set by the mesh 
 | Header | Purpose |
 |--------|---------|
 | `X-KZ-Mesh-Source-Cluster-Id` | UUID of the originating cluster. Used to look up the federation record and PSK on the receiving side. |
-| `X-KZ-Mesh-User-Id` | Authenticated user ID from the source cluster. Becomes the identity for ReBAC checks on the target. |
-| `X-KZ-Mesh-User-Roles` | Comma-separated roles of the authenticated user (e.g., `admin,editor`). |
+| `X-KZ-Mesh-User-Id` | Source-asserted user id. Whether the target adopts it as the identity is identity-mode-dependent (see note). |
+| `X-KZ-Mesh-User-Roles` | Source-asserted roles (e.g., `admin,editor`). Source-asserted cluster roles are stripped for receiver-controlled modes. |
 | `X-KZ-Mesh-Signature` | HMAC-SHA256 signature over the canonical payload (cluster ID, user ID, roles, route, method, URI). |
 | `X-KZ-Mesh-Signature-Ts` | Unix timestamp (seconds) when the signature was issued. Must be within TTL window (default 300s). |
 | `X-KZ-Mesh-Route` | Comma-separated list of cluster IDs this request has traversed. Used for loop detection (max 8 hops). |
 | `X-KZ-Mesh-Correlation-Id` | UUID for cross-cluster request tracing. Preserved across hops; generated on the first hop if absent. |
+
+:::note Identity-mode-dependent trust
+In `shared_idp` (receiver-controlled) mode the target establishes identity from the
+caller's **own validated shared-realm token**, not the source-asserted
+`X-KZ-Mesh-User-Id`/`-Roles`. The source-asserted values are the identity only in
+source-trusted `peer_kc`/grandfathered mode. See
+[Identity Trust Modes](./identity-trust-modes.md).
+:::
 
 ### Signature Payload
 

--- a/docs/docs/federation/overview.md
+++ b/docs/docs/federation/overview.md
@@ -5,17 +5,17 @@ title: Federation Overview
 
 # Cluster Federation
 
-Kamiwaza cluster federation enables cross-cluster operations between paired Kamiwaza clusters. A federated cluster can query remote data, list remote models, and execute compute jobs on its partner — all through a secured mesh proxy with HMAC-signed trust and ReBAC authorization.
+Kamiwaza cluster federation enables cross-cluster operations between paired Kamiwaza clusters. A federated cluster can query remote data, list remote models, and execute compute jobs on its partner — all through a secured mesh proxy. The transport is HMAC-signed and mTLS-protected; **who the caller is** is decided by the federation's [identity mode](./identity-trust-modes.md), and **what they may do** is enforced by the receiving cluster's own ReBAC and per-record gates.
 
 ## Key Concepts
 
-**Mesh Proxy** — Routes API calls from one cluster to another. The proxy strips the caller's authentication, signs the request with the federation's pre-shared key (PSK) via HMAC-SHA256, and forwards to the remote cluster's Istio ingress gateway. The response streams back transparently.
+**Mesh Proxy** — Routes API calls from one cluster to another. For transport integrity the proxy signs each request with the federation's pre-shared key (PSK) via HMAC-SHA256; it forwards the caller's own token so the receiver can validate the caller's identity, and routes to the remote cluster's Istio ingress gateway. The response streams back transparently.
 
-**Federation Trust** — Each federation pair shares a pre-shared key. All cross-cluster requests are HMAC-signed with this key. The receiving cluster verifies the signature before processing the request. Trust is per-federation, not per-cluster.
+**Federation Trust** — Each federation pair shares a pre-shared key. All cross-cluster requests are HMAC-signed with this key, and the receiving cluster verifies the signature before processing the request. The PSK/HMAC secures the *transport*; the caller's *identity* is validated separately, according to the federation's [identity mode](./identity-trust-modes.md). Trust is per-federation, not per-cluster.
 
-**ReBAC Gating** — Authorization is enforced on both sides of the federation link:
-- **Source cluster**: The calling user must have the `operator` relation on the `federation` namespace for the target federation
-- **Target cluster**: The mesh-originated identity is evaluated against standard per-resource ReBAC guards (catalog, retrieval, jobs)
+**Identity Modes** — A federation's [identity mode](./identity-trust-modes.md) decides whose identity a cross-cluster caller presents and how the receiver validates it: **`shared_idp`** (receiver-controlled — both clusters trust a shared realm) or **`peer_kc`** (source-trusted — the legacy 1.0 model, gated by cluster policy).
+
+**Receiver-controlled authorization** — Cross-cluster egress on the source is **authenticated-only**: any authenticated caller may reach the mesh proxy — there is no `operator`-relation gate. Authorization is decided by the **receiving** cluster, which validates the caller's identity per the identity mode and then evaluates the request against its **own** per-resource ReBAC guards (catalog, retrieval, jobs) and per-record gates. Roles do **not** cross clusters (see [shared identity ≠ shared authority](./identity-trust-modes.md#core-principle-shared-identity--shared-authority)).
 
 **Compute Ships to Data** — Raw data never leaves the originating cluster. Only structured results (API responses, job outputs) cross the federation boundary.
 
@@ -39,13 +39,13 @@ Cluster A (source)                          Cluster B (target)
 │   ▼                  │                    │                     │
 │ Mesh Proxy           │   HMAC-signed      │ Istio Gateway       │
 │ /api/mesh/{cluster}/ │──────────────────▶│   │                 │
-│   │ @guarded         │   HTTPS + mTLS     │   ▼                 │
-│   │ (federation:     │                    │ ext-authz           │
-│   │  operator)       │                    │   │ verify HMAC     │
-│   │                  │                    │   │ mint identity   │
+│   │ (auth-only)      │   HTTPS + mTLS     │   ▼                 │
+│   │                  │                    │ ext-authz           │
+│   │                  │                    │   │ verify HMAC     │
+│   │                  │                    │   │ validate ident. │
 │   │                  │                    │   ▼                 │
 │   │                  │                    │ @guarded endpoint   │
-│   │                  │                    │   │ (standard ReBAC)│
+│   │                  │                    │   │ (receiver ReBAC)│
 │   │                  │   streamed         │   ▼                 │
 │   │◀─────────────────│◀──────────────────│ Service response    │
 │   │ response         │                    │                     │

--- a/docs/docs/federation/retrieval.md
+++ b/docs/docs/federation/retrieval.md
@@ -151,3 +151,10 @@ The mesh proxy adds these headers to cross-cluster requests:
 | `X-KZ-Mesh-Signature` | HMAC-SHA256 signature |
 | `X-KZ-Mesh-Correlation-Id` | Request correlation ID for cross-cluster tracing |
 | `X-KZ-Mesh-Route` | Hop trace for loop detection |
+
+:::note Identity-mode-dependent trust
+`X-KZ-Mesh-User-Id`/`-Roles` are **source-asserted**. In `shared_idp` (receiver-controlled)
+mode the receiver establishes identity from the caller's own validated shared-realm
+token and strips source-asserted cluster roles; the forwarded values are the identity
+only in source-trusted `peer_kc` mode. See [Identity Trust Modes](./identity-trust-modes.md).
+:::

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -123,12 +123,21 @@ On success, both clusters transition to `PAIRED`. The receiver seeds
 Cross-cluster mesh egress is **authenticated-only** — no `federation:operator`
 relation is required to use the mesh proxy.
 
-:::note Choosing an identity mode
-This pairing uses the default source-trusted `peer_kc` mode. To pair with the
-receiver-controlled **`shared_idp`** mode instead, supply `shared_issuer_url`
-(plus `shared_jwks_url` / `shared_ca_pem`) when you **create** the federation
-(Step 2). The mode cannot be changed later without re-pairing. See
-[Identity Trust Modes](./identity-trust-modes.md).
+:::warning Choose an identity mode before pairing
+The steps above create a source-trusted **`peer_kc`** federation. On a stock
+cluster that is **refused with HTTP 400** unless the operator has set
+`ALLOW_UNTRUSTED_FEDERATION=true` (it defaults to `false`).
+
+To pair in the receiver-controlled **`shared_idp`** mode instead, the **receiver**
+supplies `shared_issuer_url` (plus `shared_jwks_url` / `shared_ca_pem`) when it
+**creates its own federation row** — each cluster stamps its mode from what it was
+given at create, and the mode is grantor-decided. The receiver must **also** have
+the shared realm's issuer enrolled in its trusted-shared-issuers list
+(`scheduler.trustedSharedIssuers`), which is empty and fail-closed by default —
+otherwise the caller's token is rejected with `403`.
+
+The identity mode cannot be changed later without deleting and re-pairing. Full
+details and the recommended flow: [Identity Trust Modes](./identity-trust-modes.md).
 :::
 
 ## Step 4: Store Remote CA Certificate

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -118,9 +118,18 @@ curl -sk -X POST "https://<LOCAL_IP>/api/cluster/federations/<FEDERATION_ID>/pai
 # Response: status should be "PAIRED"
 ```
 
-On success, both clusters transition to `PAIRED` and ReBAC relations are seeded:
-- **Source cluster**: `federation:{id}:operator` for the admin who paired
-- **Target cluster**: `cluster_jobs:__all__:executor` for the remote admin
+On success, both clusters transition to `PAIRED`. The receiver seeds
+`cluster_jobs:__all__:executor` for the remote admin so federated jobs can run.
+Cross-cluster mesh egress is **authenticated-only** — no `federation:operator`
+relation is required to use the mesh proxy.
+
+:::note Choosing an identity mode
+This pairing uses the default source-trusted `peer_kc` mode. To pair with the
+receiver-controlled **`shared_idp`** mode instead, supply `shared_issuer_url`
+(plus `shared_jwks_url` / `shared_ca_pem`) when you **create** the federation
+(Step 2). The mode cannot be changed later without re-pairing. See
+[Identity Trust Modes](./identity-trust-modes.md).
+:::
 
 ## Step 4: Store Remote CA Certificate
 
@@ -169,8 +178,8 @@ Disconnecting immediately blocks new mesh proxy requests. Running operations on 
 |---------|-------|-----|
 | 502 `mesh_proxy_bad_gateway` | TLS verification failed | Store remote CA cert (Step 4) or add IP to gateway cert SANs |
 | 401 on remote cluster | Mesh HMAC verification failed | Check PSK matches; check Istio `includeRequestHeadersInCheck` includes `x-kz-mesh-*` headers |
-| 403 `rebac_denied` on source | User lacks `federation:operator` relation | Re-pair the federation (seeding happens at pair time) |
+| 403 on source before the request forwards | Cross-cluster egress is authenticated-only in 1.1 — there is no `federation:operator` gate; a 403 here means the caller is not authenticated | Ensure the caller presents a valid token to the source cluster |
 | 403 `namespace_unsupported` | `federation` namespace not registered | Ensure `authz/constants.py` includes `federation` in `ALLOWED_OBJECT_NAMESPACES` |
 | 400 `missing_object_id` | Cluster selector did not resolve to a PAIRED federation (unknown name/UUID, a local-cluster selector, or a non-PAIRED federation). The mesh guard's id-resolver (`mesh/guards.py resolve_federation_id`) returns `None`, so `@guarded` raises this *before* the route runs — the service-layer `mesh_target_not_found` (404) / `mesh_target_is_local` (400) codes are never reached on this path (ENG-7520). | Check federation status; selector must match a PAIRED federation by name, UUID, or prefix |
-| 403 `not_authorized_to_probe_cluster` on `/api/cluster/cluster_capabilities` | Mesh-origin capabilities probe lacks a `cluster:<local_uuid>` viewer grant — federation pairing seeds `federation:operator` only, **not** `cluster:viewer` (ENG-7892) | Grant the federated subject the `cluster:<local_uuid>` viewer relation explicitly before probing |
+| 403 `not_authorized_to_probe_cluster` on `/api/cluster/cluster_capabilities` | Mesh-origin capabilities probe lacks a `cluster:<local_uuid>` viewer grant, which federation pairing does not seed (ENG-7892) | Grant the federated subject the `cluster:<local_uuid>` viewer relation explicitly before probing |
 | 307 redirect | Missing trailing slash | Add `/` to the API path |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -71,6 +71,7 @@ const sidebars: SidebarsConfig = {
 			label: "Federation",
 			items: [
 				"federation/overview",
+				"federation/identity-trust-modes",
 				"federation/setup",
 				"federation/retrieval",
 				"federation/job-submission",


### PR DESCRIPTION
External customer docs for the shipped 1.1 federated-identity-isolation feature — closes ENG-8581 (CloseFeature Gate 3). New identity-trust-modes.md; corrects overview/setup/api-reference/operations/retrieval which described the pre-1.1 model (federation:operator egress gate + source-header identity, both changed in 1.1). Every specific claim source-grounded (kamiwaza code + canonical spec) and adversarially verified against source. Held for review. Base=develop (federation docs live on develop; main is behind).