### PR TITLE
ENG-9274: make the M1-20 qualification path executable end to end

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -188,6 +188,67 @@ sharing evidence, write those values to `${EVIDENCE_DIR}/metadata.json` using
 the applicable schema in [Customer support bundle](#customer-support-bundle)
 or [M1-20 qualification bundle](#m1-20-qualification-bundle).
 
+### Inputs you must be given (release qualification only)
+
+For a release qualification these five values come from the release owner, not
+from the cluster, and the bundle is refused without them. Get them before you
+start rather than at the end:
+
+| Variable | What it is |
+| --- | --- |
+| `KAMIWAZA_M1_RUN_ID` | The harness run this evidence belongs to. Must match the run exactly. |
+| `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to. |
+| `MAINTENANCE_TICKET` | The change record authorizing this run. |
+| `CI_RUN_URL` | The M1-20 CI run URL. |
+| `M1_EVIDENCE_URL` | Where the signed qualification evidence is published. |
+
+`KAMIWAZA_M1_RUN_ID` and `CANDIDATE_SHA` are checked against the harness ledger
+and a mismatch is rejected outright, so neither can be invented locally. The
+candidate must be a commit that contains the approver's enrolled signing key —
+see [Record the external sign-off](#record-the-external-sign-off).
+
+### Capture the metadata now, not at the end
+
+`metadata.json` is the one bundle file with no natural home in the procedure,
+and the easiest to get wrong: every field is required, and `run_id` and
+`candidate_sha` are matched against the harness. Capture what is knowable at
+this point, so the values describe the cluster **before** the upgrade rather
+than being reconstructed afterwards:
+
+```bash
+: "${MAINTENANCE_TICKET:?export the change record authorizing this run}"
+export OPERATOR="${OPERATOR:-$(id -un)}"
+export STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Chart version of the installed release, e.g. core-1.0.0
+INSTALLED_CHART_VERSION=$(helm list -n "${NAMESPACE}" -o json \
+  | jq -r --arg r "${RELEASE}" '.[] | select(.name == $r) | .chart')
+
+# Prefer the immutable digest over the mutable tag: imageID carries name@sha256:...
+INSTALLED_CORE_IMAGE=$(kubectl get pods -n "${NAMESPACE}" \
+  -l app.kubernetes.io/name=core-scheduler \
+  -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="core")].imageID}')
+# Fall back to the deployment's tag only if the pod has not reported an imageID.
+if [[ -z "${INSTALLED_CORE_IMAGE}" ]]; then
+  INSTALLED_CORE_IMAGE=$(kubectl get deployment/core-scheduler -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="core")].image}')
+fi
+
+test -n "${INSTALLED_CHART_VERSION}"
+test -n "${INSTALLED_CORE_IMAGE}"
+printf 'chart=%s\nimage=%s\n' \
+  "${INSTALLED_CHART_VERSION}" "${INSTALLED_CORE_IMAGE}"
+
+export INSTALLED_CHART_VERSION INSTALLED_CORE_IMAGE
+```
+
+Both `test` lines are deliberate: an empty value here becomes a bundle that is
+refused hours later, at the point where re-running is most expensive.
+
+Write the file once the upgrade completes and `FINISHED_AT` is known — the
+schema in [M1-20 qualification bundle](#m1-20-qualification-bundle) lists every
+field, and the generator below fills them from the variables exported here.
+
 ## 2. Verify the 1.0.0 baseline
 
 Confirm the cluster is reachable and healthy enough to back up. Record the
@@ -906,6 +967,142 @@ For M1 qualification, `metadata.json` must include:
 Before publishing M1 evidence, enforce the exact file list above, then run the
 same secret scan and manual review documented in
 [Customer support bundle](#customer-support-bundle).
+
+### Generating `metadata.json`
+
+Every field is required and the harness matches `run_id` and `candidate_sha`
+against its ledger, so hand-assembly is the most common way a complete,
+correct upgrade still produces a rejected bundle. Generate it from the
+variables exported in [step 1](#inputs-you-must-be-given-release-qualification-only),
+after the upgrade finishes:
+
+```bash
+export FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+: "${CI_RUN_URL:?export the exact M1-20 CI run URL}"
+: "${M1_EVIDENCE_URL:?export the signed qualification evidence URL}"
+: "${INSTALLATION_MODE:?export online or offline}"
+: "${INTENDED_ARTIFACT:?export the exact 1.2.0 artifact name or digest}"
+: "${RUNBOOK_URL:?export the versioned URL of the runbook you followed}"
+
+jq -n \
+  --argjson schema_version 1 \
+  --arg run_id "${RUN_ID}" \
+  --arg candidate_sha "${CANDIDATE_SHA}" \
+  --arg source_product_version "1.0.0" \
+  --arg target_product_version "1.2.0" \
+  --arg installation_mode "${INSTALLATION_MODE}" \
+  --arg operator "${OPERATOR}" \
+  --arg maintenance_ticket "${MAINTENANCE_TICKET}" \
+  --arg cluster_context "$(kubectl config current-context)" \
+  --arg namespace "${NAMESPACE}" \
+  --arg installed_release_version "1.0.0" \
+  --arg installed_chart_version "${INSTALLED_CHART_VERSION}" \
+  --arg installed_core_image "${INSTALLED_CORE_IMAGE}" \
+  --arg intended_artifact "${INTENDED_ARTIFACT}" \
+  --arg started_at "${STARTED_AT}" \
+  --arg finished_at "${FINISHED_AT}" \
+  --arg runbook_id "core-database-upgrade-1.2" \
+  --arg runbook_url "${RUNBOOK_URL}" \
+  --arg ci_run_url "${CI_RUN_URL}" \
+  --arg m1_evidence_url "${M1_EVIDENCE_URL}" \
+  '$ARGS.named' >"${EVIDENCE_DIR}/metadata.json"
+
+# Refuse to ship a file with an empty or placeholder value in it.
+jq -e 'to_entries | all(.value | tostring | (length > 0) and (test("^exact-|^immutable-|^customer-change-id$|^named-operator$") | not))' \
+  "${EVIDENCE_DIR}/metadata.json" >/dev/null
+```
+
+`RUNBOOK_URL` must be a versioned or immutable URL — a commit-pinned link, not
+a branch link. A branch URL moves after the fact, which makes the evidence
+unreproducible and does not satisfy M1-20.
+
+The second `jq` is the check worth keeping: it fails if any field is empty or
+still carries one of the schema's placeholder strings. Those placeholders are
+valid non-empty text, so the harness would otherwise accept them and the
+finished record would assert a change ticket and an operator that never
+existed.
+
+## Record the external sign-off
+
+M1-20 completes as **Blocked** on purpose, so an independent approver can
+inspect finished evidence before approving it. The case closes only when a
+signed approval is imported.
+
+The approval is an Ed25519 signature over the artifact's own fields, verified
+against a public key **enrolled in the candidate commit**. Three consequences
+follow, and each has refused an otherwise-valid approval:
+
+- The approver's key must already be enrolled in the candidate the run is
+  pinned to. A run pinned to a commit predating enrollment can never accept
+  that approver's sign-off, no matter how the signature is produced.
+- The approval must be timestamped **after** the rehearsal finished, and no
+  more than five minutes ahead of the verifying clock. Signing in advance
+  fails.
+- `role` must be one of `business-owner`, `customer-proxy`, or
+  `release-approver`. It is a signed field, so it cannot be corrected
+  afterwards without re-signing.
+
+### Produce the signed approval
+
+The approver runs this on the machine holding their private key. The signature
+covers every field except `signature` itself, serialized as canonical JSON —
+sorted keys, no whitespace. Any other serialization verifies as invalid:
+
+```bash
+# Values supplied by the release owner; RUN_ID and CANDIDATE_SHA must match the run.
+: "${RUN_ID:?}" ; : "${CANDIDATE_SHA:?}"
+export APPROVER="Full Name"
+export ROLE="release-approver"        # or business-owner / customer-proxy
+export SOURCE="the record this approval is tracked in"
+export PRIVATE_KEY="${HOME}/.kamiwaza-signoff.key"
+
+python3 - <<'PY' >external-signoff.json
+import base64, json, os, datetime
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+payload = {
+    "schema_version": 1,
+    "approved": True,
+    "approver": os.environ["APPROVER"],
+    "role": os.environ["ROLE"],
+    "approved_at": datetime.datetime.now(datetime.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "source": os.environ["SOURCE"],
+    "run_id": os.environ["RUN_ID"],
+    "candidate_sha": os.environ["CANDIDATE_SHA"],
+}
+# Canonical form: sorted keys, compact separators, signature excluded.
+signed = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+key = load_pem_private_key(
+    open(os.environ["PRIVATE_KEY"], "rb").read(),
+    password=(os.environ["KEY_PASSPHRASE"].encode()
+              if os.environ.get("KEY_PASSPHRASE") else None),
+)
+payload["signature"] = base64.b64encode(key.sign(signed)).decode()
+print(json.dumps(payload, indent=2))
+PY
+```
+
+The private key never leaves the approver's machine; only
+`external-signoff.json` is returned. If the key is passphrase-protected, set
+`KEY_PASSPHRASE` for the command rather than storing it.
+
+### Import it
+
+Run this from the `kamiwaza` checkout the qualification run was created in:
+
+```bash
+scripts/kw_py scripts/run_db_migration_m1.py \
+  resume "${RUN_ID}" --external-signoff /path/to/external-signoff.json
+```
+
+The import validates the signature, the enrolled key, the run and candidate
+binding, the timestamp window, and refuses any approval carrying sensitive
+data. On success M1-20 moves from Blocked to Pass. On failure the case stays
+Blocked and the reason names the specific check that refused — read it rather
+than re-signing blindly, since the usual causes are a candidate that predates
+enrollment or a timestamp earlier than the rehearsal's completion.
 
 ## Run M1-20 release qualification
 

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -188,19 +188,33 @@ sharing evidence, write those values to `${EVIDENCE_DIR}/metadata.json` using
 the applicable schema in [Customer support bundle](#customer-support-bundle)
 or [M1-20 qualification bundle](#m1-20-qualification-bundle).
 
-### Inputs you must be given (release qualification only)
+### Inputs you must have before you start
 
-For a release qualification these five values come from the release owner, not
-from the cluster, and the bundle is refused without them. Get them before you
-start rather than at the end:
+The procedure requires these exports, spread across steps 1, 4, 7 and the
+qualification sections. Every one of them stops the run where it is first
+referenced, so collect them now rather than discovering the gap mid-window.
 
-| Variable | What it is |
-| --- | --- |
-| `KAMIWAZA_M1_RUN_ID` | The harness run this evidence belongs to. Must match the run exactly. |
-| `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to. |
-| `MAINTENANCE_TICKET` | The change record authorizing this run. |
-| `CI_RUN_URL` | The M1-20 CI run URL. |
-| `M1_EVIDENCE_URL` | Where the signed qualification evidence is published. |
+Supplied by the release owner (a qualification run cannot derive these):
+
+| Variable | What it is | First needed |
+| --- | --- | --- |
+| `KAMIWAZA_M1_RUN_ID` | The harness run this evidence belongs to | step 1 |
+| `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to | step 1 |
+| `MAINTENANCE_TICKET` | The change record authorizing this run | step 1 |
+| `INTENDED_ARTIFACT` | The exact 1.2.0 artifact name or digest being installed | step 4 |
+| `KEYGEN_LICENSE_KEY` | The license the installer validates at startup | step 4 |
+| `RUNBOOK_URL` | Commit-pinned URL of the revision you followed | metadata |
+| `CI_RUN_URL` | The M1-20 CI run URL | metadata |
+| `M1_EVIDENCE_URL` | Where the signed qualification evidence is published | metadata |
+
+Properties of the installation under test:
+
+| Variable | What it is | First needed |
+| --- | --- | --- |
+| `DOMAIN` | The existing domain of the 1.0.0 installation | step 1 |
+| `ADMIN_PASSWORD` | Its current admin password | step 1 |
+| `KAMIWAZA_CA_CERT` | Path to the CA certificate validating that domain | step 7 |
+| `INSTALLATION_MODE` | `online` or `offline`, matching the path you take in step 4 | metadata |
 
 `KAMIWAZA_M1_RUN_ID` and `CANDIDATE_SHA` are checked against the harness ledger
 and a mismatch is rejected outright, so neither can be invented locally. The

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -234,7 +234,7 @@ than being reconstructed afterwards:
 export OPERATOR="${OPERATOR:-$(id -un)}"
 export STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-# Chart version of the installed release, e.g. core-1.0.0
+# Chart version of the installed release, e.g. kamiwaza-1.0.0
 INSTALLED_CHART_VERSION=$(helm list -n "${NAMESPACE}" -o json \
   | jq -r --arg r "${RELEASE}" '.[] | select(.name == $r) | .chart')
 
@@ -987,7 +987,7 @@ same secret scan and manual review documented in
 Every field is required and the harness matches `run_id` and `candidate_sha`
 against its ledger, so hand-assembly is the most common way a complete,
 correct upgrade still produces a rejected bundle. Generate it from the
-variables exported in [step 1](#inputs-you-must-be-given-release-qualification-only),
+variables exported in [step 1](#inputs-you-must-have-before-you-start),
 after the upgrade finishes:
 
 ```bash
@@ -1022,7 +1022,8 @@ jq -n \
   '$ARGS.named' >"${EVIDENCE_DIR}/metadata.json"
 
 # Refuse to ship a file with an empty or placeholder value in it.
-jq -e 'to_entries | all(.value | tostring | (length > 0) and (test("^exact-|^immutable-|^customer-change-id$|^named-operator$") | not))' \
+jq -e --arg placeholder '^(exact|immutable|named-operator|customer-change-id|online-or-offline|full-git-commit-sha|RFC3339|published immutable)' \
+  'to_entries | all(.value | tostring | (length > 0) and (test($placeholder) | not))' \
   "${EVIDENCE_DIR}/metadata.json" >/dev/null
 ```
 
@@ -1031,10 +1032,13 @@ a branch link. A branch URL moves after the fact, which makes the evidence
 unreproducible and does not satisfy M1-20.
 
 The second `jq` is the check worth keeping: it fails if any field is empty or
-still carries one of the schema's placeholder strings. Those placeholders are
-valid non-empty text, so the harness would otherwise accept them and the
-finished record would assert a change ticket and an operator that never
-existed.
+still carries one of the placeholder strings from the schema above. Those
+placeholders are valid non-empty text, so the harness would otherwise accept
+them and the finished record would assert a change ticket and an operator that
+never existed.
+
+If you extend the schema, extend that pattern with it — a placeholder it does
+not match is one the harness will accept.
 
 ## Record the external sign-off
 


### PR DESCRIPTION
## Why

[ENG-9274](https://linear.app/kamiwaza/issue/ENG-9274) depends on an independent executor following this runbook end to end and returning a signed evidence bundle. Reading it as that executor would, they could perform the upgrade **correctly** and still fail the qualification — the last mile was the least specified part of the document.

## Three gaps, verified rather than assumed

**1. `metadata.json` was the only bundle file with no command that writes it.** I checked all seventeen files in `runbook_bundle.EVIDENCE_FILES` against the procedure: sixteen fall out of commands the operator already runs. `metadata.json` got *"Write `${EVIDENCE_DIR}/metadata.json` with these fields"* plus a template of placeholders, six hundred lines from where its values are knowable.

It is also the most strictly validated file in the bundle — `runbook_evidence._metadata` matches `run_id` and `candidate_sha` against the harness ledger and refuses any missing field. Highest-probability failure point in the procedure, and the one an agent is most likely to fill with plausible-looking placeholder text.

**2. Three of its fields had no derivation anywhere in the document**: `installed_chart_version`, `installed_core_image` in the immutable digest form the schema asks for (§2 only produced the mutable tag), and what `maintenance_ticket` means for a run with no customer.

**3. Sign-off was absent entirely** — zero occurrences of `external-signoff`. The approver had no documented field set, no canonical-serialization rule, and no import command.

## What changed

| Section | Change |
| --- | --- |
| §1 (new) *Inputs you must be given* | The five values the executor cannot derive locally, with the note that `run_id`/`candidate_sha` are ledger-matched and cannot be invented |
| §1 (new) *Capture the metadata now* | Derives chart version and image **digest** before the upgrade, while they still describe the cluster being upgraded; `test -n` guards so an empty value fails here rather than hours later |
| M1-20 bundle (new) *Generating `metadata.json`* | A `jq` generator for all 20 fields, plus a guard that refuses a file still carrying the schema's own placeholder strings |
| (new) *Record the external sign-off* | The three bindings, a signing snippet, and the import command |

## The placeholder guard is the part I'd keep

`runbook_evidence` validates these fields with `_text()` — non-empty string. So `"customer-change-id"` and `"named-operator"` **pass**, and the finished release record would assert a change ticket and an operator that never existed. The guard closes the one gap the harness structurally cannot.

## Verification

Both new code blocks were executed, not just written:

- **The `jq` generator** produces exactly the 20 required fields, with `schema_version` as a JSON **number** (the harness compares `== 1`, so a string fails). The placeholder guard passes a clean file and rejects one with `maintenance_ticket` left as `customer-change-id`.
- **The signing snippet** was run against a generated Ed25519 key and its output compared to the real verifier: `json.dumps(payload, sort_keys=True, separators=(",", ":"))` is **byte-identical** to `signoff._signed_bytes(payload)`, and the resulting signature verifies. An approver following it produces something the harness accepts.
- **The import command was corrected before shipping.** My first draft used `scripts/kw_py -m scripts.db_migration_m1.cli`, which cannot work — `cli.py` has a `main()` but no `__main__` guard. The real entry point is `scripts/run_db_migration_m1.py`. This is precisely the class of error the change exists to remove.
- Field list cross-checked against `runbook_evidence._metadata`'s required tuple; role vocabulary matches `signoff._APPROVER_ROLES` (`release-approver` is being added in kamiwaza-internal/kamiwaza#2533, which should land first).

## Note

Docs-only; no behaviour change. `RUNBOOK_URL` is documented as needing a commit-pinned URL — a branch link moves after the fact and makes the evidence unreproducible.

Refs ENG-9274

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.11.0"
generated_at: "2026-08-12T00:12:00Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 191
linear_issues: [ENG-9274]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "3 checks green, 0 failing, on head e9db62ee379779afc678df9bad328967f9c03b6b: 'Docs tests and production build', 'Validate package locks', 'check-linear-issue'. Gate re-verifies."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-11T23:01:23Z; eligible 2026-08-11T23:46:23Z; elapsed at bundle-author time. Gate re-verifies against GitHub's clock."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-9274 present in head branch (docs/eng-9274-m1-20-signoff-procedure), PR title, and PR body. The repo's own check-linear-issue check is green."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Markdown-only diff to a single runbook file. Shell and Python appear solely inside fenced instructional code blocks and contain no debug statements."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review verdict APPROVE posted as issue comment 5260329046, Reviewed-SHA pinned to e9db62ee379779afc678df9bad328967f9c03b6b, which is the current head. Two passes: the first returned REQUEST CHANGES on three items, all fixed in e9db62e and re-verified by execution in the second."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Documentation-only change to one Markdown file in a Docusaurus site. No cluster-running code, no deployed code path, no runtime behaviour of any kind."

manual_steps:
  - id: ms-1
    description: "Confirm the metadata generator the runbook now provides emits exactly what the harness requires, since a rejected bundle is the failure this change exists to prevent."
    observation: "Ran the runbook's `jq -n ... '$ARGS.named'` block verbatim with realistic values and fed the output to the real validator, scripts/db_migration_m1/runbook_evidence.py::_metadata. Result: 'field count: 20, schema_version type: number'; _metadata() returned {'name': 'metadata', 'passed': True, 'detail': 'candidate and release identity match'}; 'missing from generator: []' and 'extra in generator: []'. schema_version being a JSON number rather than a string matters because the code compares == 1."
    status: pass

  - id: ms-2
    description: "Confirm the Ed25519 signing snippet produces an artifact the verifier accepts, rather than leaving the approver to infer the canonical serialization from a rejection."
    observation: "Ran the snippet verbatim against a generated key, then compared in-process with signoff._signed_bytes: 'BYTE-IDENTICAL: True'; 'payload keys == ExternalSignoff: True | symdiff: set()'; 'signature verifies through _signed_bytes: True'; '_approval_fields_valid(release-approver): True'."
    status: pass

  - id: ms-3
    description: "Confirm the placeholder guard covers the schema in both directions, since the schema's own placeholders are valid non-empty text that the harness would otherwise accept."
    observation: "Parsed every value from the metadata schema block and ran each through the actual jq predicate: 13 placeholder-bearing values, all rejected — full-git-commit-sha, online-or-offline, named-operator, customer-change-id, exact-kube-context, exact-installed-chart-version, immutable-image-reference-or-digest, exact-1.2.0-artifact-name-or-digest, 'RFC3339 UTC timestamp' (x2), 'published immutable or versioned URL', 'exact M1-20 CI run URL', 'exact signed qualification/evidence URL'. 18 realistic values all accepted with zero false rejects. End to end the guard exits 0 on a real bundle and 1 when any single field is swapped for its placeholder or emptied."
    status: pass

  - id: ms-4
    description: "Confirm the cross-references resolve, since Docusaurus is configured to warn rather than fail on broken anchors and CI would not catch a dead link."
    observation: "docs/docusaurus.config.ts:59 sets onBrokenAnchors: \"warn\". Extracted all 29 headings, computed github-slugger slugs, and resolved all 16 internal anchors in the file: broken=0. The first verification pass found one dead anchor (#inputs-you-must-be-given-release-qualification-only, a leftover from an earlier heading name); it was fixed in e9db62e and the slug now appears nowhere in the file."
    status: pass

  - id: ms-5
    description: "Confirm the commands read real cluster state rather than plausible-looking selectors, and that the documented entry point exists."
    observation: "Against deploy/charts/core/templates/scheduler/deployment.yaml: pod label is app.kubernetes.io/name: core-scheduler, the container is named core, and the deployment is named core-scheduler — so the -l selector, both jsonpaths and the fallback are correct. Against deploy/charts/kamiwaza/Chart.yaml (name: kamiwaza, version: '1.0.0') installed as release kamiwaza, `helm list -o json` renders .chart as kamiwaza-1.0.0, matching the corrected example. `run_db_migration_m1.py resume --help` shows [--external-signoff EXTERNAL_SIGNOFF] ... run_id, confirming the documented import command is the real entry point."
    status: pass

verdict:
  decision: approve
  rationale: "All five required auto-checks pass and pr-evidence is not applicable to a Markdown-only change. Every executable instruction the change adds was run against the real code: the generator emits exactly the 20 fields runbook_evidence._metadata requires with schema_version as a number, the signing snippet produces bytes byte-identical to signoff._signed_bytes whose signature verifies, the placeholder guard rejects all 13 schema placeholders while accepting 18 realistic values, all 16 internal anchors resolve, and the documented selectors and entry point match the real chart and CLI."

gate:
  approval_submitted: false
  approval_blocked_reason: "Author-time bundle; no formal APPROVE submitted yet. Live gate validation runs next, and the formal review is submitted by the kamiwaza-pr-verify service account via the central approve dispatcher rather than from an operator-held token."
```

</details>

# pr-verify bundle — ENG-9274 M1-20 qualification path

Makes the M1-20 qualification path executable end to end for an independent
runbook executor. Before this change they could perform the upgrade correctly
and still fail the qualification: `metadata.json` was the only one of the
seventeen bundle files with no command that produces it, three of its fields
had no derivation anywhere in the document, and sign-off was not mentioned at
all.

`pr-evidence` is marked not-required because the diff is one Markdown file in a
Docusaurus site — no cluster-running surface of any kind. The manual steps
instead record execution of every command the change adds, against the real
harness code, since a documented command that does not work is precisely the
defect this change exists to remove.

Depends on kamiwaza-internal/kamiwaza#2533, merged as 3b987d1ba, which makes
`release-approver` a valid role.

<!-- pr-verify-end -->