### PR TITLE
ENG-9862: Remove @jxstanford default CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# Default reviewer for all files. Requested on every PR but does NOT
-# require approval to merge (require_code_owner_review is false in
-# the org ruleset).
-* @jxstanford


### PR DESCRIPTION
## Summary

Remove the generated `CODEOWNERS` file whose only entry was `* @jxstanford`.

## Type

- [x] Chore - Dependencies, config, CI/CD

## Motivation

The org-wide default code-owner role is being retired. `* @jxstanford` was this
file's only entry, so the file is removed rather than left as an empty ruleset.

The file was not hand-maintained: it was generated from the
`REPO_FILES["CODEOWNERS"]` template in `kamiwaza-stack`'s `govern-repos.py` and
pushed to every managed repo via the contents API. All 13 generated copies were
byte-identical. That template is removed in the same change set, so
`govern-repos.py --apply` will no longer recreate this file.

## Breaking Changes

- [x] None - Fully backward compatible

Every org ruleset `pull_request` rule sets `require_code_owner_review=false`
with `required_approving_review_count=1` on `main`, `develop`, `release/*` and
`hotfix/*`, and legacy branch protection carries no review rule on `develop` or
`release/*`. Code-owner approval never gated a merge here. The only behavioral
change is that pull requests no longer auto-request `@jxstanford` as a reviewer;
the 1-approval gate is unchanged and any reviewer still satisfies it.

## Testing and verification

- Confirmed no `CODEOWNERS` file remains in this repo and no `jxstanford`
  reference remains in any `CODEOWNERS` across the stack.
- Confirmed the removal does not touch `.github/CODEOWNERS` in repos that have
  a separate one.

## Source

- [x] Issue/Ticket: ENG-9862 —
  https://linear.app/kamiwaza/issue/ENG-9862/governance-remove-jxstanford-as-the-default-codeowners-entry-across
