### PR TITLE
ENG-9274: file the license under the installation, not the release owner

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -202,17 +202,17 @@ Supplied by the release owner (a qualification run cannot derive these):
 | `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to | step 1 |
 | `MAINTENANCE_TICKET` | The change record authorizing this run | step 1 |
 | `INTENDED_ARTIFACT` | The exact 1.2.0 artifact name or digest being installed | step 4 |
-| `KEYGEN_LICENSE_KEY` | The license the installer validates at startup | step 4 |
 | `RUNBOOK_URL` | Commit-pinned URL of the revision you followed | metadata |
 | `CI_RUN_URL` | The M1-20 CI run URL | metadata |
 | `M1_EVIDENCE_URL` | Where the signed qualification evidence is published | metadata |
 
-Properties of the installation under test:
+Properties of the installation under test, held by whoever operates it:
 
 | Variable | What it is | First needed |
 | --- | --- | --- |
 | `DOMAIN` | The existing domain of the 1.0.0 installation | step 1 |
 | `ADMIN_PASSWORD` | Its current admin password | step 1 |
+| `KEYGEN_LICENSE_KEY` | The license this installation runs under, from the approved license source. The installer validates it at startup, so a missing or wrong value fails **after** the backup has been taken. | step 4 |
 | `KAMIWAZA_CA_CERT` | Path to the CA certificate validating that domain | step 7 |
 | `INSTALLATION_MODE` | `online` or `offline`, matching the path you take in step 4 | metadata |
 


### PR DESCRIPTION
## What

Moves `KEYGEN_LICENSE_KEY` from the "supplied by the release owner" table to the installation-properties table in the 1.0.0 → 1.2.0 upgrade runbook.

## Why this is a correctness fix, not a preference

I put it in the wrong table in #191. The runbook is written for the general case — a customer operator upgrading their own cluster — and in that case nobody hands them a license. It belongs to the installation, and step 4's own guard has always said so:

```
: "${KEYGEN_LICENSE_KEY:?export KEYGEN_LICENSE_KEY from the approved license source}"
```

"The approved license source", not "the release owner". The table contradicted the guard sitting 200 lines below it.

It also matters for the immediate qualification run: the executor is building the 1.0.0 machine themselves, so they obtain the license as part of standing it up. Reading the old table, they would have waited for someone to send them one.

## Also

Spells out the consequence that makes it worth confirming early: the installer validates the license at startup, so a missing or wrong value fails **after the backup has been taken** — mid-window, at the least convenient moment. That is the whole reason the inputs table exists.

The other table gains a clarifying lead-in: "Properties of the installation under test, **held by whoever operates it**".

## Verification

- All 10 internal anchors still resolve (Docusaurus slug rules; the config sets `onBrokenAnchors: "warn"`, so CI cannot catch a regression here).
- Every `: "${VAR:?...}"` guard in the file is still covered by one of the two tables. `RUN_ID` remains correctly absent — it is derived in step 1 from `KAMIWAZA_M1_RUN_ID`, which is listed.

Docs-only; no behaviour change.

Refs ENG-9274

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.11.0"
generated_at: "2026-08-12T16:50:00Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 192
linear_issues: [ENG-9274]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "3 checks green, 0 failing, on head 6135483f523d5e5f2ac127bd425d44fe80d9ef44: 'Docs tests and production build', 'Validate package locks', 'check-linear-issue'. Gate re-verifies."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-12T01:38:16Z; eligible 2026-08-12T02:23:16Z; roughly 15 hours elapsed at bundle-author time. Gate re-verifies against GitHub's clock."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-9274 present in head branch (docs/eng-9274-license-ownership), PR title, and PR body. The repo's own check-linear-issue check is green."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Markdown-only diff: one table row moved and one lead-in clause changed in a single runbook file. No code added."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review verdict APPROVE posted as issue comment 5269770720, Reviewed-SHA pinned to 6135483f523d5e5f2ac127bd425d44fe80d9ef44, which is the current head."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Documentation-only change to one Markdown file in a Docusaurus site. No cluster-running code, no deployed code path, no runtime behaviour."

manual_steps:
  - id: ms-1
    description: "Confirm the change removes a real contradiction rather than restating a preference, by checking the table against the runbook's own guard."
    observation: "The runbook's step 4 contains `: \"${KEYGEN_LICENSE_KEY:?export KEYGEN_LICENSE_KEY from the approved license source}\"` — the approved license source, not the release owner. The pre-change table listed the variable under 'Supplied by the release owner', contradicting the guard 200 lines below it. After the change the variable sits in the installation-properties table, whose lead-in now reads 'Properties of the installation under test, held by whoever operates it'."
    status: pass

  - id: ms-2
    description: "Verify the new factual claim that a bad license fails after the backup has been taken, since that is the reason the runbook tells an operator to confirm it early."
    observation: "Section ordering in the file confirms it: '## 3. Back up and validate the database' is at line 289, and '## 4. Run the supported installer once' — where the KEYGEN_LICENSE_KEY guard fires — is at line 381. The backup genuinely precedes the failure point."
    status: pass

  - id: ms-3
    description: "Re-verify internal anchors and required-export coverage at the reviewed head, because Docusaurus is configured to warn rather than fail on broken anchors and CI cannot catch a regression."
    observation: "Checked out at 6135483f523d5e5f2ac127bd425d44fe80d9ef44 (confirmed identical to the PR head). All 10 internal anchors resolve against the file's 29 headings under github-slugger rules: broken=0. Of the 11 `: \"${VAR:?...}\"` guards in the file, 10 appear in the two tables; the only uncovered one is RUN_ID, which is correct because it is derived in step 1 from KAMIWAZA_M1_RUN_ID, and that variable is listed. docs/docusaurus.config.ts:59 sets onBrokenAnchors: \"warn\"."
    status: pass

verdict:
  decision: approve
  rationale: "All five required auto-checks pass and pr-evidence is not applicable to a Markdown-only change. The edit removes a contradiction between a summary table and the guard it summarizes, the added ordering claim was verified against the document's own structure, and anchors plus export coverage were re-checked at the reviewed head."

gate:
  approval_submitted: false
  approval_blocked_reason: "Author-time bundle; no formal APPROVE submitted yet. Live gate validation runs next, and the formal review is submitted by the kamiwaza-pr-verify service account via the central approve dispatcher rather than from an operator-held token."
```

</details>

# pr-verify bundle — ENG-9274 license ownership

Moves `KEYGEN_LICENSE_KEY` from the release-owner table to the installation-properties
table in the 1.0.0 → 1.2.0 upgrade runbook, correcting a contradiction introduced by
kamiwaza-ai/kamiwaza-docs#191 between that table and step 4's own guard.

`pr-evidence` is marked not-required because the diff is six lines of Markdown in a
documentation site. The manual steps instead record verification of the claim the change
makes and of the two properties CI cannot check for this file — anchor resolution and
required-export coverage.

<!-- pr-verify-end -->