### PR TITLE
ENG-8752: Point version banner GA link at 1.0.1

### DIFF
--- a/docs/src/theme/DocVersionBanner/index.tsx
+++ b/docs/src/theme/DocVersionBanner/index.tsx
@@ -20,7 +20,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is the next release of Kamiwaza. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.0</b></Link>.
+          <Link to="/"><b>1.0.1</b></Link>.
         </div>
       </div>
     );
@@ -38,7 +38,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is no longer actively maintained. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.0</b></Link>.
+          <Link to="/"><b>1.0.1</b></Link>.
         </div>
       </div>
     );


### PR DESCRIPTION
## What

Points the `DocVersionBanner` GA links at **1.0.1**. Addresses the High-priority finding on #178.

## Why

The unreleased/unmaintained version banner (`docs/src/theme/DocVersionBanner/index.tsx:23,41`) hardcoded `1.0.0` as the current GA release (from ENG-8031 / #171). Now that 1.0.1 is the latest published version served at `/`, older version pages were telling readers to switch to **1.0.0** even though root docs serve **1.0.1**. Both banner links now read `1.0.1`.

Two-line label change only — matches the existing hardcode-per-release pattern; the `to="/"` target (always the latest) is unchanged.

## Flow

Targets `release/1.0.1`. Once merged, **#178 (`release/1.0.1` → `main`) picks this up automatically** (its head is `release/1.0.1`), so the published site gets the corrected banner. The banner is a shared theme file (not versioned), so this one change fixes it across all version pages.

_Note: this leaves the banner still hardcoded, so it'll need the same bump next release. A follow-up could derive the label from `versions.json` to make it self-updating — out of scope here._
