### PR TITLE
ENG-9182: Address PR #186 review — storage-doc accuracy + dynamic version banner

### DIFF
--- a/docs/docs/installation/online_install.md
+++ b/docs/docs/installation/online_install.md
@@ -17,7 +17,7 @@ The online installer is the recommended way to install Kamiwaza 1.0.2 on an inte
   - **`/var` ≥ 1.1 TB** — the install consumes roughly **890 GB** here: the Rook/Ceph OSD image (**700 GB**, `storage_host_prep_virtual_block_size`), the TopoLVM volume group backing stateful PVCs (**150 GB**, `storage_host_prep_topolvm_vg_size`), and roughly 40 GB of container images under `/var/lib/k0s`. Size the volume so that 890 GB leaves you under the ~85% disk-pressure threshold described below: 890 GB on a 1 TB volume is 89% and still inside the eviction range, so **1.1 TB** (≈81%) is the practical floor.
   - **`/` ≥ 30 GB** — installed tooling under `/opt` and `/usr/local`, plus general headroom.
 
-  **On a smaller host, reduce the OSD image** rather than provisioning 1.1 TB. Passing `-e storage_host_prep_virtual_block_size=80G` — the size the offline installer uses by default — brings the requirement down to **350 GB on `/var`**:
+  **On a smaller host, reduce the OSD image** rather than provisioning 1.1 TB. Passing `-e storage_host_prep_virtual_block_size=80G` — the same 80 GB OSD size the offline install guide recommends — brings the requirement down to **350 GB on `/var`**:
 
   ```bash
   KEYGEN_LICENSE_KEY="<kamiwaza-prod-license-key>" \

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -265,7 +265,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 32 cores / 64 threads
 - **RAM:** 128-256GB system RAM
-- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 400GB, but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
+- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 350GB (provision 400GB to clear it comfortably), but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
 - **GPU:** 1-4 GPUs with 40GB+ VRAM each
   - 1-4x NVIDIA B200 (192GB HBM3e)
   - 1-4x NVIDIA H200 (141GB HBM3e)

--- a/docs/src/theme/DocVersionBanner/index.tsx
+++ b/docs/src/theme/DocVersionBanner/index.tsx
@@ -2,50 +2,71 @@ import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
+import {
+  useActivePlugin,
+  useDocsVersion,
+  useDocsPreferredVersion,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocVersionBanner';
 
+// The GA/"latest" version label is resolved dynamically from the active docs
+// plugin's version metadata (ultimately `docs/package.json` via
+// docusaurus.config.ts). Do not hardcode a version string here — earlier
+// version-bump PRs repeatedly forgot to update a literal, publishing a stale
+// "current GA release" link.
 export default function DocVersionBanner({className}: Props): React.ReactNode {
   const versionMetadata = useDocsVersion();
 
-  if (versionMetadata.banner === 'unreleased') {
-    return (
-      <div
-        className={clsx(
-          className,
-          ThemeClassNames.docs.docVersionBanner,
-          'alert alert--warning margin-bottom--md',
-        )}
-        role="alert">
-        <div>
-          This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
-          is the next release of Kamiwaza. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.2</b></Link>.
-          {/* TODO: dynamic version resolution instead of hardcoding the version.
-          Currently this is a manual step that has been overlooked in previous
-          version-bump PRs. */}
-        </div>
-      </div>
-    );
+  // No banner for the current/latest version.
+  if (!versionMetadata.banner) {
+    return null;
   }
 
-  if (versionMetadata.banner === 'unmaintained') {
-    return (
-      <div
-        className={clsx(
-          className,
-          ThemeClassNames.docs.docVersionBanner,
-          'alert alert--secondary margin-bottom--md',
-        )}
-        role="alert">
-        <div>
-          This is documentation for Kamiwaza <b>{versionMetadata.label}</b>, which
-          is no longer actively maintained. For the current GA release, see{' '}
-          <Link to="/"><b>1.0.2</b></Link>.
-        </div>
-      </div>
-    );
-  }
+  const {pluginId} = useActivePlugin({failfast: true});
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
 
-  return null;
+  const getVersionMainDoc = (version: typeof latestVersionSuggestion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId);
+  // Prefer linking to the same doc in the latest version; fall back to its main
+  // doc. Either can be missing (e.g. a doc dropped between versions), so guard
+  // rather than assert — a missing target degrades to a plain label instead of
+  // crashing the banner render.
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  const gaLabel = <b>{latestVersionSuggestion.label}</b>;
+  const gaLink = latestVersionSuggestedDoc ? (
+    <Link
+      to={latestVersionSuggestedDoc.path}
+      onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}>
+      {gaLabel}
+    </Link>
+  ) : (
+    gaLabel
+  );
+
+  const isUnreleased = versionMetadata.banner === 'unreleased';
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        isUnreleased
+          ? 'alert alert--warning margin-bottom--md'
+          : 'alert alert--secondary margin-bottom--md',
+      )}
+      role="alert">
+      <div>
+        This is documentation for Kamiwaza <b>{versionMetadata.label}</b>,{' '}
+        {isUnreleased
+          ? 'which is the next release of Kamiwaza.'
+          : 'which is no longer actively maintained.'}{' '}
+        For the current GA release, see {gaLink}.
+      </div>
+    </div>
+  );
 }

--- a/docs/versioned_docs/version-1.0.2/installation/online_install.md
+++ b/docs/versioned_docs/version-1.0.2/installation/online_install.md
@@ -17,7 +17,7 @@ The online installer is the recommended way to install Kamiwaza 1.0.2 on an inte
   - **`/var` ≥ 1.1 TB** — the install consumes roughly **890 GB** here: the Rook/Ceph OSD image (**700 GB**, `storage_host_prep_virtual_block_size`), the TopoLVM volume group backing stateful PVCs (**150 GB**, `storage_host_prep_topolvm_vg_size`), and roughly 40 GB of container images under `/var/lib/k0s`. Size the volume so that 890 GB leaves you under the ~85% disk-pressure threshold described below: 890 GB on a 1 TB volume is 89% and still inside the eviction range, so **1.1 TB** (≈81%) is the practical floor.
   - **`/` ≥ 30 GB** — installed tooling under `/opt` and `/usr/local`, plus general headroom.
 
-  **On a smaller host, reduce the OSD image** rather than provisioning 1.1 TB. Passing `-e storage_host_prep_virtual_block_size=80G` — the size the offline installer uses by default — brings the requirement down to **350 GB on `/var`**:
+  **On a smaller host, reduce the OSD image** rather than provisioning 1.1 TB. Passing `-e storage_host_prep_virtual_block_size=80G` — the same 80 GB OSD size the offline install guide recommends — brings the requirement down to **350 GB on `/var`**:
 
   ```bash
   KEYGEN_LICENSE_KEY="<kamiwaza-prod-license-key>" \

--- a/docs/versioned_docs/version-1.0.2/installation/system_requirements.md
+++ b/docs/versioned_docs/version-1.0.2/installation/system_requirements.md
@@ -265,7 +265,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 32 cores / 64 threads
 - **RAM:** 128-256GB system RAM
-- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 400GB, but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
+- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 350GB (provision 400GB to clear it comfortably), but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
 - **GPU:** 1-4 GPUs with 40GB+ VRAM each
   - 1-4x NVIDIA B200 (192GB HBM3e)
   - 1-4x NVIDIA H200 (141GB HBM3e)


### PR DESCRIPTION
Feeds fixes into `release/1.0.2` so they flow up through #186 (release/1.0.2 → main). Direct pushes to `release/1.0.2` are blocked by the "changes must go through a PR" ruleset, hence this stacked PR.

Addresses the REQUEST_CHANGES review on #186 (jxstanford):

- **#1 (High, blocking)** — `online_install.md` called `80G` "the size the offline installer uses by default." That's false: the Ansible `storage_host_prep` role default is **700G** (as `offline_install.md:14` states in the same PR). Reworded to "the same 80 GB OSD size the offline install guide recommends." Fixed in `docs/docs/` and the `version-1.0.2` snapshot (kept byte-identical).
- **#2 (Medium)** — `system_requirements.md` Tier 2 said the `80G` override drops the *install* floor to **400GB**. The floor is **350GB**; 400GB is the recommended provisioning that clears it. Corrected in both copies.
- **#3/#4 (Medium)** — `DocVersionBanner` hardcoded `1.0.2` (a recurring version-bump manual step; the TODO sat in the unreachable `unreleased` branch). Reimplemented using the upstream `useDocVersionSuggestions` pattern so the GA link resolves dynamically from `package.json` for both the main and SDK doc plugins — no literal to forget on the next bump. Guarded the doc-resolution fallback so a missing target degrades to a plain label instead of crashing the render.

Not included (deliberately): #5 (stale `1.0.0` OpenAPI version) is pre-existing, not in this PR's diff, and regenerating needs the kamiwaza platform repo — the reviewer classified it as a non-blocking one-command follow-up. #6 (offline "~270 GB" optimism) is covered by the existing "roughly" hedge.

Verification: `docs/docs` == `version-1.0.2` snapshot (byte-identical); `cd docs && npm run build` succeeds; `tsc` clean.

Ref: ENG-9182