### PR TITLE
ENG-9274: close three gaps the independent executor hit

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -98,6 +98,8 @@ within one 10-second period once `core-db-init` completes.
 | Ray head pod `Running` but **not Ready**, with its READY column one container short (`2/3` where the mesh sidecar is present), while `core-db-init` is pre-head | Correct. The gate is holding. | Wait. Continue to observe `core-db-init`. |
 | `core-api` has no endpoints, and requests to it fail or return 503, during that same window | Correct, and it follows directly from the line above. | Wait. Do not restart anything. |
 | Ray head becomes Ready and `core-api` endpoints reappear shortly after `core-db-init` succeeds | Correct. The gate has reopened. | Continue to [step 6](#6-verify-the-schema-from-the-running-core-image). |
+| `core-postgres-0` is recreated during the upgrade — a young pod age where you expected an old one | Correct. The platform sync rolls the PostgreSQL pod; the data lives on its volume and is unaffected. | Continue. Verify data after the upgrade in [step 6](#6-verify-the-schema-from-the-running-core-image), not by pod age. |
+| The core schema marker still reads `core` / `1.0` after a successful upgrade | Correct — see [step 6](#6-verify-the-schema-from-the-running-core-image). The marker records the schema **contract** the database satisfies, which 1.2.0 does not change. There is no `1.2` marker value and you will never see one. | Continue. Judge success by `state`, `supported`, `migration_required`, and the head revisions. |
 | Ray head still not Ready well **after** the schema has reached head | Not expected. | Collect evidence and escalate to Support. Do not delete the pod. |
 | `schema-readiness` container is in `CrashLoopBackOff` | Not expected — almost always chart/image skew. | See [image contract](#image-contract-do-not-pin-an-older-core-image) below. |
 
@@ -677,7 +679,14 @@ Required result:
 - `state` is `at_head`;
 - `supported` is `true`;
 - `migration_required` is `false`;
-- `marker_version` is `1.0` and `marker.tsv` contains exactly `core<TAB>1.0`;
+- `marker_version` is `1.0` and `marker.tsv` contains exactly `core<TAB>1.0`.
+  **This is correct after a successful 1.2.0 upgrade and is the single most
+  misread line in this procedure.** The marker names the schema contract the
+  database satisfies, not the product release you installed. 1.2.0 does not
+  advance it, no `1.2` marker value exists, and a marker reading `1.0` is
+  therefore evidence of success rather than of an incomplete upgrade. Judge the
+  upgrade by `state`, `supported`, `migration_required`, and the head revisions
+  below;
 - `db_heads` contains exactly one revision;
 - `code_heads` contains exactly one revision and equals `db_heads`.
 
@@ -981,6 +990,32 @@ For M1 qualification, `metadata.json` must include:
 Before publishing M1 evidence, enforce the exact file list above, then run the
 same secret scan and manual review documented in
 [Customer support bundle](#customer-support-bundle).
+
+### What `intended_artifact` has to record
+
+Record **both** the installer's SHA-256 **and** the core image digest the
+install actually resolved. Either alone is insufficient, for different reasons.
+
+The installer is immutable once built, so its checksum identifies the payload
+exactly. But the payload contains no Kamiwaza code — it pulls images at install
+time, and the chart's core image is a floating tag with `pullPolicy: Always`.
+That is deliberate: the `schema-readiness` container runs a module that exists
+only on the development line, so a fixed release tag would not carry the gate
+this upgrade depends on. The consequence is that the tag can move between the
+moment you record the installer checksum and the moment the image is pulled.
+
+So capture the digest that was actually pulled, after the upgrade:
+
+```bash
+kubectl get pods -n "${NAMESPACE}" \
+  -o jsonpath='{range .items[*]}{.status.containerStatuses[*].imageID}{"\n"}{end}' \
+  | sort -u
+```
+
+Together the two are reproducible: the checksum says which installer ran, and
+the digest says which code it installed. Neither question can be answered later
+from the other, and the image carries no source-commit label to recover it
+from.
 
 ### Generating `metadata.json`
 

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -98,7 +98,7 @@ within one 10-second period once `core-db-init` completes.
 | Ray head pod `Running` but **not Ready**, with its READY column one container short (`2/3` where the mesh sidecar is present), while `core-db-init` is pre-head | Correct. The gate is holding. | Wait. Continue to observe `core-db-init`. |
 | `core-api` has no endpoints, and requests to it fail or return 503, during that same window | Correct, and it follows directly from the line above. | Wait. Do not restart anything. |
 | Ray head becomes Ready and `core-api` endpoints reappear shortly after `core-db-init` succeeds | Correct. The gate has reopened. | Continue to [step 6](#6-verify-the-schema-from-the-running-core-image). |
-| `core-postgres-0` is recreated during the upgrade — a young pod age where you expected an old one | Correct. The platform sync rolls the PostgreSQL pod; the data lives on its volume and is unaffected. | Continue. Verify data after the upgrade in [step 6](#6-verify-the-schema-from-the-running-core-image), not by pod age. |
+| `core-postgres-0` is recreated during the upgrade — a young pod age where you expected an old one | Correct. The platform sync rolls the PostgreSQL pod; the data lives on its volume and is unaffected by the roll. | Continue. The volume is what preserves the data. [Step 6](#6-verify-the-schema-from-the-running-core-image) then verifies the schema, which is the condition this runbook gates on — judge the roll by that, not by pod age. |
 | The core schema marker still reads `core` / `1.0` after a successful upgrade | Correct — see [step 6](#6-verify-the-schema-from-the-running-core-image). The marker records the schema **contract** the database satisfies, which 1.2.0 does not change. There is no `1.2` marker value and you will never see one. | Continue. Judge success by `state`, `supported`, `migration_required`, and the head revisions. |
 | Ray head still not Ready well **after** the schema has reached head | Not expected. | Collect evidence and escalate to Support. Do not delete the pod. |
 | `schema-readiness` container is in `CrashLoopBackOff` | Not expected — almost always chart/image skew. | See [image contract](#image-contract-do-not-pin-an-older-core-image) below. |
@@ -203,7 +203,7 @@ Supplied by the release owner (a qualification run cannot derive these):
 | `KAMIWAZA_M1_RUN_ID` | The harness run this evidence belongs to | step 1 |
 | `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to | step 1 |
 | `MAINTENANCE_TICKET` | The change record authorizing this run | step 1 |
-| `INTENDED_ARTIFACT` | The exact 1.2.0 artifact name or digest being installed | step 4 |
+| `INTENDED_ARTIFACT` | The exact 1.2.0 payload installed — offline, the candidate's `release_origination.md` manifest; online, the installer checksum plus the resolved core image digest. See [what `intended_artifact` has to record](#what-intended_artifact-has-to-record). | step 4 offline; finalized after the upgrade online |
 | `RUNBOOK_URL` | Commit-pinned URL of the revision you followed | metadata |
 | `CI_RUN_URL` | The M1-20 CI run URL | metadata |
 | `M1_EVIDENCE_URL` | Where the signed qualification evidence is published | metadata |
@@ -390,13 +390,17 @@ the evidence bundle.
 ### Online upgrade
 
 Obtain `kamiwaza-online-install.sh` and its `.sha256` file from the approved
-1.2.0 release-candidate artifact location recorded in `intended_artifact`.
-Do not reuse an installer URL or script retained from an earlier release.
-Verify the candidate before running it:
+1.2.0 release-candidate artifact location. Do not reuse an installer URL or
+script retained from an earlier release. Verify the candidate before running
+it, and retain the checksum — on this path `intended_artifact` is finalized
+after the upgrade from this value plus the resolved image digest, per
+[What `intended_artifact` has to record](#what-intended_artifact-has-to-record):
 
 ```bash
 sha256sum -c kamiwaza-online-install.sh.sha256
 chmod +x kamiwaza-online-install.sh
+
+INSTALLER_SHA256=$(sha256sum kamiwaza-online-install.sh | awk '{print $1}')
 ```
 
 Then run the verified candidate once. `--keep-extract` retains the exact
@@ -993,24 +997,48 @@ same secret scan and manual review documented in
 
 ### What `intended_artifact` has to record
 
-Record **both** the installer's SHA-256 **and** the core image digest the
-install actually resolved. Either alone is insufficient, for different reasons.
+`intended_artifact` names the exact payload this run installed. What satisfies
+it differs by installation mode, and on the online path it is **finalized after
+the upgrade**, not before.
 
-The installer is immutable once built, so its checksum identifies the payload
-exactly. But the payload contains no Kamiwaza code — it pulls images at install
-time, and the chart's core image is a floating tag with `pullPolicy: Always`.
-That is deliberate: the `schema-readiness` container runs a module that exists
-only on the development line, so a fixed release tag would not carry the gate
-this upgrade depends on. The consequence is that the tag can move between the
-moment you record the installer checksum and the moment the image is pulled.
+**Offline.** The staged candidate's own `release_origination.md` manifest is the
+record, exactly as [Offline upgrade](#offline-upgrade) instructs. That path
+pins every image to an exact, non-floating tag taken from the manifest, so the
+manifest alone identifies the payload. Nothing further is required here.
 
-So capture the digest that was actually pulled, after the upgrade:
+**Online.** Record **both** the installer's SHA-256 **and** the core image
+digest the install actually resolved. Either alone is insufficient. The
+installer is immutable once built, so its checksum identifies the payload
+exactly — but that payload carries no Kamiwaza code. It pulls images at install
+time, and the online chart resolves the core image through a floating tag with
+`pullPolicy: Always`, so the tag can move between the moment you verify the
+installer checksum and the moment the image is pulled.
+
+Capture the resolved digest after the upgrade, with the same selector used in
+[Capture the metadata now](#capture-the-metadata-now-not-at-the-end) so the
+result is a single assignable value rather than every container in the
+namespace:
 
 ```bash
-kubectl get pods -n "${NAMESPACE}" \
-  -o jsonpath='{range .items[*]}{.status.containerStatuses[*].imageID}{"\n"}{end}' \
-  | sort -u
+INSTALLED_CORE_DIGEST=$(kubectl get pods -n "${NAMESPACE}" \
+  -l app.kubernetes.io/name=core-scheduler \
+  -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="core")].imageID}{"\n"}{end}' \
+  | sed '/^$/d' | sort -u)
+
+# Exactly one digest is required. Empty means no core pod reported an imageID
+# yet — wait and re-run rather than recording a blank field. More than one means
+# the tag moved during the install and the pods are not running the same code:
+# stop, and re-run the upgrade against a pinned digest. Do not pick one of them.
+test -n "${INSTALLED_CORE_DIGEST}"
+test "$(printf '%s\n' "${INSTALLED_CORE_DIGEST}" | wc -l)" -eq 1
+
+export INTENDED_ARTIFACT="installer=sha256:${INSTALLER_SHA256};core-image=${INSTALLED_CORE_DIGEST}"
 ```
+
+`INSTALLER_SHA256` is the value captured when you verified the installer in
+[Online upgrade](#online-upgrade). The two fields are semicolon-delimited and
+each is `name=value`, so the pair stays parseable in the single
+`intended_artifact` string the bundle contract allows.
 
 Together the two are reproducible: the checksum says which installer ran, and
 the digest says which code it installed. Neither question can be answered later

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -196,14 +196,17 @@ The procedure requires these exports, spread across steps 1, 4, 7 and the
 qualification sections. Every one of them stops the run where it is first
 referenced, so collect them now rather than discovering the gap mid-window.
 
-Supplied by the release owner (a qualification run cannot derive these):
+Supplied by the release owner (a qualification run cannot derive these), with
+one exception called out in the table — on the online path `INTENDED_ARTIFACT`
+is completed by the run itself, because half of it does not exist until the
+upgrade has pulled its images:
 
 | Variable | What it is | First needed |
 | --- | --- | --- |
 | `KAMIWAZA_M1_RUN_ID` | The harness run this evidence belongs to | step 1 |
 | `CANDIDATE_SHA` | The full 1.2.0 candidate commit the run is pinned to | step 1 |
 | `MAINTENANCE_TICKET` | The change record authorizing this run | step 1 |
-| `INTENDED_ARTIFACT` | The exact 1.2.0 payload installed — offline, the candidate's `release_origination.md` manifest; online, the installer checksum plus the resolved core image digest. See [what `intended_artifact` has to record](#what-intended_artifact-has-to-record). | step 4 offline; finalized after the upgrade online |
+| `INTENDED_ARTIFACT` | The exact 1.2.0 payload installed — offline, the candidate's `release_origination.md` checksum; online, the installer checksum plus the resolved core image digest. Both are composed in [what `intended_artifact` has to record](#what-intended_artifact-has-to-record). | metadata |
 | `RUNBOOK_URL` | Commit-pinned URL of the revision you followed | metadata |
 | `CI_RUN_URL` | The M1-20 CI run URL | metadata |
 | `M1_EVIDENCE_URL` | Where the signed qualification evidence is published | metadata |
@@ -401,7 +404,14 @@ sha256sum -c kamiwaza-online-install.sh.sha256
 chmod +x kamiwaza-online-install.sh
 
 INSTALLER_SHA256=$(sha256sum kamiwaza-online-install.sh | awk '{print $1}')
+test -n "${INSTALLER_SHA256}"
+export INSTALLER_SHA256
 ```
+
+The `test` and the `export` are deliberate, for the same reason as the baseline
+capture above: this value is consumed after the upgrade, and an empty or
+shell-local one becomes a bundle that is refused hours later — or worse, one
+that ships an empty installer checksum the placeholder guard cannot catch.
 
 Then run the verified candidate once. `--keep-extract` retains the exact
 candidate's deploy payload so its diagnostics collector remains available at
@@ -1002,9 +1012,19 @@ it differs by installation mode, and on the online path it is **finalized after
 the upgrade**, not before.
 
 **Offline.** The staged candidate's own `release_origination.md` manifest is the
-record, exactly as [Offline upgrade](#offline-upgrade) instructs. That path
-pins every image to an exact, non-floating tag taken from the manifest, so the
-manifest alone identifies the payload. Nothing further is required here.
+record, exactly as [Offline upgrade](#offline-upgrade) instructs. That path pins
+every image to an exact, non-floating tag taken from the manifest, so the
+manifest identifies the payload on its own. Record it by checksum rather than by
+path — the manifest is not in the evidence file list, so a local path stops
+identifying anything once the workspace is gone:
+
+```bash
+RELEASE_ORIGINATION_SHA256=$(sha256sum "${PREREQ_DIR}/release_origination.md" \
+  | awk '{print $1}')
+test -n "${RELEASE_ORIGINATION_SHA256}"
+
+export INTENDED_ARTIFACT="release-origination=sha256:${RELEASE_ORIGINATION_SHA256}"
+```
 
 **Online.** Record **both** the installer's SHA-256 **and** the core image
 digest the install actually resolved. Either alone is insufficient. The
@@ -1014,31 +1034,48 @@ time, and the online chart resolves the core image through a floating tag with
 `pullPolicy: Always`, so the tag can move between the moment you verify the
 installer checksum and the moment the image is pulled.
 
-Capture the resolved digest after the upgrade, with the same selector used in
-[Capture the metadata now](#capture-the-metadata-now-not-at-the-end) so the
-result is a single assignable value rather than every container in the
-namespace:
+Capture the resolved digest after the upgrade, with the same label selector used
+in [Capture the metadata now](#capture-the-metadata-now-not-at-the-end), widened
+to every matching pod so that a disagreement between pods is detectable rather
+than invisible:
 
 ```bash
-INSTALLED_CORE_DIGEST=$(kubectl get pods -n "${NAMESPACE}" \
+: "${INSTALLER_SHA256:?export INSTALLER_SHA256 from the online installer verification in step 4}"
+
+CORE_POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" \
+  -l app.kubernetes.io/name=core-scheduler \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | sed '/^$/d' | wc -l)
+
+CORE_IMAGE_IDS=$(kubectl get pods -n "${NAMESPACE}" \
   -l app.kubernetes.io/name=core-scheduler \
   -o jsonpath='{range .items[*]}{.status.containerStatuses[?(@.name=="core")].imageID}{"\n"}{end}' \
-  | sed '/^$/d' | sort -u)
+  | sed '/^$/d')
 
-# Exactly one digest is required. Empty means no core pod reported an imageID
-# yet — wait and re-run rather than recording a blank field. More than one means
-# the tag moved during the install and the pods are not running the same code:
-# stop, and re-run the upgrade against a pinned digest. Do not pick one of them.
+# Every selected pod must have reported an imageID. A pod still pending or
+# starting has not resolved the tag yet, and accepting the digest now would
+# finalize evidence a later-starting pod could contradict. Wait for the rollout
+# to complete, then re-run this block.
+test "$(printf '%s\n' "${CORE_IMAGE_IDS}" | wc -l)" -eq "${CORE_POD_COUNT}"
+
+INSTALLED_CORE_DIGEST=$(printf '%s\n' "${CORE_IMAGE_IDS}" | sort -u)
 test -n "${INSTALLED_CORE_DIGEST}"
+
+# Exactly one distinct digest is required. More than one means the tag moved
+# during the install and the pods are not running the same code. That is a
+# stopped upgrade: preserve the evidence and escalate to Kamiwaza Support per
+# the stop rules. Do not record a digest, do not pick one of them, and do not
+# re-run the installer — a retry needs Support's approval.
 test "$(printf '%s\n' "${INSTALLED_CORE_DIGEST}" | wc -l)" -eq 1
 
 export INTENDED_ARTIFACT="installer=sha256:${INSTALLER_SHA256};core-image=${INSTALLED_CORE_DIGEST}"
 ```
 
-`INSTALLER_SHA256` is the value captured when you verified the installer in
-[Online upgrade](#online-upgrade). The two fields are semicolon-delimited and
-each is `name=value`, so the pair stays parseable in the single
-`intended_artifact` string the bundle contract allows.
+`INSTALLER_SHA256` is exported when you verify the installer in
+[Online upgrade](#online-upgrade); the `:?` above stops the run here rather than
+letting an unset value ship a bundle whose installer field is empty. The two
+fields are semicolon-delimited and each is `name=value`, so the pair stays
+parseable in the single `intended_artifact` string the bundle contract allows.
 
 Together the two are reproducible: the checksum says which installer ran, and
 the digest says which code it installed. Neither question can be answered later
@@ -1058,7 +1095,7 @@ export FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 : "${CI_RUN_URL:?export the exact M1-20 CI run URL}"
 : "${M1_EVIDENCE_URL:?export the signed qualification evidence URL}"
 : "${INSTALLATION_MODE:?export online or offline}"
-: "${INTENDED_ARTIFACT:?export the exact 1.2.0 artifact name or digest}"
+: "${INTENDED_ARTIFACT:?export it per 'What intended_artifact has to record'}"
 : "${RUNBOOK_URL:?export the versioned URL of the runbook you followed}"
 
 jq -n \


### PR DESCRIPTION
## Where these came from

The first end-to-end 1.0.0 → 1.2.0 upgrade performed by someone who did not write this runbook, on a real RHEL 9 box. **The upgrade succeeded** — every gate green. These are the places the document let the executor down along the way.

All three are gaps where the runbook was **silent** rather than wrong, which is the kind you cannot find from the inside: you already know the answer, so you never notice it isn't written down.

## 1. The schema marker stays `core` / `1.0` — and nothing said so

Step 6 correctly requires `marker_version` is `1.0`. But someone who has just upgraded *to 1.2.0*, reads the marker, and sees `1.0` has every reason to conclude the upgrade didn't finish.

I checked before changing anything: there is no `at_head (1.2)` string anywhere in the runbook, and `at_head` is a bare enum in `kamiwaza/db/schema_state.py` with no version qualifier. So this isn't a wrong statement to correct — it's a missing one. The marker names the schema **contract** the database satisfies, not the product release, and 1.2.0 does not advance it.

Stated now at the check itself and in the expected-observations table, because whichever a reader reaches first has to answer it. Left-field consequence if unfixed: false failure reports from the field on upgrades that worked.

## 2. PostgreSQL is recreated during the upgrade

`core-postgres-0` gets rolled by the platform sync — routine, data is on the volume. But the table two sections up already tells operators **"Do not restart anything"**, so an unexplained young pod age reads as exactly the fault they were warned about. Added as an expected observation, with the note to verify data in step 6 rather than by pod age.

## 3. `intended_artifact` could not be satisfied as written

The schema asks for an artifact name or digest. The installer is immutable, so its checksum identifies the payload — but the payload contains **no Kamiwaza code**. It pulls images at install time, and the chart's core image is a floating tag with `pullPolicy: Always`.

That's deliberate and correct: the `schema-readiness` container runs a module that exists only on the development line, so a fixed release tag wouldn't carry the gate this upgrade depends on. The consequence is that the tag can move between recording the checksum and pulling the image.

So the guidance is now: record **both** the installer SHA-256 and the resolved core image digest, with the command to capture the latter. The checksum says which installer ran; the digest says which code it installed. Neither is recoverable from the other afterwards, because the image carries no `org.opencontainers.image.revision` label — I checked.

Two independent parties reached this same conclusion separately, which is part of why it's worth writing down.

## Verification

- All 10 internal anchors resolve (Docusaurus slug rules). `onBrokenAnchors: "warn"`, so CI cannot catch a regression here — this check is the only gate.
- The `metadata.json` placeholder guard still rejects every schema placeholder: `exact-1.2.0-artifact-name-or-digest`, `immutable-image-reference-or-digest`, `customer-change-id`. I added prose rather than editing the placeholder strings precisely because the guard matches on them.

Docs-only; no behaviour change.

## Not in this PR

Two release-level defects the same run surfaced, filed separately because they are code, not docs:

- **ENG-10261** (Urgent) — the online installer's Phase 2 unconditionally switches to a Kind context, which breaks every k0s-on-metal RHEL 9 upgrade. `install-prod.sh` already gates this correctly; the online wrapper reimplements it without the gate.
- **ENG-10262** (High) — `--keygen-tag` is inert: six values files are written and no helmfile release consumes them, so a licensed install silently pulls from GHCR.
- **ENG-10263** (High) — the diagnostics collector exits 0 with Helm evidence missing when run under `sudo`.

Refs ENG-9274

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.11.0"
generated_at: "2026-08-13T18:34:21Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 193
linear_issues: [ENG-9274]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "All three required checks green on head 44bdd77 at bundle-author time (Docs tests and production build, Validate package locks, check-linear-issue). Gate will re-verify."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-13T03:12:41Z; the 45-minute floor elapsed many hours before this bundle was authored. Gate will re-verify against GitHub's clock."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Documentation-only change to a single Markdown runbook; no cluster-running code is touched, so the cluster-smoke sentinel is not applicable."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-9274 present in the head branch name, the PR title, and the PR body reference line."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff scanned; the only added executable text is documented kubectl/sha256sum example blocks inside the runbook. No console.log, debugger, pdb.set_trace, or breakpoint anywhere in the diff."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review multi-engine review reached APPROVE on round 3 and is posted as a SHA-pinned issue comment against head 44bdd77aeaae6b46a225499d34be15e1cfa716b3. Rounds 1 and 2 returned REQUEST_CHANGES and their findings were fixed in 4302231 and 44bdd77."

manual_steps: []

verdict:
  decision: approve
  rationale: "Docs-only runbook change with all required checks green and a round-3 /pr-review APPROVE pinned to the current head; no live-stack surface exists for a click-through observation, so manual_steps is empty rather than invented."

gate:
  approval_submitted: false
```

</details>


<!-- pr-verify-end -->