### PR TITLE
ENG-10051: document the schema-readiness gate in the 1.0.0→1.2.0 upgrade runbook

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -104,9 +104,12 @@ within one 10-second period once `core-db-init` completes.
 Verifying the gate's state directly:
 
 ```bash
-kubectl get pods -n "${NAMESPACE}" -l ray.io/node-type=head -o wide
+kubectl get pods -n "${NAMESPACE}" \
+  -l ray.io/cluster=core-raycluster,ray.io/node-type=head -o wide
 kubectl get endpoints core-api -n "${NAMESPACE}" -o wide
-kubectl logs -n "${NAMESPACE}" -l ray.io/node-type=head -c schema-readiness --tail=20
+kubectl logs -n "${NAMESPACE}" \
+  -l ray.io/cluster=core-raycluster,ray.io/node-type=head \
+  -c schema-readiness --tail=20
 ```
 
 An empty `ENDPOINTS` column on `core-api` while `core-db-init` is still running
@@ -621,7 +624,8 @@ do with the platform's health, and a failure recorded then is not evidence of
 anything. Confirm the gate has reopened first:
 
 ```bash
-kubectl get pods -n "${NAMESPACE}" -l ray.io/node-type=head -o wide
+kubectl get pods -n "${NAMESPACE}" \
+  -l ray.io/cluster=core-raycluster,ray.io/node-type=head -o wide
 kubectl get endpoints core-api -n "${NAMESPACE}" -o wide
 ```
 

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -45,8 +45,12 @@ failed Helm hook is a stopped upgrade, not permission to improvise.
   this before creating the scratch database.
 - The exact domain, installation mode, and release inputs used for the site.
 - The approved CA certificate that validates the production HTTPS endpoint.
-- A confirmed maintenance window. Scheduler and API availability can be
-  interrupted while the post-install database hook runs.
+- A confirmed maintenance window that covers a **Core API outage**, not merely a
+  possible interruption. From the moment the 1.2.0 chart's Ray head starts until
+  `core-db-init` brings the schema to head, the Core API serves no traffic at
+  all. This is designed behaviour, not a fault; see
+  [What normal looks like](#what-normal-looks-like-during-the-upgrade) before
+  you begin.
 - External writers quiesced for the backup and upgrade window.
 - The site's existing domain, runtime, storage, GPU, and installer options
   recorded and preserved for the 1.2.0 invocation.
@@ -57,6 +61,86 @@ namespace, intended 1.2.0 artifact, and candidate SHA. The CI and signed M1
 evidence URLs are release-engineering inputs, not values a customer operator
 must create. If the database is below the 1.0.0 source floor, stop and request
 the required intermediate upgrade procedure.
+
+## What normal looks like during the upgrade
+
+Read this section before starting. A gated workload and a broken one look
+alike from the outside, and the single most likely way to turn a healthy
+upgrade into a failed one is to react to the gate as though it were a fault.
+
+### The Core API stops serving, on purpose
+
+The 1.2.0 chart adds a second container, `schema-readiness`, to the Ray head
+pod. It runs the core image's `python -m kamiwaza.node.readiness_server` and its
+readiness probe asks one question: is the core database at the schema head this
+build carries?
+
+A Kubernetes pod is Ready only when **every** container is Ready, and the
+`core-api` Service selects the Ray head. So while the database is behind — the
+entire window from the new head starting to `core-db-init` reaching head —
+the head is not Ready, `core-api` has no endpoints, and the Core API answers
+nothing. That is the gate doing its job: 1.0.0-shaped data is never served
+through a 1.2.0 binary, and a paused or failed `core-db-init` cannot go
+unnoticed.
+
+The probe is declared in the chart as `GET /healthz/schema` on port 7788, with
+`periodSeconds: 10` and `failureThreshold: 3`. Where the mesh rewrites app
+probes, the rendered pod spec shows the equivalent
+`/app-health/schema-readiness/readyz` on the sidecar's port instead — both
+describe the same probe. The thresholds mean the head leaves `core-api`'s
+endpoints roughly 30 seconds after the schema stops being at head, and rejoins
+within one 10-second period once `core-db-init` completes.
+
+### Expected observations
+
+| Observation | Meaning | Action |
+| --- | --- | --- |
+| Ray head pod `Running` but **not Ready**, with its READY column one container short (`2/3` where the mesh sidecar is present), while `core-db-init` is pre-head | Correct. The gate is holding. | Wait. Continue to observe `core-db-init`. |
+| `core-api` has no endpoints, and requests to it fail or return 503, during that same window | Correct, and it follows directly from the line above. | Wait. Do not restart anything. |
+| Ray head becomes Ready and `core-api` endpoints reappear shortly after `core-db-init` succeeds | Correct. The gate has reopened. | Continue to [step 6](#6-verify-the-schema-from-the-running-core-image). |
+| Ray head still not Ready well **after** the schema has reached head | Not expected. | Collect evidence and escalate to Support. Do not delete the pod. |
+| `schema-readiness` container is in `CrashLoopBackOff` | Not expected — almost always chart/image skew. | See [image contract](#image-contract-do-not-pin-an-older-core-image) below. |
+
+Verifying the gate's state directly:
+
+```bash
+kubectl get pods -n "${NAMESPACE}" -l ray.io/node-type=head -o wide
+kubectl get endpoints core-api -n "${NAMESPACE}" -o wide
+kubectl logs -n "${NAMESPACE}" -l ray.io/node-type=head -c schema-readiness --tail=20
+```
+
+An empty `ENDPOINTS` column on `core-api` while `core-db-init` is still running
+is the expected reading, not a finding.
+
+### Image contract: do not pin an older core image
+
+The `schema-readiness` container runs a module that exists only in 1.2.0 and
+later core images. The chart and the core image normally ship together — the
+chart's `appVersion` is rewritten to the core version it was built against — so
+every supported upgrade path is safe.
+
+Deliberately skewing them is not. Pinning a core image older than the chart —
+for example `KAMIWAZA_IMAGE_TAG=release-1.1.0` against the 1.2.0 chart — leaves
+the container with no module to run. It crash-loops, the head never becomes
+Ready, and `core-api` loses every endpoint permanently. **That is a full API
+outage, not a held gate**, and no amount of waiting clears it.
+
+If you must run a core image older than the gate, disable the gate in the same
+change by setting `ray.head.schemaGate.enabled: false`. That restores exactly
+the pre-1.2.0 behaviour — a head that serves regardless of schema state — and
+is the documented escape hatch. Do not use it to work around a head that is
+correctly holding against a pre-head schema; that would serve 1.0.0 data
+through a 1.2.0 binary, which is the outcome this procedure exists to prevent.
+
+### Wait windows
+
+`core-db-init` may legitimately use its full dependency-wait budget of
+1800 seconds (`core.scheduler.waitForDeps.timeoutSeconds`). The scheduler's
+`startupProbe` is sized to match at `180 × 10s = 1800s`, so a slow but healthy
+migration no longer expires the scheduler's startup gate before `core-db-init`
+gives up. Preserve the site's configured Helm timeout, and size any wait of
+your own against 1800 seconds rather than against a shorter fresh-install
+example.
 
 ## 1. Create the evidence workspace
 
@@ -264,7 +348,19 @@ test -x "${COLLECTOR_COMMAND}"
 That path is derived from the generated online installer's Linux
 `DEFAULT_EXTRACT_DIR` and `PAYLOAD_ROOT_NAME` constants in
 `kajiya/infra/online-ubuntu/kamiwaza-online-install.sh`; `--keep-extract`
-prevents cleanup of the candidate payload.
+prevents cleanup of the candidate payload. The payload build stages the deploy
+tree's whole `scripts/` directory, so the collector arrives with its executable
+bit intact.
+
+The `test -x` above is the check that matters — run it before you need the
+collector, not after an upgrade has already failed. If it fails, the payload
+was cleaned up (`--keep-extract` missing) or the candidate predates the
+collector. Locate the payload root before continuing, and do not proceed to the
+installer without a working collector:
+
+```bash
+find /var/lib/kamiwaza-online-install -maxdepth 3 -name kamiwaza-online-payload -type d
+```
 
 ### Offline upgrade
 
@@ -306,6 +402,12 @@ export COLLECTOR_COMMAND="/opt/kamiwaza/scripts/collect-core-db-init-diagnostics
 test -x "${COLLECTOR_COMMAND}"
 ```
 
+The `kamiwaza-prod` RPM installs the deploy tree's `scripts/` directory under
+`/opt/kamiwaza`, so the collector is present once the 1.2.0 RPM is installed —
+which is why the RPM upgrade above precedes this check. If `test -x` fails, the
+installed RPM predates the collector; upgrade to the verified 1.2.0 candidate
+package before continuing.
+
 Confirm the reported package version is the intended 1.2.0 candidate. Export
 the exact values from that candidate's `release_origination.md`; do not infer
 or reuse tags from the currently installed release:
@@ -327,8 +429,10 @@ export KAMIWAZA_IMAGE_OVERRIDES="<exact comma-separated overrides from release_o
 
 Preserve the site's existing `KAMIWAZA_K8S_RUNTIME`, resource profile,
 storage, GPU, and Helm override inputs. Preserve the site's configured Helm
-timeout; do not copy the fresh-install guide's shorter example timeout into a
-populated-database migration. Then run the upgraded installer once:
+timeout, and size it against `core-db-init`'s full 1800-second dependency-wait
+budget (see [Wait windows](#wait-windows)); do not copy the fresh-install
+guide's shorter example timeout into a populated-database migration. Then run
+the upgraded installer once:
 
 ```bash
 (
@@ -377,6 +481,14 @@ kubectl get pods -n "${NAMESPACE}" \
   -l app.kubernetes.io/name=core-db-init \
   --sort-by=.metadata.creationTimestamp -o wide
 ```
+
+While this Job is running, the Ray head is expected to be `Running` but **not
+Ready** and `core-api` is expected to have no endpoints. That is the
+schema-readiness gate holding, not a fault — see
+[What normal looks like](#what-normal-looks-like-during-the-upgrade). Do not
+restart the head, delete its pod, or roll back the release in response to it.
+The head rejoins `core-api` on its own within about ten seconds of the schema
+reaching head.
 
 Do not delete the Job or pods. The completed Job and its pods are retained for
 `core.scheduler.dbInit.ttlSecondsAfterFinished` (3600 seconds by default) and
@@ -501,6 +613,21 @@ Verify the actual production domain with the approved CA certificate and record
 machine-readable results in `smoke/results.json`. M1 qualification must never
 replace this trust check with `--insecure`.
 
+**Order matters.** These checks reach the Core API through the Ray head, which
+is withdrawn from `core-api` while the schema is behind. Run them only after
+[step 6](#6-verify-the-schema-from-the-running-core-image) reports `at_head`
+and the head is Ready. Run earlier, they fail for a reason that has nothing to
+do with the platform's health, and a failure recorded then is not evidence of
+anything. Confirm the gate has reopened first:
+
+```bash
+kubectl get pods -n "${NAMESPACE}" -l ray.io/node-type=head -o wide
+kubectl get endpoints core-api -n "${NAMESPACE}" -o wide
+```
+
+Both the head's READY column showing every container ready and a nonempty
+`core-api` endpoints list are preconditions for the checks below.
+
 ```bash
 : "${KAMIWAZA_CA_CERT:?export the approved production CA certificate path}"
 kubectl get pods -n "${NAMESPACE}" -o wide
@@ -536,6 +663,9 @@ responsible for producing all five named checks:
 | Installer exits nonzero before `core-db-init` exists | Host, artifact, registry, or Helm preparation failed before schema execution. | Preserve installer logs and cluster/Helm state; contact Support before retrying. |
 | `core-db-init` pod is Pending, `ImagePullBackOff`, or `CreateContainerConfigError` | Migration code did not start. | Collect pod descriptions and events; fix only the Support-approved infrastructure cause, then obtain retry approval. |
 | `core-db-init` starts and exits nonzero | Migration or database validation failed. | Collect every attempt log and description. Do not delete the Job, stamp the DB, or rerun. Escalate to Support. |
+| Ray head is `Running` but not Ready, and `core-api` has no endpoints, **while `core-db-init` is still pre-head** | Not a failure. The schema-readiness gate is holding the API off a pre-head database, as designed. | Wait for `core-db-init`. Do not restart the head, delete its pod, or roll back — a retry here is the wrong action and can only lose evidence. |
+| Ray head is still not Ready **after** schema status reports `at_head` | The gate should have reopened and did not. | Collect the head pod description, its `schema-readiness` container logs, and `core-api` endpoints; escalate to Support. Do not delete the pod. |
+| `schema-readiness` container is in `CrashLoopBackOff` | Chart and core image are skewed: the pinned core image predates the module this container runs. | Full API outage until corrected. Deploy a core image matching the chart, or set `ray.head.schemaGate.enabled: false` if the older image is intentional. See [image contract](#image-contract-do-not-pin-an-older-core-image). |
 | Installer exits zero but schema status is not `at_head` and supported | The release gate and the database disagree. | Treat the upgrade as failed; preserve the database and evidence and contact Support. |
 | Schema is healthy but a required smoke test fails | Schema migration completed, but the platform is not operational. | Preserve evidence. Support determines whether the issue is configuration, service recovery, or rollback/cutover. |
 | Evidence contains a credential, token, private key, or Kubernetes Secret | The bundle is unsafe to share. | Quarantine it, rotate exposed credentials as required, redact by omission, and regenerate the bundle. |


### PR DESCRIPTION
## Summary

The 1.0.0 → 1.2.0 core database upgrade runbook was accurate when it shipped, but the schema-readiness gate landed after it and changes what an operator actually sees during the upgrade. The Ray head pod now carries a `schema-readiness` container whose readiness probes the core database's schema head; pod readiness is the AND over its containers and `core-api` selects the head, so the Core API serves nothing for the whole schema-behind window. That is designed behaviour — but an operator following the runbook as written watches the API go down with nothing telling them it was intended, and the natural reaction (restart the head, delete the pod, roll back) is the one action that can only lose evidence.

This adds a **What normal looks like during the upgrade** section ahead of step 1, because the operator needs the expected shape before the window opens rather than after:

- The prerequisite now states the Core API **will** stop serving, not that availability "can be interrupted".
- The held-gate observations are tabulated against the ones that genuinely warrant escalation.
- The image-contract sharp edge moves out of `charts/core/values.yaml` comments and into the runbook: pinning a core image older than the chart crash-loops the container into a real full-API outage, with `ray.head.schemaGate.enabled: false` as the documented escape hatch.

The same distinction is threaded through the steps that touch it — step 5 names the not-Ready head as correct while db-init is pre-head, step 7 states that the smoke checks reach the API through that head and cannot run before it reopens, and the failure-states table gains three rows separating a holding gate from a stuck one from a skewed image.

Wait-window guidance now cites `core-db-init`'s 1800s dependency-wait budget, which the scheduler's `startupProbe` was resized to match (`180 × 10s`).

Both diagnostics-collector paths were confirmed against packaging rather than left asserted, and each now says what to do when its `test -x` fails — which is the part an operator actually needs.

## Verification

- Docusaurus build succeeds with the modified runbook; the page is **not** among the pre-existing broken-anchor warnings.
- All four new heading anchors render and every intra-page link on the page resolves.
- Probe contract (`/healthz/schema`, port 7788, `periodSeconds: 10`, `failureThreshold: 3`), the gate toggle, and the 1800s values were each checked against `deploy` chart source rather than transcribed from the ticket.
- Collector paths verified against packaging: the RPM spec and the online-payload builder each stage the deploy tree's whole `scripts/` directory with `cp -a`.

## Notes

Live confirmation of the collector paths on a RHEL 9 box was **not** performed — SSH to the ad-hoc test host requires an interactive SSO gate. The paths are confirmed against packaging source instead, and the runbook's existing `test -x` checks fail closed on a real install if either path is ever wrong. Tracked in the ticket.

Publication path decision: the runbook stays on `develop` and reaches docs.kamiwaza.ai with the 1.2.0 docs promotion rather than being promoted to `main` ahead of the release. Recorded on the ticket.

A build failure I hit locally turned out to be my own environment, not the repo: running `npm ci` inside `docs/` alone leaves `redoc` unable to resolve `yaml`, because it resolves that from the **repo-root** `node_modules`. Both CI and the documented workflow install at the root first, so nothing is broken. I filed ENG-10053 for it prematurely and have cancelled it.

Refs ENG-10051

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.8.0"
generated_at: "2026-08-11T00:08:18Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 190
linear_issues: [ENG-10051]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "check-linear-issue and Validate package locks green; Docs tests and production build observed running at bundle-author time. Gate re-verifies live."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-11T00:03:41Z; eligible at 2026-08-11T00:48:41Z. Gate re-verifies against GitHub's clock."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Documentation-only change: one markdown file under docs/docs/runbooks/. No cluster-running code, so the pr-evidence cluster-smoke sentinel is not applicable."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-10051 present in head branch docs/eng-10051-schema-readiness-gate-runbook, PR title, commit trailers, and PR body (Refs ENG-10051)."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff is a single markdown file; no console.log / debugger / pdb.set_trace / breakpoint constructs. The bash shown in fenced blocks is operator runbook procedure, not executable source."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review verdict APPROVE posted as a SHA-pinned issue comment on head a8ac5c9d791044b51d967230f4d35a81fe4e95f9."

manual_steps:
  - id: ms-1
    description: "Build the Docusaurus production site with the modified runbook and confirm the changed page is free of broken anchors."
    observation: "npm run build printed '[SUCCESS] Generated static files in \"build\".' Docusaurus's broken-anchor warning listed only pre-existing pages (/blog/2024/04/15/a-primer-on-GenAI-hardware, /0.11.0/security/admin-guide, /0.9.3/installation/macos_tarball and six others); runbooks/core-database-upgrade-1.2 did not appear in that list."
    status: pass

  - id: ms-2
    description: "Confirm the four new heading anchors render in the built HTML and that every intra-page link on the page resolves to an id present on the page."
    observation: "In build/runbooks/core-database-upgrade-1.2.html the ids what-normal-looks-like-during-the-upgrade, image-contract-do-not-pin-an-older-core-image, wait-windows and 6-verify-the-schema-from-the-running-core-image are all present. All 22 distinct href='#...' values on the page match ids on the same page."
    status: pass

  - id: ms-3
    description: "Check the probe contract the runbook now documents against the deploy chart, rather than transcribing it from the ticket."
    observation: "charts/core/templates/_helpers.tpl core.schemaReadinessContainer renders container name 'schema-readiness' running 'python -m kamiwaza.node.readiness_server' with readinessProbe httpGet path /healthz/schema, port 7788, periodSeconds 10, timeoutSeconds 5, failureThreshold 3. charts/core/values.yaml ray.head.schemaGate has enabled: true, port: 7788, and the same probe values."
    status: pass

  - id: ms-4
    description: "Check the 1800-second wait-window figures the runbook now cites against the deploy chart."
    observation: "charts/core/values.yaml scheduler.probes.startup.failureThreshold is 180 with periodSeconds 10 (=1800s), and scheduler.waitForDeps.timeoutSeconds is 1800. The two are equal, matching the values.yaml comment 'deliberately equal to scheduler.waitForDeps.timeoutSeconds'."
    status: pass

  - id: ms-5
    description: "Confirm the two diagnostics-collector paths the runbook documents are actually produced by packaging."
    observation: "packaging/rpm/kamiwaza-prod.spec line 35 iterates 'ansible charts cluster crds manifests scripts prereqs Makefile README.md CHANGELOG.md' and runs 'cp -a ${item} %{buildroot}/opt/kamiwaza/', yielding /opt/kamiwaza/scripts/collect-core-db-init-diagnostics.sh. kajiya infra/online-ubuntu/build-online-install.sh line 201 stages the same 'scripts' item into PAYLOAD_ROOT via copy_payload_item's 'cp -a'; install-online.sh sets Linux DEFAULT_EXTRACT_DIR=/var/lib/kamiwaza-online-install and PAYLOAD_ROOT_NAME=kamiwaza-online-payload, yielding /var/lib/kamiwaza-online-install/kamiwaza-online-payload/scripts/collect-core-db-init-diagnostics.sh."
    status: pass

verdict:
  decision: approve
  rationale: "Documentation-only change to an operator runbook. Every added technical claim verified against deploy chart, kamiwaza module, and packaging source; production site builds with working anchors; one selector-precision defect found in self-review and fixed in a8ac5c9. Live RHEL 9 confirmation of the collector paths was requested by the ticket but could not be performed non-interactively; it is NOT claimed as a verified manual step here -- see the note in the bundle body."

gate:
  approval_submitted: false
  approval_blocked_reason: "Bundle authored before the gate ran; the gate decides."
```

</details>

# pr-verify bundle — ENG-10051

Documents the schema-readiness gate in the 1.0.0 → 1.2.0 core database upgrade runbook.

## Check requested by the ticket that was NOT performed

ENG-10051 asked for the two diagnostics-collector paths to be confirmed on a real RHEL 9 install
rather than by repo inspection. That was **not** done: `ssh -o BatchMode=yes
adhoctest-ssh.kamiwaza.dev` returns a Cloudflare Zero Trust browser SSO URL and then
"Connection timed out during banner exchange", so the gate cannot be completed non-interactively.

It is deliberately **not** listed as a manual step above, because the bundle's manual steps are
observations that were actually made and this one was not. The paths are instead confirmed against
packaging source in `ms-5` -- a strong check, but not an equivalent one. The runbook's pre-existing
`test -x "${COLLECTOR_COMMAND}"` assertions fail closed on a real install if either path is ever
wrong, and ENG-10051 carries the exact commands to close this out on a box.

<!-- pr-verify-end -->
