### PR TITLE
docs(federation): reconcile public API and trust/onboarding contracts

### DIFF
--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -69,6 +69,29 @@ DELETE /api/cluster/federations/{federation_id}
 
 Tears down the federation. Removes ReBAC grants and cleans up the pre-shared key.
 
+### Rotate the Pre-Shared Key
+
+```
+POST /api/cluster/federations/{federation_id}/rotate-preshared-key
+```
+
+Mints a new pre-shared key and returns it **once**. The outgoing key keeps
+verifying until the rotation is completed, so the mesh stays up while you deliver
+the new value to the peer's operator out of band. Requires admin role.
+
+```
+POST /api/cluster/federations/{federation_id}/complete-key-rotation
+{ "acknowledged": true }
+```
+
+Retires the outgoing key, ending the rotation. `acknowledged` is required because
+this step breaks any peer still signing with the old key, and the cluster cannot
+observe whether the peer has adopted the new one.
+
+Because the key is symmetric, replacing it on one side alone would sever the mesh
+immediately — rotation exists to provide the window in which both keys are valid.
+Do not edit the stored secret directly.
+
 ### Ping a Federation
 
 ```

--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -17,7 +17,10 @@ Manage cluster federation pairing and cluster metadata.
 GET /api/cluster/federations
 ```
 
-Returns all federations the current user has operator or viewer access to.
+Returns federations visible to an authenticated native-realm administrator.
+The optional `status` query parameter accepts `PAIRING`, `PAIRED`,
+`DISCONNECTED`, or `DELETED`; `skip` and `limit` provide pagination. This is
+not a per-user ReBAC-filtered list.
 
 **Response:**
 ```json
@@ -29,37 +32,65 @@ Returns all federations the current user has operator or viewer access to.
     "callback_hostname": "string",
     "local_cluster_id": "uuid",
     "remote_cluster_id": "uuid",
-    "status": "PAIRED | PAIRING | FAILED",
+    "status": "PAIRING | PAIRED | DISCONNECTED | DELETED",
     "last_ping": "timestamp",
     "created_at": "timestamp"
   }
 ]
 ```
 
-### Create and Pair a Federation
+### Get or Update a Federation
 
 ```
-POST /api/cluster/federations
-POST /api/cluster/federations/{federation_id}/pair
+GET /api/cluster/federations/{federation_id}
+PUT /api/cluster/federations/{federation_id}
 ```
 
-Create the receiver's `WAITING` record first, then the initiator record. Call
-`/{federation_id}/pair` on the initiator to drive the signed handshake and CA
-exchange. Both endpoints require a native-realm administrator.
+Both operations require an authenticated native-realm administrator. `GET`
+returns the complete federation record. `PUT` accepts the mutable connection
+metadata (for example `remote_ips`, `callback_hostname`, and the display name)
+and returns the updated record; trust mode and terminal status are not mutable
+through this endpoint.
+
+### Create and Pair a Federation (legacy flow)
+
+```
+POST /api/cluster/federations/pair
+```
+
+This compatibility endpoint completes rows created by the older symmetric
+wizard. New deployments should use the request/approve flow below. It requires
+a native-realm administrator and exchanges the peer CA/trust material.
 
 **Request:**
 ```json
 {
-  "remote_cluster_name": "fed-b",
-  "remote_ips": [
-    {"ip": "10.0.0.12", "hostname": "fed-b.example.internal", "primary": true}
-  ],
-  "preshared_key": "read-from-private-input",
-  "role": "initiator",
-  "shared_issuer_url": "https://idp.example.internal/realms/federation",
-  "shared_jwks_url": "https://idp.example.internal/realms/federation/protocol/openid-connect/certs"
+  "remote_cluster_name": "string",
+  "remote_ips": ["192.168.50.168"],
+  "local_ca_cert": "-----BEGIN CERTIFICATE-----\n..."
 }
 ```
+
+### Request, Approve, and Poll (current flow)
+
+The current flow keeps the receiver in control of identity trust and admission:
+
+```
+POST /api/cluster/federations/request
+POST /api/cluster/federations/{federation_id}/approve
+POST /api/cluster/federations/{federation_id}/deny
+GET  /api/cluster/federations/{federation_id}/request-status
+```
+
+The initiator submits a request with its remote address and a freshly generated
+PSK. The receiver reviews the inert `REQUESTED` card, chooses `shared_idp` or
+`receiver_realm`, and supplies the out-of-band PSK before approving. The
+initiator polls `request-status`; it never treats a local row as paired until
+the signed completion succeeds. `deny` is terminal for that request.
+
+Use `POST /api/cluster/federations/generate-psk` to mint a new PSK without
+creating a federation row. PSKs are secrets: transmit them through an approved
+out-of-band channel and never place them in logs or source control.
 
 ### Unpair a Federation
 
@@ -69,24 +100,65 @@ DELETE /api/cluster/federations/{federation_id}
 
 Tears down the federation. Removes ReBAC grants and cleans up the pre-shared key.
 
+### Disconnect and Reconnect
+
+```
+POST /api/cluster/federations/{federation_id}/disconnect
+POST /api/cluster/federations/{federation_id}/reconnect
+```
+
+`disconnect` is a reversible admission stop: it blocks new mesh requests while
+preserving the federation row, trust material, and receiver realm. `reconnect`
+is allowed only from `DISCONNECTED` and restores the local admission state.
+Neither operation deletes the federation; use `DELETE` for a soft delete.
+
+### Preflight, Diagnose, and Address Resolution
+
+```
+POST /api/cluster/federations/preflight
+POST /api/cluster/federations/{federation_id}/diagnose
+POST /api/cluster/federations/resolve-address
+```
+
+These native-admin endpoints validate a proposed route, diagnose a stored
+route, or derive the IP/hostname pair used by the pairing UI. They do not
+replace the pairing handshake or persist a federation by themselves.
+
 ### Rotate the Pre-Shared Key
 
 ```
 POST /api/cluster/federations/{federation_id}/rotate-preshared-key
 ```
 
-Mints a new pre-shared key and returns it **once**. The outgoing key keeps
-verifying until the rotation is completed, so the mesh stays up while you deliver
-the new value to the peer's operator out of band. Requires admin role.
+Mints K2 and returns the plaintext **once**, plus a non-secret fingerprint and
+generation. K1 remains active while the peer operator receives K2 out of band.
+Requires a native-realm administrator.
 
 ```
+POST /api/cluster/federations/{federation_id}/adopt-preshared-key-rotation
+{ "preshared_key": "<K2>", "fingerprint": "<sha256>" }
+```
+
+The peer operator adopts K2 without changing its active signer. The initiating
+operator then performs the peer-first cutover:
+
+```
+GET  /api/cluster/federations/{federation_id}/key-rotation-status
+POST /api/cluster/federations/{federation_id}/activate-key-rotation
+     { "fingerprint": "<K2 fingerprint>" }
 POST /api/cluster/federations/{federation_id}/complete-key-rotation
-{ "acknowledged": true }
+     { "fingerprint": "<K2 fingerprint>" }
 ```
 
-Retires the outgoing key, ending the rotation. `acknowledged` is required because
-this step breaks any peer still signing with the old key, and the cluster cannot
-observe whether the peer has adopted the new one.
+Activation proves possession of K2 at the peer before making it the local
+active signer. Completion retires K1 at the peer first, then removes the local
+alternate. `key-rotation-status` exposes phase, generation, and fingerprints,
+never plaintext keys. If a staged window must be abandoned before activation:
+
+```
+POST /api/cluster/federations/{federation_id}/abort-key-rotation
+{ "fingerprint": "<K2 fingerprint>", "generation": "<generation>" }
+```
 
 Because the key is symmetric, replacing it on one side alone would sever the mesh
 immediately — rotation exists to provide the window in which both keys are valid.
@@ -101,23 +173,60 @@ POST /api/cluster/federations/{federation_id}/ping
 Tests authenticated end-to-end connectivity through the signed peer path and
 returns `{ "federation_id": "...", "reachable": true }` on success.
 
-### Preflight and Diagnose
+### Federation User Allowlist and Guest Lifecycle
+
+These receiver-side operations require a native-realm administrator. They are
+not mesh-user enumeration endpoints.
 
 ```
-POST /api/cluster/federations/preflight
-POST /api/cluster/federations/{federation_id}/diagnose
-POST /api/cluster/federations/resolve-address
+POST /api/cluster/federations/{federation_id}/users
+GET  /api/cluster/federations/{federation_id}/users
+POST /api/cluster/federations/{federation_id}/users/{external_id}/revoke
+POST /api/cluster/federations/{federation_id}/users/{external_id}/restore
 ```
 
-Preflight probes a proposed route before persistence. Diagnose probes the
-stored route. Resolve-address derives the IP/FQDN complement used by the
-console pairing wizard. These endpoints are admin-only.
+The allowlist controls which source identities may be brokered. Revocation
+marks the receiver row disabled and rejects subsequent calls; `restore` reverses
+that exact allowlist mutation without changing the stored tuple recipe. A
+federation-wide `reconnect` restores access after a disconnect. A
+receiver-realm federation uses the guest endpoints:
+
+```
+POST /api/cluster/federations/{federation_id}/guests
+GET  /api/cluster/federations/{federation_id}/guests/{external_id}/attributes
+PUT  /api/cluster/federations/{federation_id}/guests/{external_id}/attributes
+POST /api/cluster/federations/{federation_id}/guests/{external_id}/revoke
+```
+
+Guest enrollment returns the receiver-issued offline credential once. Store it
+only in the source credential store; do not log or return it again. Attribute
+assignment is receiver-owned and is available only for `receiver_realm` guests.
+
+For a cross-federation administrative roster, use:
+
+```
+GET /api/cluster/federation-guests?with_attributes=true
+```
+
+For an admitted guest, receiver-owned ReBAC relations can be inspected or
+changed with:
+
+```
+GET    /api/cluster/federations/{federation_id}/users/{external_id}/relations
+POST   /api/cluster/federations/{federation_id}/users/{external_id}/relations
+DELETE /api/cluster/federations/{federation_id}/users/{external_id}/relations
+```
+
+Relation mutation bodies contain `object_namespace`, `object_id`, and
+`relation`; privileged/admin relations are rejected by the service layer.
 
 ---
 
 ## Mesh Proxy
 
-The mesh proxy forwards requests to remote federated clusters. Every request is HMAC-signed and ReBAC-gated.
+The mesh proxy forwards requests to remote federated clusters. Every request is
+HMAC-signed; the receiver applies identity-mode validation, allowlisting,
+ReBAC, and attribute gates.
 
 ### Proxy Path Pattern
 
@@ -154,8 +263,8 @@ by the **receiving** cluster (its allowlist, per-resource ReBAC, and per-record 
 | `X-KZ-Mesh-Signature` | HMAC-SHA256 | Verified on the remote cluster |
 | `X-KZ-Mesh-Signature-Ts` | Unix timestamp | Replay protection (5-minute window) |
 | `X-KZ-Mesh-Correlation-Id` | Per-request UUID | Observability tracing |
-| `X-KZ-Mesh-Peer-Token` | Caller's bearer token | Validated by the receiver in receiver-controlled identity modes and hashed into the signed envelope |
-| `X-KZ-Mesh-User-Attributes` | Source's `X-User-Attributes` | Source-asserted attributes (ignored in receiver-controlled modes) |
+| `X-KZ-Mesh-Peer-Token` | Caller bearer or receiver-realm credential | Receiver-side identity validation in receiver-controlled modes |
+| `X-KZ-Mesh-User-Attributes` | Source's `X-User-Attributes` | Source-asserted attributes (see note) |
 
 :::warning Identity-mode-dependent trust
 Whether the receiver **trusts** the source-asserted identity headers
@@ -168,8 +277,7 @@ headers are trusted only in source-trusted **`peer_kc`** / grandfathered mode.
 :::
 
 **Stripped before forwarding:**
-- `Authorization` (the value is carried in the dedicated peer-token field,
-  not as the receiver's normal bearer header)
+- `Authorization` (the local token is not valid on the remote cluster)
 - `Cookie`
 - `Proxy-*` headers
 
@@ -188,9 +296,9 @@ headers are trusted only in source-trusted **`peer_kc`** / grandfathered mode.
 | Status | Condition |
 |--------|-----------|
 | `401` | Local auth failed (invalid JWT / PAT) |
-| `403` `rebac_denied` | The **receiver's** per-resource ReBAC blocks the operation (there is no source-side `federation:operator` egress gate in 1.1) |
-| `400` / `404` | Invalid route, local target, or no exact paired federation |
-| `502` `mesh_proxy_bad_gateway` | Receiver connection, TLS, or upstream gateway failure |
+| `403` `rebac_denied` | The **receiver's** per-resource ReBAC blocks the operation (there is no source-side `federation:operator` egress gate in the current flow) |
+| `400` / `404` | Invalid route, local target, or no paired federation |
+| `502` `mesh_proxy_bad_gateway` | Remote connection, TLS, or upstream gateway failure |
 | `504` `mesh_proxy_timeout` | Remote request exceeded the proxy timeout |
 | `508` | Mesh hop/loop limit exceeded |
 
@@ -214,26 +322,13 @@ Submits a job to Ray and returns immediately. Poll `/status` or `/result` to tra
   "cluster_selector": "local" | "federation_name",
   "entrypoint": "python analysis.py",
   "runtime_env": {
-    "env_vars": {"KEY": "value"}
+    "env_vars": {"KEY": "value"},
+    "working_dir": "s3://..."
   },
   "metadata": {"label": "value"},
-  "timeout_seconds": 300,
-  "delegated_access": {
-    "datasets": [
-      {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,orders,PROD)",
-        "operations": ["discover", "retrieve"]
-      }
-    ],
-    "models": []
-  },
-  "python_packages": ["humanize==4.13.0"]
+  "timeout_seconds": 300
 }
 ```
-
-`runtime_env` accepts environment variables only. Delegated jobs may request
-exact package versions from the receiver's approved package catalog; arbitrary
-Ray `pip`, `working_dir`, `py_modules`, and `conda` settings are stripped.
 
 **Response:**
 ```json
@@ -258,10 +353,9 @@ Submits the job, polls until completion (or timeout), extracts the result marker
 ```json
 {
   "id": "uuid",
-  "status": "SUCCEEDED" | "FAILED" | "STOPPED",
+  "status": "SUCCEEDED" | "FAILED" | "TIMEOUT" | "CANCELLED",
   "result": { ... },
   "duration_seconds": 3.1,
-  "timed_out": false,
   "error_message": "string | null"
 }
 ```
@@ -326,7 +420,7 @@ This grants a relation to a **local** user — one with an account on the cluste
 
 | Scenario | Namespace | Relation | Notes |
 |----------|-----------|----------|-------|
-| Manage a federation (admin) | `federation` | `operator` | Federation **management** endpoints. **Not** required to call `/api/mesh/{fed}/*` — mesh egress is authenticated-only in 1.1 |
+| Manage a federation (admin) | `federation` | `operator` | Federation **management** endpoints. **Not** required to call `/api/mesh/{fed}/*` — mesh egress is authenticated-only in the current flow |
 | Local user can query a dataset | `dataset` | `viewer` | For native (non-mesh) retrieval on this cluster |
 | User can submit jobs | `cluster_jobs` | `executor` | Object id is the constant `"__all__"` |
 | User can own a dataset | `dataset` | `owner` | Can write and manage |

--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -122,10 +122,21 @@ The mesh proxy forwards requests to remote federated clusters. Every request is 
 ### Proxy Path Pattern
 
 ```
-{METHOD} /api/mesh/{federation_name}/{remote_path}
+{METHOD} /api/mesh/{federation_selector}/{remote_path}
 ```
 
-The `{federation_name}` is the `remote_cluster_name` from the federation record. The `{remote_path}` is the path on the remote cluster (without the `/api` prefix — it's re-added by the proxy).
+`{federation_selector}` accepts an exact federation UUID, an exact remote cluster
+UUID, or the federation record's `remote_cluster_name` as an exact or prefix
+match. Use the federation UUID for automation. A name or prefix that matches
+multiple paired rows returns `409 mesh_target_ambiguous` instead of choosing a
+peer.
+
+`remote_cluster_name` is the peer label stored when the federation is created
+or paired. Ping does not refresh it after a peer rename. The cached old name
+and federation UUID continue to work; re-pairing adopts the new display name.
+
+`{remote_path}` is the path on the remote cluster. The proxy adds `/api` when
+the path does not already begin with `/api` or `/runtime`.
 
 **Authorization:** Mesh egress is **authenticated-only** — any authenticated local
 user may call `/api/mesh/{fed}/*`. There is **no** `federation:operator` gate on the

--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -5,7 +5,16 @@ title: API Reference
 
 # Federation API Reference
 
-Complete reference for the mesh proxy and federation endpoints. All endpoints require authentication via Keycloak JWT or PAT.
+Reference for the public federation-management and mesh-proxy contracts. The
+examples below use the `/api` prefix. Management routes are versioned with the
+1.2 contract; the receiver-realm and per-user onboarding routes are the current
+1.3 federation extension. The peer-protocol routes under
+`/api/cluster/remote/*` are included for troubleshooting but are not intended
+for direct user calls.
+
+Unless a row says otherwise, a user-facing route accepts a Keycloak JWT or PAT.
+`NativeRealmRequired` means the credential must be issued by this cluster's
+native realm; a mesh-forwarded credential is rejected before the handler runs.
 
 ## Federation Management
 
@@ -17,7 +26,9 @@ Manage cluster federation pairing and cluster metadata.
 GET /api/cluster/federations
 ```
 
-Returns federations visible to an authenticated native-realm administrator.
+Returns federations visible to any authenticated native-realm user. The route
+does not apply a per-user federation ReBAC relation filter; management writes
+remain administrator-only.
 The optional `status` query parameter accepts `PAIRING`, `PAIRED`,
 `DISCONNECTED`, or `DELETED`; `skip` and `limit` provide pagination. This is
 not a per-user ReBAC-filtered list.
@@ -55,21 +66,32 @@ through this endpoint.
 ### Create and Pair a Federation (legacy flow)
 
 ```
-POST /api/cluster/federations/pair
+POST /api/cluster/federations
+POST /api/cluster/federations/{federation_id}/pair
 ```
 
-This compatibility endpoint completes rows created by the older symmetric
-wizard. New deployments should use the request/approve flow below. It requires
-a native-realm administrator and exchanges the peer CA/trust material.
+The first endpoint creates one half of the deprecated symmetric pairing. The
+second completes the returned row and exchanges the peer CA/trust material.
+Both require a native-realm administrator. New deployments should use the
+request/approve flow below; legacy creation may be refused when
+`ALLOW_UNTRUSTED_FEDERATION` is disabled.
 
-**Request:**
+**Legacy create request (representative):**
 ```json
 {
-  "remote_cluster_name": "string",
-  "remote_ips": ["192.168.50.168"],
-  "local_ca_cert": "-----BEGIN CERTIFICATE-----\n..."
+  "remote_cluster_name": "peer-name",
+  "remote_ips": [{"ip": "<PEER_IP>", "hostname": "<PEER_FQDN>", "primary": true}],
+  "callback_hostname": "<THIS_CLUSTER_FQDN>",
+  "preshared_key": "<PSK_FROM_PRIVATE_FILE>",
+  "role": "initiator"
 }
 ```
+
+The pair request body is a `FederationPairRequest` containing the local CA
+material required by the legacy handshake. The API returns `400` for invalid
+or unsupported mode input, `403` for a non-admin/non-native caller, `404` for
+an unknown federation, and `409` when the row is already paired or otherwise
+in a conflicting state.
 
 ### Request, Approve, and Poll (current flow)
 
@@ -173,6 +195,38 @@ POST /api/cluster/federations/{federation_id}/ping
 Tests authenticated end-to-end connectivity through the signed peer path and
 returns `{ "federation_id": "...", "reachable": true }` on success.
 
+### Realm cleanup
+
+```
+POST /api/cluster/federations/realms/reclaim?dry_run=true&include_disconnected=false
+```
+
+Native-realm administrators can list receiver-owned realms that no longer have
+an active federation. `dry_run=true` (the default) returns the orphan report;
+set it to `false` only after reviewing that report. Disconnected federations are
+excluded unless `include_disconnected=true`. A `403` means the caller is not a
+native administrator; a `409`/`500` indicates a reclamation conflict or cleanup
+failure. Realm reclamation is destructive and cannot be undone.
+
+### Management authorization and status matrix
+
+| Routes | Caller | Success / representative refusal |
+|---|---|---|
+| `GET /federations` | Any authenticated **native-realm** user | `200`; `401` unauthenticated, `403` mesh-origin |
+| `GET/PUT/DELETE /federations/{id}` | Native-realm administrator | `200`; `404` unknown id, `409` invalid lifecycle, `403` non-admin or mesh-origin |
+| `POST /federations`, `POST /federations/{id}/pair` (deprecated) | Native-realm administrator | `200`; `400` validation/policy refusal, `404` unknown id, `409` state conflict |
+| `POST /federations/generate-psk`, `/request`, `/{id}/approve`, `/{id}/deny`, `/{id}/request-status` | Native-realm administrator | `200`; `400` validation, `404` unknown request, `409` request state conflict, `502` peer failure |
+| `POST /federations/preflight`, `/resolve-address`, `/{id}/diagnose`, `/{id}/ping` | Native-realm administrator | `200`; `400` invalid route, `404` unknown id, `502`/`504` peer reachability failure |
+| `POST /federations/{id}/disconnect`, `/reconnect`, `/refresh-peer-ca` | Native-realm administrator | `200`; `400` invalid input, `404` unknown id, `409` lifecycle/fingerprint conflict |
+| `POST /federations/{id}/rotate-preshared-key`, `/adopt-preshared-key-rotation`, `/abort-key-rotation`, `/activate-key-rotation`, `/complete-key-rotation`; `GET .../key-rotation-status` | Native-realm administrator | `200`; `404` unknown id, `409` rotation state/fingerprint conflict, `502` peer refusal/unavailability |
+| `POST/GET /federations/{id}/users*`, guest and relation routes | Native-realm administrator | `200`; `400` invalid relation/body, `404` unknown federation/user, `409` concurrent or lifecycle conflict |
+| `POST /federations/{id}/onboarding/request`, `GET .../onboarding/me`, claim/status/recover | Authenticated caller, scoped to their own identity | `200`; `403` unauthorized delegation, `404` unknown request, `409` already claimed/conflict |
+| `GET .../onboarding`, onboarding approve/deny | Native-realm administrator | `200`; `404` unknown request, `409` request conflict |
+
+Validation failures use FastAPI's `422` response when the JSON shape cannot be
+parsed. A `500` is reserved for an unexpected server failure; clients should
+not interpret it as a successful federation transition.
+
 ### Federation User Allowlist and Guest Lifecycle
 
 These receiver-side operations require a native-realm administrator. They are
@@ -219,6 +273,61 @@ DELETE /api/cluster/federations/{federation_id}/users/{external_id}/relations
 
 Relation mutation bodies contain `object_namespace`, `object_id`, and
 `relation`; privileged/admin relations are rejected by the service layer.
+
+### Per-user onboarding
+
+Receiver-realm and shared-IDP federations use the same self-service/requester
+surface. The requester can see only their own state; the receiver administrator
+controls admission and denial.
+
+```
+POST /api/cluster/federations/{federation_id}/onboarding/request
+GET  /api/cluster/federations/{federation_id}/onboarding
+GET  /api/cluster/federations/{federation_id}/onboarding/me
+POST /api/cluster/federations/{federation_id}/onboarding/{request_id}/approve
+POST /api/cluster/federations/{federation_id}/onboarding/{request_id}/deny
+POST /api/cluster/federations/{federation_id}/onboarding/claim
+GET  /api/cluster/federations/{federation_id}/onboarding/claims/{attempt_id}
+POST /api/cluster/federations/{federation_id}/onboarding/claims/{attempt_id}/recover
+```
+
+`request` accepts a justification/contact and, for an administrator acting for
+another local user, an explicit `external_id`. `approve` may carry the
+receiver-owned attributes and relation recipe; it never accepts authority from
+the source cluster. `claim` exchanges a one-time claim token for the durable
+credential and binds it to the calling user. `GET .../me`, claim status, and
+recovery never return a credential. Typical errors are `403` for an
+unauthorized delegated request, `404` for an unknown federation/request, and
+`409` for a request already approved, denied, or claimed.
+
+### Peer protocol (internal)
+
+These routes are mounted under `/api/cluster/remote`. They are called by a
+paired peer, not by a browser or SDK. Except for the initial request intake and
+the token-scoped poll, they require the authenticated federation HMAC/mTLS
+context (`TrustedFederatedCluster`).
+
+```
+POST /api/cluster/remote/federation-request                 # initial inert intake
+GET  /api/cluster/remote/federation-request/{request_token} # token-scoped poll
+POST /api/cluster/remote/pair
+POST /api/cluster/remote/onboarding-request
+POST /api/cluster/remote/onboarding-status
+POST /api/cluster/remote/onboarding-claim
+POST /api/cluster/remote/onboarding-claim-attempt
+POST /api/cluster/remote/onboarding-claim-status
+POST /api/cluster/remote/key-rotation-activate
+POST /api/cluster/remote/key-rotation-complete
+POST /api/cluster/remote/ping
+POST /api/cluster/remote/identity-status
+POST /api/cluster/remote/disconnect
+```
+
+The unauthenticated intake is bounded and creates only a `REQUESTED` record; it
+does not accept a PSK or trust configuration. The request-token poll is scoped
+to that one non-secret token. Peer-protocol failures return structured `4xx`
+responses (invalid HMAC, replay, unknown federation, or state conflict); the
+caller should not retry a refusal as if it were a successful transition.
 
 ---
 
@@ -280,6 +389,24 @@ headers are trusted only in source-trusted **`peer_kc`** / grandfathered mode.
 - `Authorization` (the local token is not valid on the remote cluster)
 - `Cookie`
 - `Proxy-*` headers
+
+### Terminal response proof headers
+
+When the receiver rejects a caller because its guest or brokered-user admission
+is revoked, it signs the exact status and response body before returning it.
+The source proxy uses these headers to verify the refusal before purging only
+that caller's durable federation credential:
+
+| Header | Meaning |
+|---|---|
+| `X-KZ-Mesh-Response-Signature` | HMAC proof over status, body, timestamp, correlation id, and request signature |
+| `X-KZ-Mesh-Response-Signature-Ts` | Proof timestamp; checked against the same replay window |
+| `X-KZ-Mesh-Response-Correlation-Id` | Correlation id bound to the original request |
+| `X-KZ-Mesh-Response-Request-Signature` | Exact request signature bound into the proof |
+
+Ingress/ext-authz configuration must preserve these four response headers on the
+return path. Missing, malformed, stale, or tampered proof headers never trigger
+credential deletion; the proxy returns the upstream refusal without purging.
 
 ### Common Proxied Endpoints
 

--- a/docs/docs/federation/identity-trust-modes.md
+++ b/docs/docs/federation/identity-trust-modes.md
@@ -10,13 +10,15 @@ presents to the remote cluster, and how the remote cluster verifies it.** This i
 the federation's **identity mode** — a per-federation setting chosen by the
 cluster that receives the calls (the *grantor*).
 
-Kamiwaza 1.2 ships three identity modes:
+The 1.2 baseline supports `shared_idp` and the legacy `peer_kc` posture. The
+current federation extension (targeting 1.3) adds `receiver_realm` and its
+receiver-owned guest lifecycle:
 
 | Mode | Trust | Who validates the caller | Use when |
 |---|---|---|---|
 | **`shared_idp`** | Receiver-controlled | The receiver validates the caller's token against a **shared realm** both clusters trust | Both clusters can trust one shared identity provider (single operator, or a tightly-coupled pair) |
 | **`peer_kc`** | Source-trusted (legacy 1.0) | The receiver validates against the **peer cluster's own** Keycloak realm | Grandfathered pairings, or when you explicitly accept the source cluster as an identity authority |
-| **`receiver_realm`** | Receiver-controlled | The receiver provisions and validates a dedicated `federation-<id>` realm | Strong per-federation isolation with receiver-issued guest credentials |
+| **`receiver_realm`** *(1.3 extension)* | Receiver-controlled | The receiver provisions and validates a dedicated `federation-<id>` realm | Strong per-federation isolation with receiver-issued guest credentials |
 
 `receiver_realm` is the default trust mode for the current request/approve flow.
 It is scoped to `per_federation`; the receiver owns guest enrollment, attributes,

--- a/docs/docs/federation/identity-trust-modes.md
+++ b/docs/docs/federation/identity-trust-modes.md
@@ -10,12 +10,17 @@ presents to the remote cluster, and how the remote cluster verifies it.** This i
 the federation's **identity mode** — a per-federation setting chosen by the
 cluster that receives the calls (the *grantor*).
 
-Kamiwaza 1.2.0 ships two identity modes:
+Kamiwaza 1.2 ships three identity modes:
 
 | Mode | Trust | Who validates the caller | Use when |
 |---|---|---|---|
 | **`shared_idp`** | Receiver-controlled | The receiver validates the caller's token against a **shared realm** both clusters trust | Both clusters can trust one shared identity provider (single operator, or a tightly-coupled pair) |
 | **`peer_kc`** | Source-trusted (legacy 1.0) | The receiver validates against the **peer cluster's own** Keycloak realm | Grandfathered pairings, or when you explicitly accept the source cluster as an identity authority |
+| **`receiver_realm`** | Receiver-controlled | The receiver provisions and validates a dedicated `federation-<id>` realm | Strong per-federation isolation with receiver-issued guest credentials |
+
+`receiver_realm` is the default trust mode for the current request/approve flow.
+It is scoped to `per_federation`; the receiver owns guest enrollment, attributes,
+relations, revocation, and the one-time offline credential.
 
 ## Core principle: shared identity ≠ shared authority
 
@@ -44,7 +49,7 @@ authenticates against that shared realm and presents its token; the receiver
 validates that token against the realm's published keys (JWKS) before honoring
 the request.
 
-Per-federation configuration (set on the receiver at pairing time):
+Per-federation configuration (set by the receiver in the approve request):
 
 | Field | Purpose |
 |---|---|
@@ -52,12 +57,28 @@ Per-federation configuration (set on the receiver at pairing time):
 | `shared_jwks_url` | Where the receiver fetches the shared realm's signing keys to validate tokens. |
 | `shared_ca_pem` | (Optional) TLS trust root used to reach the shared realm's JWKS endpoint. |
 
+The issuer is required for `shared_idp`; the JWKS URL is derived when omitted.
+
 :::important
 Naming an issuer on a federation is **not sufficient** for the receiver to accept
 its tokens. The receiver only accepts a shared-realm token if that issuer is
 **enrolled in the cluster's trusted-shared-issuers list** (see
 [Cluster policy](#cluster-policy) below). An unenrolled issuer is rejected.
 :::
+
+## `receiver_realm` — receiver-controlled isolation
+
+The receiver provisions `federation-<federation_id>` in Keycloak after approval.
+An administrator enrolls each source identity through the guest API and receives
+an offline credential once. The source stores that credential encrypted and
+uses it for mesh calls; the receiver can revoke the guest at any time. Receiver
+attributes are assigned through the guest-attributes API and are evaluated by
+the receiver's gates. `realm_scope=per_federation` is currently the only built
+scope; unsupported scopes are rejected rather than silently mapped.
+
+The source's local roles and attribute headers are not authority in this mode:
+the receiver resolves the guest from its own realm and applies its own ReBAC
+and gate policy.
 
 ## `peer_kc` — source-trusted (legacy)
 
@@ -75,43 +96,25 @@ realm — it trusts the source cluster to be the identity authority. This is the
   from the `ALLOW_UNTRUSTED_FEDERATION` refusal, and surfaced as the weaker
   posture so operators can see which pairings rest on trusting the source.
 
-`peer_kc` remains supported in 1.2.0. It is not the recommended mode for a new
-pair, but it is not scheduled for removal. Keep it disabled unless the operator
-explicitly accepts the source-trusted posture.
-
-## Future: `receiver_realm` — receiver-owned guests
-
-The planned `receiver_realm` mode provisions and owns a separate guest identity
-for every approved remote user. Pairing will use a receiver-owned
-request/approve flow, and each user will complete an onboarding request that
-the receiver approves before issuing guest credentials.
-
-This mode is **not available in Kamiwaza 1.2.0**. Core rejects it with
-`identity_mode_unsupported`; do not select it for a 1.2 deployment. It remains
-the intended future pattern when clusters cannot share an issuer and the
-receiver must disable, rotate, or audit guest identities independently.
-
-The `shared_idp` setup in this guide does not exercise `receiver_realm`. Do not
-infer receiver-realm behavior from a shared-IDP pairing.
-
 ## Choosing and configuring a mode
 
 The **grantor** (the cluster receiving the calls) decides the mode from its own
 policy at pairing time. A requester may *propose* a mode, but an inbound proposal
 is not auto-trusted — the receiver's policy decides.
 
-The mode is selected implicitly by what you supply when you create the federation:
+The mode is selected by the receiver's `ApproveFederationRequest`:
 
-- **Supply `shared_issuer_url`** → the federation is `shared_idp`.
-- **Omit it on the legacy create path** → the federation is `peer_kc` (subject
-  to `ALLOW_UNTRUSTED_FEDERATION`).
-- **Do not select `receiver_realm` on 1.2.0** → the reserved value is rejected
-  until the receiver-owned guest-identity implementation is delivered.
+- **`identity_mode: receiver_realm`** (default) → dedicated receiver realm.
+- **`identity_mode: shared_idp`** plus `shared_issuer_url` → shared realm.
+- `peer_kc` is not accepted by the new request/approve schema; it remains only
+  for grandfathered or deprecated symmetric pairings and is subject to
+  `ALLOW_UNTRUSTED_FEDERATION` when newly created through that legacy path.
 
 :::warning
 **The identity mode cannot be changed in place.** Switching a federation between
-`peer_kc` and `shared_idp` requires **deleting and re-pairing** it. (Rotatable
-trust details, such as the shared JWKS URL, *can* be updated without re-pairing.)
+`peer_kc`, `shared_idp`, and `receiver_realm` requires **deleting and re-pairing**
+it. Rotatable trust details, such as the shared JWKS URL, can be updated without
+re-pairing when the mode permits it.
 :::
 
 See the [Setup Guide](./setup.md) for the concrete pairing steps.
@@ -124,7 +127,7 @@ the secure posture.
 
 | Setting | Deploy chart key | Default | Effect |
 |---|---|---|---|
-| `ALLOW_UNTRUSTED_FEDERATION` | `scheduler.allowUntrustedFederation` | `false` | When `false`, creating a **new** `peer_kc` (source-trusted) federation is refused. Existing pairings are grandfathered. |
+| `ALLOW_UNTRUSTED_FEDERATION` | `scheduler.allowUntrustedFederation` | `false` | When `false`, creating a **new legacy `peer_kc`** federation is refused. Existing pairings are grandfathered. The current request/approve flow does not create `peer_kc`. |
 | `AUTH_GATEWAY_TRUSTED_SHARED_ISSUERS` | `scheduler.trustedSharedIssuers` | *(empty)* | The comma-separated list of shared-realm issuer URLs this cluster will accept `shared_idp` tokens from. **Empty means no shared issuers are trusted** — a `shared_idp` token is rejected unless its issuer is on this list. |
 
 ## Next steps

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -47,78 +47,14 @@ for complete commands.
 
 ### Legacy compatibility pairing
 
-The commands below are retained only to drain old in-flight symmetric rows.
-They create the legacy `peer_kc` posture and should not be used for new
-deployments. Do not put real PSKs in documentation, shell history, tickets, or
-logs.
-
-**1. Authenticate to both clusters:**
-
-```bash
-# Remote cluster (the receiver)
-REMOTE_TOKEN=$(curl -sk "https://192.168.50.13/api/auth/token" -X POST \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'username=admin%40kamiwaza.localhost&password=kamiwaza&grant_type=password' \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
-
-# Local cluster (the initiator)
-LOCAL_TOKEN=$(curl -sk "https://kamiwaza.test/api/auth/token" -X POST \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'username=admin%40kamiwaza.localhost&password=kamiwaza&grant_type=password' \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
-```
-
-**2. Create WAITING receiver on the remote cluster:**
-
-```bash
-curl -sk -X POST "https://192.168.50.13/api/cluster/federations" \
-  -H "Authorization: Bearer $REMOTE_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "remote_cluster_name": "dev-laptop",
-    "remote_ips": [{"ip": "192.168.50.168", "primary": true}],
-    "preshared_key": "my-strong-shared-secret",
-    "callback_hostname": "192.168.50.13",
-    "role": "receiver"
-  }'
-```
-
-**3. Create PAIRING initiator on the local cluster:**
-
-```bash
-FEDERATION_RESPONSE=$(curl -sk -X POST "https://kamiwaza.test/api/cluster/federations" \
-  -H "Authorization: Bearer $LOCAL_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "remote_cluster_name": "studio-1",
-    "remote_ips": [{"ip": "192.168.50.13", "primary": true}],
-    "preshared_key": "my-strong-shared-secret",
-    "callback_hostname": "192.168.50.168"
-  }')
-
-FEDERATION_ID=$(echo "$FEDERATION_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
-echo "Federation ID: $FEDERATION_ID"
-```
-
-**4. Initiate pairing:**
-
-```bash
-curl -sk -X POST "https://kamiwaza.test/api/cluster/federations/$FEDERATION_ID/pair" \
-  -H "Authorization: Bearer $LOCAL_TOKEN"
-```
-
-**5. Store remote CA certificate:**
-
-```bash
-# Fetch the remote cluster's root CA (run on the remote cluster or via SSH)
-REMOTE_CA=$(kubectl get secret root-ca -n kamiwaza -o jsonpath='{.data.ca\.crt}' | base64 -d)
-
-# Store in federation record on the local cluster
-kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
-  "UPDATE cluster_federations SET remote_ca_cert = '$(echo "$REMOTE_CA" | sed "s/'/''/g")' WHERE id = '$FEDERATION_ID';"
-```
-
-Repeat the CA cert step in the other direction (store the local CA on the remote cluster's federation record).
+Rows created by the deprecated symmetric wizard are retained only to drain old
+in-flight work. They create the source-trusted `peer_kc` posture and may be
+refused when `ALLOW_UNTRUSTED_FEDERATION` is disabled. Follow the
+[legacy section of the setup guide](./setup.md#legacy-compatibility-drain-only)
+with native-realm administrator tokens and mode-`0600` request files. Never
+place a real PSK in shell history, tickets, logs, or this repository, and never
+edit federation or certificate columns directly in SQL. Use
+`refresh-peer-ca` for an authenticated CA replacement.
 
 ### Verifying Pairing Succeeded
 
@@ -309,7 +245,7 @@ per-resource ReBAC or per-record gate, not a missing source-side operator relati
 
 **Resolution:**
 
-- If `remote_ca_cert` is NULL: re-pair the federation, or manually inject the CA cert (see setup step 5).
+- If `remote_ca_cert` is NULL: re-pair the federation, or use the authenticated `refresh-peer-ca` endpoint with an independently verified CA fingerprint.
 - If the remote cert does not include the node IP: update the gateway certificate SANs (see [Federation Setup](./setup.md#add-node-ip-to-gateway-certificate)).
 
 ### Trailing Slash Redirects (307 -> auth loss)
@@ -375,7 +311,7 @@ timedatectl status
 | `RUNNING` | Actively executing on the Ray cluster |
 | `SUCCEEDED` | Completed successfully |
 | `FAILED` | Exited with an error |
-| `STOPPED` | Cancelled by user or timed out |
+| `STOPPED` | Canceled by user or timed out |
 
 ### Checking Job Status
 
@@ -436,7 +372,7 @@ curl -sk "https://kamiwaza.test/api/cluster/jobs/<job-id>/result" \
 
 When `timeout_seconds` is set on job submission and the job is executed via the synchronous `/run` endpoint, the platform polls Ray until the timeout elapses. If the job is still running at that point:
 
-1. The job is cancelled via the Ray Dashboard API
+1. The job is canceled via the Ray Dashboard API
 2. The `timed_out` flag is set to `true` in the `federated_jobs` table
 3. The job status transitions to `STOPPED`
 

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -7,34 +7,135 @@ title: Operations & Troubleshooting
 
 Operational runbook for federated mesh operations. Covers setup verification, common failure modes, job monitoring, and diagnostic queries.
 
-## 1. Pairing and first verification
+## 1. Federation Setup
 
-Use the receiver-controlled `shared_idp` workflow in the
-[Federation Setup](./setup.md) guide. Preflight both routes, create the
-receiver record first, create and pair the initiator, then onboard the shared
-subject on the receiver. The handshake exchanges platform CA trust; do not
-inject certificates or PSKs with SQL.
+### Prerequisites
 
-After both cards reach `PAIRED`, verify the exact record and route:
+Before attempting to pair two clusters, verify:
+
+1. **Both clusters run Istio** with `KAMIWAZA_ROUTING_PROVIDER=istio`
+2. **STRICT mTLS** is configured (`PeerAuthentication` in the `kamiwaza` namespace)
+3. **ReBAC is enabled** on both clusters
+4. **Network connectivity** exists between clusters on port 443
+5. **Gateway certs include node IPs** in Subject Alternative Names (SANs)
+6. **NTP is synchronized** on both clusters (clock skew must be under 300 seconds)
+
+### Recommended request/approve pairing
+
+For new federations, use the poll-not-push request flow. The initiator calls
+`POST /api/cluster/federations/generate-psk`, submits
+`POST /api/cluster/federations/request` with its reachable endpoints and the
+fresh PSK, and gives the PSK to the receiver operator through an approved
+out-of-band channel. The receiver reviews the `REQUESTED` row and calls
+`POST /api/cluster/federations/{id}/approve` with:
+
+```json
+{
+  "identity_mode": "receiver_realm",
+  "realm_scope": "per_federation",
+  "preshared_key": "<PSK_FROM_OUT_OF_BAND_CHANNEL>"
+}
+```
+
+Use `identity_mode: "shared_idp"` plus `shared_issuer_url` (and optional JWKS
+and CA fields) for a shared realm. The receiver's trusted issuer policy must
+contain that issuer. The initiator polls
+`GET /api/cluster/federations/{id}/request-status` until the signed handshake
+reports `PAIRED`; a refusal is structured and does not leave source credential
+rows behind. See the [setup guide](./setup.md#recommended-requestapprove-flow)
+for complete commands.
+
+### Legacy compatibility pairing
+
+The commands below are retained only to drain old in-flight symmetric rows.
+They create the legacy `peer_kc` posture and should not be used for new
+deployments. Do not put real PSKs in documentation, shell history, tickets, or
+logs.
+
+**1. Authenticate to both clusters:**
+
+```bash
+# Remote cluster (the receiver)
+REMOTE_TOKEN=$(curl -sk "https://192.168.50.13/api/auth/token" -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=admin%40kamiwaza.localhost&password=kamiwaza&grant_type=password' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+
+# Local cluster (the initiator)
+LOCAL_TOKEN=$(curl -sk "https://kamiwaza.test/api/auth/token" -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=admin%40kamiwaza.localhost&password=kamiwaza&grant_type=password' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+```
+
+**2. Create WAITING receiver on the remote cluster:**
+
+```bash
+curl -sk -X POST "https://192.168.50.13/api/cluster/federations" \
+  -H "Authorization: Bearer $REMOTE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "remote_cluster_name": "dev-laptop",
+    "remote_ips": [{"ip": "192.168.50.168", "primary": true}],
+    "preshared_key": "my-strong-shared-secret",
+    "callback_hostname": "192.168.50.13",
+    "role": "receiver"
+  }'
+```
+
+**3. Create PAIRING initiator on the local cluster:**
+
+```bash
+FEDERATION_RESPONSE=$(curl -sk -X POST "https://kamiwaza.test/api/cluster/federations" \
+  -H "Authorization: Bearer $LOCAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "remote_cluster_name": "studio-1",
+    "remote_ips": [{"ip": "192.168.50.13", "primary": true}],
+    "preshared_key": "my-strong-shared-secret",
+    "callback_hostname": "192.168.50.168"
+  }')
+
+FEDERATION_ID=$(echo "$FEDERATION_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+echo "Federation ID: $FEDERATION_ID"
+```
+
+**4. Initiate pairing:**
+
+```bash
+curl -sk -X POST "https://kamiwaza.test/api/cluster/federations/$FEDERATION_ID/pair" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
+```
+
+**5. Store remote CA certificate:**
+
+```bash
+# Fetch the remote cluster's root CA (run on the remote cluster or via SSH)
+REMOTE_CA=$(kubectl get secret root-ca -n kamiwaza -o jsonpath='{.data.ca\.crt}' | base64 -d)
+
+# Store in federation record on the local cluster
+kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
+  "UPDATE cluster_federations SET remote_ca_cert = '$(echo "$REMOTE_CA" | sed "s/'/''/g")' WHERE id = '$FEDERATION_ID';"
+```
+
+Repeat the CA cert step in the other direction (store the local CA on the remote cluster's federation record).
+
+### Verifying Pairing Succeeded
 
 ```bash
 # Check federation status
-curl --fail --silent --show-error \
-  --header "Authorization: Bearer $LOCAL_TOKEN" \
-  "$LOCAL_API/cluster/federations/$FEDERATION_ID" | jq \
-  '{id,status,identity_mode,trust_posture,remote_ips,shared_issuer_url}'
+curl -sk "https://kamiwaza.test/api/cluster/federations/$FEDERATION_ID" \
+  -H "Authorization: Bearer $LOCAL_TOKEN" | python3 -m json.tool
 
 # Expected: "status": "PAIRED"
 
 # Test cross-cluster connectivity by listing remote datasets
-curl --fail --silent --show-error \
-  --header "Authorization: Bearer $SHARED_USER_TOKEN" \
-  "$LOCAL_API/mesh/$FEDERATION_ID/api/catalog/datasets/" | jq .
+curl -sk "https://kamiwaza.test/api/mesh/studio-1/api/catalog/datasets/" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
 
 # Test remote model listing
-curl --fail --silent --show-error \
-  --header "Authorization: Bearer $SHARED_USER_TOKEN" \
-  "$LOCAL_API/mesh/$FEDERATION_ID/api/serving/deployments" | jq .
+curl -sk "https://kamiwaza.test/api/mesh/studio-1/api/serving/deployments" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
 ```
 
 ---
@@ -71,14 +172,19 @@ UUID continue to select the existing pair.
 
 **Diagnosis:**
 
-1. **Run the typed route diagnostic** -- do not read PSK material from the
-   database:
+1. **Check the rotation/status fingerprints** -- Never print or query the
+   plaintext PSK. Use the non-secret rotation status endpoint and compare the
+   active/alternate fingerprints on both clusters:
 
    ```bash
-   curl --fail --silent --show-error --request POST \
-     --header "Authorization: Bearer $LOCAL_TOKEN" \
-     "$LOCAL_API/cluster/federations/$FEDERATION_ID/diagnose" | jq .
+   curl --fail --silent --show-error -sk \
+     "https://<LOCAL_API>/api/cluster/federations/<FEDERATION_ID>/key-rotation-status" \
+     -H "Authorization: Bearer $LOCAL_TOKEN" | jq
    ```
+
+   Compare only fingerprints and generation with the remote operator. If the
+   active fingerprints differ, stop traffic and run the documented rotation or
+   disconnect/re-pair recovery; do not edit the secret catalog directly.
 
 2. **Check clock skew** -- The HMAC signature includes a timestamp. The receiving cluster rejects signatures older than 300 seconds (configurable via `auth_forward_header_signature_ttl_seconds`):
 
@@ -96,11 +202,37 @@ UUID continue to select the existing pair.
 
 **Resolution:**
 
-- If the diagnostic reports an HMAC or PSK failure: rotate the PSK through the
-  supported federation lifecycle, or disconnect and re-pair. Never compare or
-  copy stored secret references as if they were raw keys.
+- If fingerprints do not match: complete or abort the in-flight rotation, or
+  disconnect and re-pair through the supported request/approve flow.
 - If clock skew exceeds 300 seconds: synchronize NTP on both clusters.
 - If headers are missing from ext-authz config: update the Istio mesh config and restart the ext-authz pod.
+
+### PSK rotation and recovery
+
+Rotation is a peer-first, zero-outage sequence:
+
+1. On the initiator, `POST /federations/{id}/rotate-preshared-key`; deliver the
+   returned K2 and fingerprint out of band.
+2. On the peer, `POST /federations/{id}/adopt-preshared-key-rotation` with K2 and
+   its fingerprint.
+3. On the initiator, `POST /federations/{id}/activate-key-rotation` with the
+   fingerprint. Core proves peer possession before changing its active signer.
+4. After both directions use K2, `POST /federations/{id}/complete-key-rotation`
+   with the fingerprint to retire K1.
+
+Use `GET /federations/{id}/key-rotation-status` for non-secret phase,
+generation, and fingerprint recovery. If K2 is still only `STAGED`, abort with
+`POST /federations/{id}/abort-key-rotation` and the fingerprint + generation.
+Never paste a plaintext key into logs or inspect it through SQL.
+
+### Receiver-realm revocation and credential recovery
+
+Revoking a receiver guest (or a brokered allowlist user) causes the receiver to
+return `403` with `reason: revoked_guest` or `revoked_brokered_user`. The source
+mesh proxy purges only that caller's `(source_user, federation)` credential;
+other users' credentials are untouched. A later onboarding request can mint a
+new credential. `guest_approval_incomplete` is deliberately non-terminal and
+does not purge custody.
 
 ### ReBAC Denied (403 rebac_denied)
 
@@ -139,9 +271,9 @@ curl -sk -X POST "https://<TARGET_IP>/api/cluster/federations/<FEDERATION_ID>/us
   }'
 ```
 
-:::note No longer needed in 1.1
+:::note No longer needed in the current flow
 Earlier releases required a `federation:operator` relation on the source cluster to
-use the mesh proxy. In 1.1 the mesh egress is **authenticated-only** — that grant is
+use the mesh proxy. The mesh egress is **authenticated-only** — that grant is
 no longer required, and a mesh `403` now originates from the **receiver's**
 per-resource ReBAC or per-record gate, not a missing source-side operator relation.
 :::
@@ -152,8 +284,14 @@ per-resource ReBAC or per-record gate, not a missing source-side operator relati
 
 **Diagnosis:**
 
-1. Run `POST /api/cluster/federations/{id}/diagnose` and inspect the TLS layer's
-   stable reason. Re-pair if the handshake did not persist peer trust.
+1. Check that `remote_ca_cert` is populated in the `cluster_federations` table:
+
+   ```bash
+   kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
+     "SELECT id, remote_cluster_name,
+             CASE WHEN remote_ca_cert IS NOT NULL THEN 'SET' ELSE 'NULL' END AS ca_cert_status
+      FROM cluster_federations WHERE status = 'PAIRED';"
+   ```
 
 2. Verify the remote cluster's gateway cert includes its node IP in SANs:
 
@@ -171,10 +309,8 @@ per-resource ReBAC or per-record gate, not a missing source-side operator relati
 
 **Resolution:**
 
-- If peer trust is absent: re-pair the federation. Do not manually inject a CA.
-- If the remote certificate does not cover the configured route, update
-  `global.ingress.gateway.{ipAddresses,extraDnsNames}` and reconcile the
-  deployment.
+- If `remote_ca_cert` is NULL: re-pair the federation, or manually inject the CA cert (see setup step 5).
+- If the remote cert does not include the node IP: update the gateway certificate SANs (see [Federation Setup](./setup.md#add-node-ip-to-gateway-certificate)).
 
 ### Trailing Slash Redirects (307 -> auth loss)
 
@@ -391,10 +527,11 @@ All cross-cluster mesh requests include these headers. They are set by the mesh 
 | `X-KZ-Mesh-Signature-Ts` | Unix timestamp (seconds) when the signature was issued. Must be within TTL window (default 300s). |
 | `X-KZ-Mesh-Route` | Comma-separated list of cluster IDs this request has traversed. Used for loop detection (max 8 hops). |
 | `X-KZ-Mesh-Correlation-Id` | UUID for cross-cluster request tracing. Preserved across hops; generated on the first hop if absent. |
+| `X-KZ-Mesh-Peer-Token` | Caller bearer or receiver-realm credential used for receiver-side identity validation. |
 
 :::note Identity-mode-dependent trust
-In `shared_idp` (receiver-controlled) mode the target establishes identity from the
-caller's **own validated shared-realm token**, not the source-asserted
+In `shared_idp` or `receiver_realm` (receiver-controlled) mode the target establishes identity from the
+caller's **own validated token/realm credential**, not the source-asserted
 `X-KZ-Mesh-User-Id`/`-Roles`. The source-asserted values are the identity only in
 source-trusted `peer_kc`/grandfathered mode. See
 [Identity Trust Modes](./identity-trust-modes.md).

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -41,6 +41,30 @@ curl --fail --silent --show-error \
 
 ## 2. Mesh Proxy Troubleshooting
 
+### Duplicate or stale cluster names
+
+**Symptoms:** Federation cards show the same peer label, a renamed peer still
+shows its old label, a new name returns `404 mesh_target_not_found`, or a shared
+name or prefix returns `409 mesh_target_ambiguous`.
+
+**Diagnosis:** Read the stored selector and UUID for every active federation:
+
+```bash
+curl --fail --silent --show-error \
+  --header "Authorization: Bearer $LOCAL_TOKEN" \
+  "$LOCAL_API/cluster/federations?status=PAIRED" | jq \
+  '.[] | {id, remote_cluster_id, remote_cluster_name, status}'
+```
+
+`remote_cluster_name` is stored when the federation is created or paired.
+Renaming the peer changes its local cluster row, but ping does not refresh the
+cached federation row.
+
+**Resolution:** Use the exact federation UUID for automation. Assign a distinct
+`core.initialClusterName` on every cluster, then re-pair existing federations to
+adopt renamed peer labels. Until re-pairing, the cached old name and federation
+UUID continue to select the existing pair.
+
 ### HMAC Signature Failures (403)
 
 **Symptoms:** 403 response on mesh proxy requests. No `rebac_denied` detail in the response body -- the request is rejected before reaching the endpoint.

--- a/docs/docs/federation/overview.md
+++ b/docs/docs/federation/overview.md
@@ -13,7 +13,7 @@ Kamiwaza cluster federation enables cross-cluster operations between paired Kami
 
 **Federation Trust** — Each federation pair shares a pre-shared key. All cross-cluster requests are HMAC-signed with this key, and the receiving cluster verifies the signature before processing the request. The PSK/HMAC secures the *transport*; the caller's *identity* is validated separately, according to the federation's [identity mode](./identity-trust-modes.md). Trust is per-federation, not per-cluster.
 
-**Identity Modes** — A federation's [identity mode](./identity-trust-modes.md) decides whose identity a cross-cluster caller presents and how the receiver validates it: **`receiver_realm`** (receiver-controlled dedicated realm, the current default), **`shared_idp`** (receiver-controlled shared realm), or **`peer_kc`** (source-trusted legacy posture, gated by cluster policy).
+**Identity Modes** — A federation's [identity mode](./identity-trust-modes.md) decides whose identity a cross-cluster caller presents and how the receiver validates it. The 1.2 baseline supports **`shared_idp`** (receiver-controlled shared realm) and **`peer_kc`** (source-trusted legacy posture); the current 1.3 extension adds **`receiver_realm`** (a receiver-controlled dedicated realm with guest credentials).
 
 **Receiver-controlled authorization** — Cross-cluster egress on the source is **authenticated-only**: any authenticated caller may reach the mesh proxy — there is no `operator`-relation gate. Authorization is decided by the **receiving** cluster, which validates the caller's identity per the identity mode and then evaluates the request against its **own** per-resource ReBAC guards (catalog, retrieval, jobs) and per-record gates. Roles do **not** cross clusters (see [shared identity ≠ shared authority](./identity-trust-modes.md#core-principle-shared-identity--shared-authority)).
 
@@ -61,7 +61,7 @@ Cluster A (source)                          Cluster B (target)
 
 ## Federation lifecycle at a glance
 
-| Step | What | Where it's documented |
+| Step | What | Where it is documented |
 |------|------|----------------------|
 | Pair two clusters | Exchange PSK + CA certs; provision the federation record on both sides | [Setup](./setup.md) |
 | Allowlist federated users | Decide which remote users can act on this cluster | [Setup](./setup.md) |

--- a/docs/docs/federation/overview.md
+++ b/docs/docs/federation/overview.md
@@ -13,7 +13,7 @@ Kamiwaza cluster federation enables cross-cluster operations between paired Kami
 
 **Federation Trust** — Each federation pair shares a pre-shared key. All cross-cluster requests are HMAC-signed with this key, and the receiving cluster verifies the signature before processing the request. The PSK/HMAC secures the *transport*; the caller's *identity* is validated separately, according to the federation's [identity mode](./identity-trust-modes.md). Trust is per-federation, not per-cluster.
 
-**Identity Modes** — A federation's [identity mode](./identity-trust-modes.md) decides whose identity a cross-cluster caller presents and how the receiver validates it. Kamiwaza 1.2.0 supports **`shared_idp`** (receiver-controlled shared realm) and **`peer_kc`** (source-trusted compatibility mode, gated by cluster policy). **`receiver_realm`** is reserved for a future receiver-owned guest-identity workflow and is rejected in 1.2.0.
+**Identity Modes** — A federation's [identity mode](./identity-trust-modes.md) decides whose identity a cross-cluster caller presents and how the receiver validates it: **`receiver_realm`** (receiver-controlled dedicated realm, the current default), **`shared_idp`** (receiver-controlled shared realm), or **`peer_kc`** (source-trusted legacy posture, gated by cluster policy).
 
 **Receiver-controlled authorization** — Cross-cluster egress on the source is **authenticated-only**: any authenticated caller may reach the mesh proxy — there is no `operator`-relation gate. Authorization is decided by the **receiving** cluster, which validates the caller's identity per the identity mode and then evaluates the request against its **own** per-resource ReBAC guards (catalog, retrieval, jobs) and per-record gates. Roles do **not** cross clusters (see [shared identity ≠ shared authority](./identity-trust-modes.md#core-principle-shared-identity--shared-authority)).
 
@@ -54,21 +54,16 @@ Cluster A (source)                          Cluster B (target)
 
 ## Prerequisites
 
-- Two compatible Kamiwaza 1.2.0 clusters using the Istio deployment profile
+- Two Kamiwaza clusters running on Istio with `KAMIWAZA_ROUTING_PROVIDER=istio`
 - STRICT mTLS (`PeerAuthentication`) in both namespaces
 - Network connectivity between clusters on port 443
-- Distinct, mutually reachable peer hostnames covered by each gateway TLS
-  certificate. When connecting by IP, set `remote_ips[].hostname` for Host/SNI
-  routing and include both the IP and hostname in the certificate SANs.
-- A receiver-controlled identity mode. Use `shared_idp` for the first-wave
-  workflow documented here; keep `peer_kc` default-off unless its weaker trust
-  posture is explicitly accepted.
+- Each cluster's Istio gateway TLS cert must include its node IP in SANs
 
 ## Federation lifecycle at a glance
 
 | Step | What | Where it's documented |
 |------|------|----------------------|
-| Pair two clusters | Preflight both routes, create reciprocal records, and let the handshake exchange CA trust | [Setup](./setup.md) |
+| Pair two clusters | Exchange PSK + CA certs; provision the federation record on both sides | [Setup](./setup.md) |
 | Allowlist federated users | Decide which remote users can act on this cluster | [Setup](./setup.md) |
 | Query remote data | Federated retrieval over the mesh proxy | [Retrieval](./retrieval.md) |
 | Submit remote jobs | Cluster-job execution with on-behalf-of (OBO) identity | [Job Submission](./job-submission.md) |

--- a/docs/docs/federation/release-notes-1-3.md
+++ b/docs/docs/federation/release-notes-1-3.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 8
+title: Federation 1.3.0 release notes
+---
+
+# Federation 1.3.0 release notes
+
+This note records the consumer-facing authorization changes tracked by
+[ENG-9924](https://linear.app/kamiwaza/issue/ENG-9924) and implemented by
+[ENG-8859](https://linear.app/kamiwaza/issue/ENG-8859). The change is a
+privacy boundary: a denied caller must learn that its view was filtered, but
+must not learn the size of the withheld set or the policy that made the
+decision.
+
+## `gate_audit` footer compatibility
+
+Before 1.3.0, a gated result could expose counts and the gate name:
+
+```json
+{
+  "gate_audit": {
+    "gate": "acme-clearance",
+    "included": 4,
+    "redacted": 1,
+    "total": 5
+  }
+}
+```
+
+In 1.3.0 the four existing keys remain present for structural compatibility,
+but their values are always `null`:
+
+```json
+{
+  "gate_audit": {
+    "filtered": true,
+    "included": null,
+    "redacted": null,
+    "total": null,
+    "gate": null
+  }
+}
+```
+
+`filtered` is the only disclosure signal. It is `true` when rows were withheld
+or when released rows were narrowed to fewer columns. Column narrowing is not
+row redaction, so it contributes zero to `redacted_count` in the counting
+contract below.
+
+The old keys are intentionally not numeric zeroes. Existing consumers that
+index a key continue to receive `None`; consumers that perform arithmetic or
+ordering (for example, `metadata["redacted"] > 0`) now fail with a `TypeError`
+and must migrate to the released rows plus `filtered`.
+
+### Envelope shape is seam-specific
+
+Do not infer the shape from the runtime type. On the job-result seam,
+`metadata["gate_audit"]` is a **list** with one entry per gated target. On
+inline and SSE retrieval seams it is a **dict** for the current gate. This
+asymmetry is retained for compatibility; branch on the API seam documented for
+your client.
+
+For chained gates, each list entry describes that gate's own input. A later
+entry can therefore be `filtered: false` even when an earlier gate already
+removed rows. A caller asking whether the overall view changed should read the
+aggregate `metadata["filtered"]` flag, not infer it from one entry.
+
+## GateResult counting contract
+
+Gate authors return a `GateResult`, but the runner owns the release boundary
+and validates the result before any records leave the cluster. For an input
+batch of `N` records:
+
+* `included_count == len(records)` — the records returned by the gate are the
+  records released;
+* `redacted_count` counts records withheld **entirely**; column narrowing is
+  not counted as row redaction; and
+* `included_count + redacted_count == total_count`.
+
+Counts are converted with Python's `operator.index`, so integer-like values
+such as NumPy integer scalars are accepted while floats, strings, and other
+non-integral values are rejected. A gate result that violates any invariant is
+replaced with a whole-batch fail-closed result and the audit reason is
+`gate_postcondition_violation`. No partially trusted records from that batch
+are released.
+
+Gate authors should test both the ordinary pass/filter path and malformed
+postconditions. The server contract tests live in
+[`tests/unit/services/authz/gates/test_runner.py`](https://github.com/kamiwaza-internal/kamiwaza/blob/develop/tests/unit/services/authz/gates/test_runner.py)
+and the job-result list-shape tests live in
+[`tests/unit/cluster/jobs/test_result_gate.py`](https://github.com/kamiwaza-internal/kamiwaza/blob/develop/tests/unit/cluster/jobs/test_result_gate.py).
+
+## SDK and application migration
+
+The SDK's MiniClearance acceptance helper now preserves every parsed footer,
+including explicit `null` values, and its assertions count the rows actually
+released. It must not sum or compare the four deprecated fields. The offline
+consumer contract is covered by
+[`tests/integration/test_mini_clearance_gate_audit_contract.py`](https://github.com/kamiwaza-ai/kamiwaza-sdk/blob/develop/tests/integration/test_mini_clearance_gate_audit_contract.py)
+and the parser is documented in
+[`tests/integration/_mini_clearance.py`](https://github.com/kamiwaza-ai/kamiwaza-sdk/blob/develop/tests/integration/_mini_clearance.py).
+
+Applications should:
+
+1. treat `filtered` as the disclosure-safe indicator;
+2. count the records/columns in the response they actually received;
+3. tolerate the retained null keys during the compatibility window; and
+4. avoid using a gate name or a withheld-count estimate for authorization or
+   UI decisions.
+
+## Deprecation window
+
+The four keys (`included`, `redacted`, `total`, and `gate`) are retained as
+nullable fields for the 1.3.x compatibility window. They are candidates for
+removal in the next breaking API/schema revision after downstream SDK and UI
+consumers have removed numeric and policy-name dependencies. Until that window
+is announced, clients must accept the keys when present and must not require
+them to be numeric. `filtered` and the released payload are the stable
+contract.
+
+See also [Execution Gates](./execution-gates.md) for gate configuration and
+[Federation API Reference](./api-reference.md) for the transport envelopes.

--- a/docs/docs/federation/retrieval.md
+++ b/docs/docs/federation/retrieval.md
@@ -10,9 +10,8 @@ Federated retrieval lets you discover and query data on remote clusters without 
 ## Prerequisites
 
 - A [paired federation](./setup.md) between the clusters
-- An active receiver-side onboarding entry for the shared subject
-- Explicit per-dataset ReBAC grants on the target cluster. Mesh-originated
-  requests do not receive the native-cluster admin bypass.
+- Remote CA cert stored in the federation record
+- The mesh user must have per-dataset ReBAC grants on the target cluster (admin users with `extauthz` trust are exempt)
 
 ## Discover Remote Datasets
 
@@ -88,12 +87,19 @@ The inference request routes through the mesh proxy to the remote cluster's Ray 
 
 ## Access Control
 
-### Receiver-owned grants
+### Receiver authorization
 
-All mesh users require explicit per-dataset ReBAC grants on the target cluster.
-The native-cluster admin bypass is suppressed for mesh-originated requests.
-The catalog listing endpoint filters results so federated users see only
-datasets they have receiver-local grants for.
+Mesh origin is not a source-side admin bypass. The receiver validates the
+caller according to the federation's identity mode and then applies its own
+per-resource ReBAC and attribute gates to every mesh request, including calls
+made by a source-cluster administrator. A receiver-realm guest's attributes
+are assigned by the receiver; a shared-IdP caller's attributes come from its
+validated shared-realm token. The source's roles and forwarded attribute header
+are not authority in receiver-controlled modes.
+
+Callers therefore need explicit receiver-side dataset grants. The catalog list
+and retrieval endpoints filter or deny records that do not satisfy those
+grants and gates.
 
 Grant access **at federation-pairing time** through the brokered-user allowlist's `initial_tuples` field — **not** through `/api/auth/tuples`.
 
@@ -129,7 +135,7 @@ All federated operations use the mesh proxy at `/api/mesh/{cluster_selector}/`:
 
 | Parameter | Description |
 |-----------|-------------|
-| `cluster_selector` | Exact federation UUID is recommended. An exact remote-cluster name is accepted when unique; ambiguous prefixes are rejected rather than routed arbitrarily. |
+| `cluster_selector` | Remote cluster name, UUID, or federation ID. Prefix matching supported (e.g., `studio` matches `studio-1`). |
 | `{path}` | The API path on the remote cluster. Paths starting with `runtime/` are routed as-is; all others get an `/api/` prefix. |
 
 ### Timeouts
@@ -151,10 +157,12 @@ The mesh proxy adds these headers to cross-cluster requests:
 | `X-KZ-Mesh-Signature` | HMAC-SHA256 signature |
 | `X-KZ-Mesh-Correlation-Id` | Request correlation ID for cross-cluster tracing |
 | `X-KZ-Mesh-Route` | Hop trace for loop detection |
+| `X-KZ-Mesh-Peer-Token` | Caller bearer or receiver-realm credential used for receiver-side identity validation |
 
 :::note Identity-mode-dependent trust
-`X-KZ-Mesh-User-Id`/`-Roles` are **source-asserted**. In `shared_idp` (receiver-controlled)
-mode the receiver establishes identity from the caller's own validated shared-realm
-token and strips source-asserted cluster roles; the forwarded values are the identity
-only in source-trusted `peer_kc` mode. See [Identity Trust Modes](./identity-trust-modes.md).
+`X-KZ-Mesh-User-Id`/`-Roles` are **source-asserted**. In `shared_idp` and
+`receiver_realm` (receiver-controlled) modes the receiver establishes identity
+from its own validated token/realm credential and strips source-asserted cluster
+roles; those headers are authoritative only in source-trusted `peer_kc` mode.
+See [Identity Trust Modes](./identity-trust-modes.md).
 :::

--- a/docs/docs/federation/retrieval.md
+++ b/docs/docs/federation/retrieval.md
@@ -11,7 +11,9 @@ Federated retrieval lets you discover and query data on remote clusters without 
 
 - A [paired federation](./setup.md) between the clusters
 - Remote CA cert stored in the federation record
-- The mesh user must have per-dataset ReBAC grants on the target cluster (admin users with `extauthz` trust are exempt)
+- The mesh user must have the receiver-side per-dataset ReBAC grants and
+  attribute-gate clearance required by the target cluster. A source-cluster
+  administrator is not an exception on a mesh request.
 
 ## Discover Remote Datasets
 
@@ -104,7 +106,7 @@ grants and gates.
 Grant access **at federation-pairing time** through the brokered-user allowlist's `initial_tuples` field — **not** through `/api/auth/tuples`.
 
 :::warning Why not `/api/auth/tuples`?
-A federated caller has no local user account on the target cluster until their *first* mesh request, when the brokering service auto-provisions a local Keycloak user with a freshly-minted UUID. The per-dataset check authorizes against **that local UUID**, which isn't known ahead of time — so a tuple written against the source cluster's user UUID via `/api/auth/tuples` never matches, and the call returns `204` while access stays denied (`404 Dataset not found`). The allowlist's `initial_tuples` solves this with a `{{user_id}}` placeholder that renders to the local UUID at provision time.
+A federated caller has no local user account on the target cluster until their *first* mesh request, when the brokering service auto-provisions a local Keycloak user with a freshly-minted UUID. The per-dataset check authorizes against **that local UUID**, which is not known ahead of time — so a tuple written against the source cluster's user UUID via `/api/auth/tuples` never matches, and the call returns `204` while access stays denied (`404 Dataset not found`). The allowlist's `initial_tuples` solves this with a `{{user_id}}` placeholder that renders to the local UUID at provision time.
 :::
 
 ```bash
@@ -158,6 +160,11 @@ The mesh proxy adds these headers to cross-cluster requests:
 | `X-KZ-Mesh-Correlation-Id` | Request correlation ID for cross-cluster tracing |
 | `X-KZ-Mesh-Route` | Hop trace for loop detection |
 | `X-KZ-Mesh-Peer-Token` | Caller bearer or receiver-realm credential used for receiver-side identity validation |
+
+Terminal revocation refusals may also carry the four signed response-proof
+headers listed in the [API reference](./api-reference.md#terminal-response-proof-headers).
+The source proxy verifies that proof before purging only the affected user's
+credential.
 
 :::note Identity-mode-dependent trust
 `X-KZ-Mesh-User-Id`/`-Roles` are **source-asserted**. In `shared_idp` and

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -3,36 +3,27 @@ sidebar_position: 2
 title: Federation Setup
 ---
 
-# Federation Setup
+# Federation Setup Guide
 
-This guide pairs two Kamiwaza 1.2.0 clusters using the receiver-controlled
-`shared_idp` identity mode. The receiver validates the caller's shared-realm
-token, then applies its own onboarding, ReBAC, and policy gates.
-
-`receiver_realm` is reserved for the future receiver-owned guest-identity
-workflow and is rejected by Kamiwaza 1.2.0. `peer_kc` remains available for
-compatibility, but new `peer_kc` pairs are refused unless the operator
-explicitly enables `ALLOW_UNTRUSTED_FEDERATION`.
+This guide walks through creating a federation between two Kamiwaza clusters and verifying cross-cluster operations.
 
 ## Prerequisites
 
-- Two Kamiwaza 1.2.0 clusters with mutually reachable HTTPS endpoints.
-- Istio selected through the supported deployment values for both clusters.
-- Distinct cluster display names and distinct, mutually reachable hostnames.
-- Gateway certificates whose SANs cover the hostnames used for Host and TLS
-  SNI routing.
-- One independently owned shared OIDC realm and its issuer and JWKS URLs.
-- The shared issuer enrolled in `core.scheduler.trustedSharedIssuers` on both
-  clusters.
-- A native-realm cluster administrator on each cluster.
+Before pairing, ensure each cluster has:
 
-### Set distinct cluster display names
+1. **Istio routing enabled**: `KAMIWAZA_ROUTING_PROVIDER=istio`
+2. **STRICT mTLS**: `PeerAuthentication` in the `kamiwaza` namespace
+3. **Node IP in gateway cert SANs**: The mesh proxy connects by IP; the TLS cert must include it
 
-Supported Helmfile installations derive the display name from the first label of
-a custom DNS domain. Default or non-DNS domains fall back to the short install
-hostname; raw Helm installations retain the chart's `Default Cluster` value.
-Set an explicit name in the persistent site overlay when the derived value is
-not suitable:
+### Set display names before pairing
+
+Supported Helmfile installations derive the cluster display name from the first
+label of a custom DNS domain. Default or non-DNS domains fall back to the short
+install hostname. Raw Helm installations retain the `Default Cluster` chart
+value.
+
+Set an explicit name in the persistent site overlay when the derived name is not
+suitable:
 
 ```yaml
 # deploy/cluster/values/overrides.yaml
@@ -40,11 +31,14 @@ core:
   initialClusterName: "fed-a"
 ```
 
-Use a different value on each cluster and apply the normal Helmfile sync before
-pairing. A later change takes effect after the scheduler restarts, but an
-already-paired peer retains its cached name until the federation is re-paired.
-The display name labels and selects a federation; the hostname in `remote_ips`
-controls the HTTP Host header and TLS SNI.
+Use a distinct value on each cluster and apply the normal Helmfile sync before
+pairing. A later change renames the local cluster after the scheduler restarts,
+but paired peers retain their cached old name. Ping does not refresh that name;
+re-pair the federation to refresh peer labels and name-based selectors.
+
+The cluster display name is separate from the hostname in `remote_ips`. The
+display name labels and selects a federation, while the hostname controls the
+HTTP Host header and TLS SNI.
 
 For an IP-based connection, provide both the connect address and the hostname:
 
@@ -53,193 +47,276 @@ For an IP-based connection, provide both the connect address and the hostname:
 ```
 
 Kamiwaza connects to `ip` but sends `hostname` as the HTTP Host and TLS SNI.
-Use the same hostname in the gateway certificate. Configure certificate SANs
-with the current chart keys:
+Use the same hostname in the gateway certificate.
+
+### Add Node IP to Gateway Certificate
+
+Each cluster's Istio gateway cert must include its node IP as a Subject Alternative Name (SAN). Without this, TLS verification fails when the mesh proxy connects by IP.
+
+**Option A: Via overrides.yaml (persistent)**
+
+Add to `cluster/values/overrides.yaml`:
 
 ```yaml
 global:
-  ingress:
-    gateway:
+  istio:
+    ingress:
       ipAddresses:
-        - "10.0.0.12"
+        - "192.168.50.168"       # This cluster's node IP
       extraDnsNames:
-        - "fed-b.example.internal"
+        - "studio-1.example.com" # Optional hostname
 ```
 
-## 1. Verify both routes before pairing
+Then sync: `helmfile -f cluster/helmfile.yaml.gotmpl sync -l name=kamiwaza`
 
-In the console, select **Cluster > Federations > Add Request**, enter the peer
-address, and use **Test Connection**. Resolve DNS, TCP, TLS, or L7 failures
-before creating either record.
-
-The API equivalent is admin-only:
+**Option B: Direct kubectl patch (quick)**
 
 ```bash
-curl --fail --silent --show-error \
-  --request POST \
-  --header "Authorization: Bearer $ADMIN_TOKEN" \
-  --header 'Content-Type: application/json' \
-  --data '{"remote_ips":[{"ip":"10.0.0.12","hostname":"fed-b.example.internal","primary":true}]}' \
-  "$LOCAL_API/cluster/federations/preflight" | jq .
+kubectl patch certificate kamiwaza-gateway-tls -n istio-system --type merge -p '{
+  "spec": {
+    "ipAddresses": ["192.168.50.168"],
+    "dnsNames": ["localhost","kamiwaza.test","*.kamiwaza.test","studio-1.example.com"]
+  }
+}'
+# Force re-issue
+kubectl delete secret kamiwaza-tls -n istio-system
 ```
 
-Run the same check in the opposite direction. Pairing needs bidirectional
-reachability.
-
-## 2. Create the receiver record
-
-On the receiving cluster:
-
-1. Select **Cluster > Federations > Add Request**.
-2. Choose **Wait for remote cluster**.
-3. Enter the initiator's unique cluster name, connect address, and hostname.
-4. Enter a strong PSK from your approved secret manager.
-5. Choose **shared_idp**.
-6. Enter the shared issuer and JWKS URLs. If the issuer uses a private CA,
-   supply the complete CA chain.
-7. Create the request.
-
-The receiver should show a `WAITING` record.
-
-## 3. Create and pair the initiator
-
-On the initiating cluster:
-
-1. Select **Cluster > Federations > Add Request**.
-2. Choose **Initiate connection**.
-3. Enter the receiver's unique name, connect address, and hostname.
-4. Use **Test Connection**.
-5. Enter the same PSK and shared-realm values.
-6. Create the request and approve the confirmation.
-
-Both cards should reach `PAIRED` and show **Receiver-controlled** with the same
-shared issuer. Use **Ping** and verify that **Last Ping** updates.
-
-Pairing automatically exchanges the platform CA certificates. Do not update
-`cluster_federations.remote_ca_cert` with SQL and do not copy a raw PSK from
-the database.
-
-## Raw API equivalent
-
-The console uses a two-step API:
-
-1. `POST /api/cluster/federations` creates the receiver and initiator records.
-2. `POST /api/cluster/federations/{id}/pair` on the initiator drives the
-   handshake.
-
-Keep the PSK in mode-`0600` request files so it does not appear in process
-arguments or shell history. The initiator request shape is:
-
-```json
-{
-  "remote_cluster_name": "fed-b",
-  "remote_ips": [
-    {
-      "ip": "10.0.0.12",
-      "hostname": "fed-b.example.internal",
-      "primary": true
-    }
-  ],
-  "preshared_key": "read-from-a-private-file",
-  "callback_hostname": "fed-a.example.internal",
-  "role": "initiator",
-  "shared_issuer_url": "https://idp.example.internal/realms/federation",
-  "shared_jwks_url": "https://idp.example.internal/realms/federation/protocol/openid-connect/certs",
-  "shared_ca_pem": "optional-private-ca-chain"
-}
-```
-
-The receiver request uses `role: "receiver"` and the reciprocal name and
-route. Create the receiver first, then the initiator, then pair the returned
-initiator ID:
+**Verify:**
 
 ```bash
-curl --fail --silent --show-error \
-  --request POST --header "Authorization: Bearer $B_ADMIN_TOKEN" \
-  --header 'Content-Type: application/json' \
-  --data-binary @receiver-create-private.json \
-  "$B_API/cluster/federations" > receiver.json
-
-curl --fail --silent --show-error \
-  --request POST --header "Authorization: Bearer $A_ADMIN_TOKEN" \
-  --header 'Content-Type: application/json' \
-  --data-binary @initiator-create-private.json \
-  "$A_API/cluster/federations" > initiator.json
-
-FEDERATION_ID="$(jq -er .id initiator.json)"
-curl --fail --silent --show-error \
-  --request POST --header "Authorization: Bearer $A_ADMIN_TOKEN" \
-  "$A_API/cluster/federations/$FEDERATION_ID/pair" | jq .
+kubectl get secret kamiwaza-tls -n istio-system -o jsonpath='{.data.tls\.crt}' \
+  | base64 -d | openssl x509 -noout -text | grep -A5 "Subject Alternative Name"
+# Should include: IP Address:192.168.50.168
 ```
 
-Delete the private request files after pairing.
+:::note
+On k0s-lima clusters, `install-dev.sh` auto-detects the node IP and writes it to `overrides.yaml`.
+:::
 
-## 4. Onboard receiver-local access
+## Recommended request/approve flow
 
-Pairing establishes trust; it does not grant access to datasets, models, or
-jobs. On the receiver, open the federation's **Access** panel and add each
-shared-realm subject that may use the pair. Assign only the required
-receiver-local grants, for example:
+The request/approve flow is the supported path for new pairings. The initiator
+supplies connectivity and a freshly minted PSK; the receiver chooses the trust
+mode and admits the request. Identity mode is never inferred from source
+headers or silently changed during polling.
 
-- `dataset:<dataset-urn>#viewer` for discovery and retrieval;
-- the exact model relation required for chat; and
-- `cluster_jobs:__all__#executor` for job submission.
-
-The receiver creates and controls the local brokered identity. Source-cluster
-administrator roles do not cross the federation boundary.
-
-## 5. Verify the pair
-
-Use the exact federation UUID when scripting. Name prefixes are rejected when
-they are ambiguous.
+### 1. Initiator: mint a PSK and submit a request
 
 ```bash
-curl --fail --silent --show-error \
-  --request POST --header "Authorization: Bearer $A_ADMIN_TOKEN" \
-  "$A_API/cluster/federations/$FEDERATION_ID/ping" | jq -e '.reachable == true'
+LOCAL_TOKEN=...
+PSK=$(curl --fail --silent --show-error -sk -X POST \
+  "https://<LOCAL_IP>/api/cluster/federations/generate-psk" \
+  -H "Authorization: Bearer $LOCAL_TOKEN" | jq -r .preshared_key)
 
-curl --fail --silent --show-error \
-  --header "Authorization: Bearer $SHARED_USER_TOKEN" \
-  "$A_API/mesh/$FEDERATION_ID/api/catalog/datasets/" | jq .
+curl --fail --silent --show-error -sk -X POST \
+  "https://<LOCAL_IP>/api/cluster/federations/request" \
+  -H "Authorization: Bearer $LOCAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg psk "$PSK" '{
+    remote_cluster_name: "fed-b",
+    remote_ips: [{ip: "<REMOTE_IP>", hostname: "<REMOTE_FQDN>", primary: true}],
+    callback_hostname: "<LOCAL_FQDN>",
+    preshared_key: $psk
+  }')"
 ```
 
-The catalog response must contain only datasets authorized on the receiver.
-Continue with [Federated Retrieval](./retrieval.md) and
-[Job Submission](./job-submission.md).
+The PSK is stored in the platform secret catalog and is not included in the
+unauthenticated receiver intake. Deliver the value to the receiver operator
+through the approved out-of-band channel; do not put it in shell history,
+issue comments, or logs.
 
-## Diagnose a failure
+### 2. Receiver: review and approve
 
-Run the stored-route diagnostic before changing records:
+The receiver's native administrator lists the pending request, verifies the
+requester's advertised route, and approves it with the same PSK:
 
 ```bash
-curl --fail --silent --show-error \
-  --request POST --header "Authorization: Bearer $A_ADMIN_TOKEN" \
-  "$A_API/cluster/federations/$FEDERATION_ID/diagnose" | jq .
+REMOTE_TOKEN=...
+curl --fail --silent --show-error -sk \
+  "https://<REMOTE_IP>/api/cluster/federations" \
+  -H "Authorization: Bearer $REMOTE_TOKEN"
+
+curl --fail --silent --show-error -sk -X POST \
+  "https://<REMOTE_IP>/api/cluster/federations/<REQUEST_ID>/approve" \
+  -H "Authorization: Bearer $REMOTE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "identity_mode": "receiver_realm",
+    "realm_scope": "per_federation",
+    "preshared_key": "<PSK_FROM_OUT_OF_BAND_CHANNEL>"
+  }'
 ```
 
-Common stable reasons include `dns_unresolvable`, `connection_failed`,
-`connection_timeout`, `tls_untrusted_ca`, `tls_hostname_mismatch`,
-`peer_identity_aliases_local`, `psk_propagation_timeout`, and
-`peer_ca_projection_forbidden`.
+Inspect the returned rows for `status: "REQUESTED"`; the list filter is
+reserved for the public federation lifecycle values (`PAIRING`, `PAIRED`,
+`DISCONNECTED`, and `DELETED`).
 
-If CA inspection is required, support both deployed certificate layouts and
-never assume `root-ca` lives in the `kamiwaza` namespace:
+For a shared realm, use `identity_mode: "shared_idp"` and provide
+`shared_issuer_url` (plus `shared_jwks_url` and, when needed, `shared_ca_pem`).
+The issuer must already be in the receiver's `scheduler.trustedSharedIssuers`
+allow-list. `peer_kc` is not accepted by this new approval schema.
+
+To refuse a request instead:
 
 ```bash
-if kubectl get secret core-internal-ca-tls -n kamiwaza >/dev/null 2>&1; then
-  kubectl get secret core-internal-ca-tls -n kamiwaza \
-    -o jsonpath='{.data.ca\.crt}' | base64 -d
-else
-  kubectl get secret root-ca -n kamiwaza-ca \
-    -o jsonpath='{.data.ca\.crt}' | base64 -d
-fi
+curl --fail --silent --show-error -sk -X POST \
+  "https://<REMOTE_IP>/api/cluster/federations/<REQUEST_ID>/deny" \
+  -H "Authorization: Bearer $REMOTE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"operator rejected the proposed peer"}'
 ```
 
-This command is diagnostic only. Normal pairing exchanges and stores the CA.
+### 3. Initiator: poll to complete
 
-## Disconnect
+```bash
+curl --fail --silent --show-error -sk \
+  "https://<LOCAL_IP>/api/cluster/federations/<REQUEST_ID>/request-status" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
+```
 
-Use **Disconnect** in the federation card or call the disconnect endpoint.
-Disconnect blocks new mesh admission and revokes delegated authority. Running
-work is reconciled through the job lifecycle; confirm terminal status before
-deleting evidence or receiver-local grants.
+Poll until the response is `APPROVED`/`PAIRED` or `DENIED`. The poll performs
+the signed handshake and CA exchange; a non-2xx peer response is surfaced as a
+structured refusal and does not leave a phantom local credential.
+
+### 4. Enroll receiver-realm guests (if selected)
+
+After the federation is paired, a receiver administrator enrolls each source
+identity with `POST /api/cluster/federations/{id}/guests`. The response contains
+the receiver-issued `offline_token` once. The source stores it encrypted and
+uses it as the per-user federation credential. Use the guest attribute and
+relation endpoints to assign receiver-owned access; revocation returns a
+terminal `revoked_guest`/`revoked_brokered_user` response and purges the source
+credential on its next mesh call.
+
+:::warning
+The legacy two-sided create/`/pair` steps below remain only for draining old
+in-flight rows. Do not use them for a new federation; they can create the
+source-trusted `peer_kc` posture and are deprecated in the API.
+:::
+
+## Step 1: Create Receiver on Remote Cluster
+
+The receiver creates a WAITING federation record. Authenticate to the remote cluster and create it:
+
+```bash
+# Login to remote cluster
+REMOTE_TOKEN=$(curl -sk "https://<REMOTE_IP>/api/auth/token" -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=admin%40kamiwaza.localhost&password=<PASSWORD>&grant_type=password' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+
+# Create WAITING receiver
+curl -sk -X POST "https://<REMOTE_IP>/api/cluster/federations" \
+  -H "Authorization: Bearer $REMOTE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "remote_cluster_name": "<local-cluster-name>",
+    "remote_ips": [{"ip": "<LOCAL_IP>", "primary": true}],
+    "preshared_key": "<shared-secret>",
+    "callback_hostname": "<REMOTE_IP>",
+    "role": "receiver"
+  }'
+```
+
+:::important
+Use the same `preshared_key` on both clusters. Set `callback_hostname` to the cluster's bridged VM IP — without it, the internal pod hostname is used, which is unreachable from the other cluster.
+:::
+
+## Step 2: Create Initiator on Local Cluster
+
+```bash
+# Login to local cluster
+LOCAL_TOKEN=$(curl -sk "https://<LOCAL_IP>/api/auth/token" -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=admin%40kamiwaza.localhost&password=<PASSWORD>&grant_type=password' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+
+# Create PAIRING initiator
+curl -sk -X POST "https://<LOCAL_IP>/api/cluster/federations" \
+  -H "Authorization: Bearer $LOCAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "remote_cluster_name": "<remote-cluster-name>",
+    "remote_ips": [{"ip": "<REMOTE_IP>", "primary": true}],
+    "preshared_key": "<shared-secret>",
+    "callback_hostname": "<LOCAL_IP>"
+  }'
+# Note the federation ID from the response
+```
+
+## Step 3: Pair
+
+```bash
+curl -sk -X POST "https://<LOCAL_IP>/api/cluster/federations/<FEDERATION_ID>/pair" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
+# Response: status should be "PAIRED"
+```
+
+On success, both clusters transition to `PAIRED`. The receiver seeds
+`cluster_jobs:__all__:executor` for the remote admin so federated jobs can run.
+Cross-cluster mesh egress is **authenticated-only** — no `federation:operator`
+relation is required to use the mesh proxy.
+
+:::warning Legacy compatibility only
+These deprecated steps create the legacy source-trusted `peer_kc` posture and
+may be refused with HTTP 400 unless `ALLOW_UNTRUSTED_FEDERATION=true`. They do
+not select `receiver_realm` or `shared_idp`; use the request/approve flow above
+for either receiver-controlled mode.
+:::
+
+## Step 4: Store Remote CA Certificate
+
+The mesh proxy needs to trust the remote cluster's TLS certificate. Fetch the remote cluster's root CA and store it in the federation record:
+
+```bash
+# Get remote cluster's root CA cert
+REMOTE_CA=$(kubectl get secret root-ca -n kamiwaza -o jsonpath='{.data.ca\.crt}' | base64 -d)
+# On the remote cluster, or via SSH
+
+# Store in federation record
+kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
+  "UPDATE cluster_federations SET remote_ca_cert = '$(echo "$REMOTE_CA" | sed "s/'/''/g")' WHERE id = '<FEDERATION_ID>';"
+```
+
+:::note
+The supported request/approve poll performs the signed CA exchange. The manual
+database update shown here is retained only for legacy rows or an operator-led
+CA recovery; prefer `POST /api/cluster/federations/{id}/refresh-peer-ca` with a
+fingerprint acknowledgement for a rotated peer certificate.
+:::
+
+## Step 5: Verify
+
+```bash
+# Query remote catalog through mesh proxy
+curl -sk "https://<LOCAL_IP>/api/mesh/<remote-cluster-name>/api/catalog/datasets/" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
+# Should return dataset list from the remote cluster
+
+# List remote models
+curl -sk "https://<LOCAL_IP>/api/mesh/<remote-cluster-name>/api/serving/deployments" \
+  -H "Authorization: Bearer $LOCAL_TOKEN"
+# Should return deployment list from the remote cluster
+```
+
+## Disconnecting
+
+```bash
+curl -sk -X POST "https://<IP>/api/cluster/federations/<FEDERATION_ID>/disconnect" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Disconnecting immediately blocks new mesh proxy requests. Running operations on the remote cluster are not cancelled.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 502 `mesh_proxy_bad_gateway` | TLS verification failed | Store remote CA cert (Step 4) or add IP to gateway cert SANs |
+| 401 on remote cluster | Mesh HMAC verification failed | Check PSK matches; check Istio `includeRequestHeadersInCheck` includes `x-kz-mesh-*` headers |
+| 403 on source before the request forwards | Cross-cluster egress is authenticated-only in the current flow — there is no `federation:operator` gate; a 403 here means the caller is not authenticated | Ensure the caller presents a valid token to the source cluster |
+| 403 `namespace_unsupported` | `federation` namespace not registered | Ensure `authz/constants.py` includes `federation` in `ALLOWED_OBJECT_NAMESPACES` |
+| 400 `missing_object_id` | Cluster selector did not resolve to a PAIRED federation (unknown name/UUID, a local-cluster selector, or a non-PAIRED federation). The mesh guard's id-resolver (`mesh/guards.py resolve_federation_id`) returns `None`, so `@guarded` raises this *before* the route runs — the service-layer `mesh_target_not_found` (404) / `mesh_target_is_local` (400) codes are never reached on this path (ENG-7520). | Check federation status; selector must match a PAIRED federation by name, UUID, or prefix |
+| 403 `not_authorized_to_probe_cluster` on `/api/cluster/cluster_capabilities` | Mesh-origin capabilities probe lacks a `cluster:<local_uuid>` viewer grant, which federation pairing does not seed (ENG-7892) | Grant the federated subject the `cluster:<local_uuid>` viewer relation explicitly before probing |
+| 307 redirect | Missing trailing slash | Add `/` to the API path |

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -26,6 +26,26 @@ explicitly enables `ALLOW_UNTRUSTED_FEDERATION`.
   clusters.
 - A native-realm cluster administrator on each cluster.
 
+### Set distinct cluster display names
+
+Supported Helmfile installations derive the display name from the first label of
+a custom DNS domain. Default or non-DNS domains fall back to the short install
+hostname; raw Helm installations retain the chart's `Default Cluster` value.
+Set an explicit name in the persistent site overlay when the derived value is
+not suitable:
+
+```yaml
+# deploy/cluster/values/overrides.yaml
+core:
+  initialClusterName: "fed-a"
+```
+
+Use a different value on each cluster and apply the normal Helmfile sync before
+pairing. A later change takes effect after the scheduler restarts, but an
+already-paired peer retains its cached name until the federation is re-paired.
+The display name labels and selects a federation; the hostname in `remote_ips`
+controls the HTTP Host header and TLS SNI.
+
 For an IP-based connection, provide both the connect address and the hostname:
 
 ```json

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -59,12 +59,12 @@ Add to `cluster/values/overrides.yaml`:
 
 ```yaml
 global:
-  istio:
-    ingress:
+  ingress:
+    gateway:
       ipAddresses:
-        - "192.168.50.168"       # This cluster's node IP
+        - "<THIS_CLUSTER_NODE_IP>"
       extraDnsNames:
-        - "studio-1.example.com" # Optional hostname
+        - "<THIS_CLUSTER_FQDN>"
 ```
 
 Then sync: `helmfile -f cluster/helmfile.yaml.gotmpl sync -l name=kamiwaza`
@@ -195,98 +195,46 @@ in-flight rows. Do not use them for a new federation; they can create the
 source-trusted `peer_kc` posture and are deprecated in the API.
 :::
 
-## Step 1: Create Receiver on Remote Cluster
+## Legacy compatibility (drain only)
 
-The receiver creates a WAITING federation record. Authenticate to the remote cluster and create it:
+Rows created by the deprecated symmetric wizard can still be completed, but the
+flow is source-trusted and may be refused when `ALLOW_UNTRUSTED_FEDERATION` is
+disabled. Keep each request body in a mode-`0600` file and use the supported API;
+do not write federation or certificate columns directly in the database.
 
-```bash
-# Login to remote cluster
-REMOTE_TOKEN=$(curl -sk "https://<REMOTE_IP>/api/auth/token" -X POST \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'username=admin%40kamiwaza.localhost&password=<PASSWORD>&grant_type=password' \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+1. Authenticate as a native-realm administrator on both clusters using the
+   normal login procedure described in the [Quickstart](../quickstart.md).
+2. Create the reciprocal rows with private files that contain only your actual
+   deployment values:
 
-# Create WAITING receiver
-curl -sk -X POST "https://<REMOTE_IP>/api/cluster/federations" \
-  -H "Authorization: Bearer $REMOTE_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "remote_cluster_name": "<local-cluster-name>",
-    "remote_ips": [{"ip": "<LOCAL_IP>", "primary": true}],
-    "preshared_key": "<shared-secret>",
-    "callback_hostname": "<REMOTE_IP>",
-    "role": "receiver"
-  }'
-```
+   ```bash
+   curl --fail --silent --show-error --request POST \
+     --header "Authorization: Bearer $REMOTE_ADMIN_TOKEN" \
+     --header 'Content-Type: application/json' \
+     --data-binary @receiver-create-private.json \
+     "$REMOTE_API/cluster/federations"
 
-:::important
-Use the same `preshared_key` on both clusters. Set `callback_hostname` to the cluster's bridged VM IP — without it, the internal pod hostname is used, which is unreachable from the other cluster.
-:::
+   curl --fail --silent --show-error --request POST \
+     --header "Authorization: Bearer $LOCAL_ADMIN_TOKEN" \
+     --header 'Content-Type: application/json' \
+     --data-binary @initiator-create-private.json \
+     "$LOCAL_API/cluster/federations"
+   ```
 
-## Step 2: Create Initiator on Local Cluster
+3. Pair the initiator row returned by the second call:
 
-```bash
-# Login to local cluster
-LOCAL_TOKEN=$(curl -sk "https://<LOCAL_IP>/api/auth/token" -X POST \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'username=admin%40kamiwaza.localhost&password=<PASSWORD>&grant_type=password' \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+   ```bash
+   curl --fail --silent --show-error --request POST \
+     --header "Authorization: Bearer $LOCAL_ADMIN_TOKEN" \
+     "$LOCAL_API/cluster/federations/$FEDERATION_ID/pair"
+   ```
 
-# Create PAIRING initiator
-curl -sk -X POST "https://<LOCAL_IP>/api/cluster/federations" \
-  -H "Authorization: Bearer $LOCAL_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "remote_cluster_name": "<remote-cluster-name>",
-    "remote_ips": [{"ip": "<REMOTE_IP>", "primary": true}],
-    "preshared_key": "<shared-secret>",
-    "callback_hostname": "<LOCAL_IP>"
-  }'
-# Note the federation ID from the response
-```
+4. If a legacy peer certificate was rotated, use
+   `POST /api/cluster/federations/{id}/refresh-peer-ca` with the new PEM and its
+   independently compared fingerprint. The request/approve flow performs the
+   CA exchange automatically; no SQL recovery is needed for new pairings.
 
-## Step 3: Pair
-
-```bash
-curl -sk -X POST "https://<LOCAL_IP>/api/cluster/federations/<FEDERATION_ID>/pair" \
-  -H "Authorization: Bearer $LOCAL_TOKEN"
-# Response: status should be "PAIRED"
-```
-
-On success, both clusters transition to `PAIRED`. The receiver seeds
-`cluster_jobs:__all__:executor` for the remote admin so federated jobs can run.
-Cross-cluster mesh egress is **authenticated-only** — no `federation:operator`
-relation is required to use the mesh proxy.
-
-:::warning Legacy compatibility only
-These deprecated steps create the legacy source-trusted `peer_kc` posture and
-may be refused with HTTP 400 unless `ALLOW_UNTRUSTED_FEDERATION=true`. They do
-not select `receiver_realm` or `shared_idp`; use the request/approve flow above
-for either receiver-controlled mode.
-:::
-
-## Step 4: Store Remote CA Certificate
-
-The mesh proxy needs to trust the remote cluster's TLS certificate. Fetch the remote cluster's root CA and store it in the federation record:
-
-```bash
-# Get remote cluster's root CA cert
-REMOTE_CA=$(kubectl get secret root-ca -n kamiwaza -o jsonpath='{.data.ca\.crt}' | base64 -d)
-# On the remote cluster, or via SSH
-
-# Store in federation record
-kubectl exec core-postgres-0 -n kamiwaza -- psql -U core -d kamiwaza -c \
-  "UPDATE cluster_federations SET remote_ca_cert = '$(echo "$REMOTE_CA" | sed "s/'/''/g")' WHERE id = '<FEDERATION_ID>';"
-```
-
-:::note
-The supported request/approve poll performs the signed CA exchange. The manual
-database update shown here is retained only for legacy rows or an operator-led
-CA recovery; prefer `POST /api/cluster/federations/{id}/refresh-peer-ca` with a
-fingerprint acknowledgement for a rotated peer certificate.
-:::
-
-## Step 5: Verify
+## Verify
 
 ```bash
 # Query remote catalog through mesh proxy
@@ -307,13 +255,13 @@ curl -sk -X POST "https://<IP>/api/cluster/federations/<FEDERATION_ID>/disconnec
   -H "Authorization: Bearer $TOKEN"
 ```
 
-Disconnecting immediately blocks new mesh proxy requests. Running operations on the remote cluster are not cancelled.
+Disconnecting immediately blocks new mesh proxy requests. Running operations on the remote cluster are not canceled.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| 502 `mesh_proxy_bad_gateway` | TLS verification failed | Store remote CA cert (Step 4) or add IP to gateway cert SANs |
+| 502 `mesh_proxy_bad_gateway` | TLS verification failed | Re-run the signed pairing/CA exchange or use `refresh-peer-ca` with an independently verified fingerprint; add the peer IP/hostname to gateway cert SANs |
 | 401 on remote cluster | Mesh HMAC verification failed | Check PSK matches; check Istio `includeRequestHeadersInCheck` includes `x-kz-mesh-*` headers |
 | 403 on source before the request forwards | Cross-cluster egress is authenticated-only in the current flow — there is no `federation:operator` gate; a 403 here means the caller is not authenticated | Ensure the caller presents a valid token to the source cluster |
 | 403 `namespace_unsupported` | `federation` namespace not registered | Ensure `authz/constants.py` includes `federation` in `ALLOWED_OBJECT_NAMESPACES` |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -77,6 +77,7 @@ const sidebars: SidebarsConfig = {
 				"federation/execution-gates",
 				"federation/gate-packages",
 				"federation/api-reference",
+				"federation/release-notes-1-3",
 			],
 		},
 		{


### PR DESCRIPTION
## Summary

Reconcile the public federation documentation with the current 1.2 management contract and the 1.3 receiver-realm/onboarding extension.

- Correct management authorization, lifecycle status values, legacy paths, and endpoint/error coverage.
- Document per-user onboarding, claim recovery, peer-protocol boundaries, and terminal response-proof headers.
- Remove insecure legacy SQL/password examples and replace them with API-only, mode-0600 compatibility guidance.
- Document cluster display-name and gateway SAN semantics; relate the ENG-10633 work without expanding its implementation scope.
- Add the 1.3 federation release note to the sidebar.

Closes/addresses ENG-10665 and is related to ENG-10633.

## Verification

- `npm test` (61 passed)
- `npm run typecheck`
- `INCLUDE_FEDERAL_DOCS=true npm run build:docs` (success; existing legacy broken-anchor warnings remain)
- Documentation style guide check (warnings only for headings inside legacy fenced examples)
- `git diff --check`
