### PR TITLE
ENG-9084: derive DocVersionBanner GA link from Docusaurus version data

### DIFF
--- a/docs/src/theme/DocVersionBanner/index.tsx
+++ b/docs/src/theme/DocVersionBanner/index.tsx
@@ -2,8 +2,39 @@ import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
+import {
+  useActivePlugin,
+  useDocsPreferredVersion,
+  useDocsVersion,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocVersionBanner';
+
+// Link to the current GA release, resolved from Docusaurus' own version data
+// (the configured `lastVersion`) instead of a hardcoded version string. This
+// mirrors upstream theme-classic's DocVersionBanner: it stays correct per docs
+// plugin (default/sdk/extensions/research), derives label and href from the
+// same version object so they can't drift, and preserves the preferred-version
+// side effect on click. See ENG-9084.
+function CurrentGaReleaseLink(): React.ReactNode {
+  const {pluginId} = useActivePlugin({failfast: true})!;
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+
+  // Prefer the same doc in the latest version; fall back to its main doc.
+  const getVersionMainDoc = (version: typeof latestVersionSuggestion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
+  const target = latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <Link
+      to={target.path}
+      onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}>
+      <b>{latestVersionSuggestion.label}</b>
+    </Link>
+  );
+}
 
 export default function DocVersionBanner({className}: Props): React.ReactNode {
   const versionMetadata = useDocsVersion();
@@ -20,7 +51,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is the next release of Kamiwaza. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.1</b></Link>.
+          <CurrentGaReleaseLink />.
         </div>
       </div>
     );
@@ -38,7 +69,7 @@ export default function DocVersionBanner({className}: Props): React.ReactNode {
         <div>
           This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
           is no longer actively maintained. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.1</b></Link>.
+          <CurrentGaReleaseLink />.
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Follow-up from the **PR #181** review (Medium 2). The `DocVersionBanner` swizzle
hardcoded the current GA version string (`1.0.1`) in two places and a `to="/"`
link — requiring a manual bump every release and prone to silent drift.

This resolves the target from Docusaurus' own version data instead, mirroring
upstream `theme-classic`'s `DocVersionBanner`.

## What changed

- `useActivePlugin` + `useDocVersionSuggestions` → the banner now resolves the
  latest version **per docs plugin** (default / sdk / extensions / research),
  not just the main-docs version list. (The reviewer's literal suggestion —
  `versions.json[0]` — would have shown the *main* version on SDK/extensions
  archived pages, and `sdk_versions.json` already diverges from `versions.json`.)
- **Label and href come from the same `latestVersionSuggestion` object**, so
  they can't disagree. The link now deep-links to the *same doc* in the latest
  version (`latestDocSuggestion`), falling back to that version's main doc —
  previously every banner linked to the site root.
- Restores the `savePreferredVersionName` side effect on click.
- Custom Kamiwaza copy and the two alert styles (`--warning` for unreleased,
  `--secondary` for unmaintained) are preserved.

## Note

The link label is now Docusaurus' configured version label (e.g.
`1.0.1 (Latest)`) rather than the bare `1.0.1` — consistent with the version
dropdown site-wide.

## Validation

- Full `docs` build passes (`npm run build`, exit 0). Banner renders correctly
  on archived pages — e.g. `/0.9.3/quickstart` shows *"For the current GA
  release, see **1.0.1 (Latest)**"* linking to `/quickstart` (same doc, latest
  version). Only pre-existing broken-anchor warnings in unrelated blog/archived
  docs remain.
- Quality-gates pre-push: `frontend` gate passed; Python gates skipped (no
  relevant changes).

Docs-only; no deployment until merged to `develop`.

Linear: ENG-9084
