### PR TITLE
ENG-10271: match the public upgrade runbook to the current diagnostics collector

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -576,7 +576,24 @@ are removed before the next hook creation, so collect evidence promptly.
 
 Run the 1.2.0 production payload's deterministic collector on both success and
 failure paths. Support diagnosis and M1 qualification both require its cluster,
-db-init, and Helm outputs even when the upgrade succeeds:
+db-init, and Helm outputs even when the upgrade succeeds.
+
+Name the two collector binaries explicitly. The collector resolves `kubectl`
+and `helm` once, up front, and a tool it cannot resolve is a hole in the bundle
+that ends the run at exit 1 — it no longer proceeds and reports success with
+the Helm half missing. Resolve the paths in your own shell so they are correct
+on any host, and check them before the collector needs them:
+
+```bash
+KUBECTL_PATH="$(command -v kubectl)" || KUBECTL_PATH=''
+HELM_PATH="$(command -v helm)" || HELM_PATH=''
+test -n "${KUBECTL_PATH}"
+test -n "${HELM_PATH}"
+```
+
+An empty value here is the same finding the collector would report a step
+later: install or locate the missing tool before running the collector, rather
+than accepting a bundle without it.
 
 ```bash
 COLLECTOR_RC=0
@@ -584,11 +601,12 @@ COLLECTOR_COMMAND_FAILURES=0
 COLLECTOR_EVIDENCE_COMPLETE=0
 
 "${COLLECTOR_COMMAND}" \
-  "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" || COLLECTOR_RC=$?
+  "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}" || COLLECTOR_RC=$?
 
 if [[ "${COLLECTOR_RC}" -ne 0 ]]; then
-  printf 'stop: diagnostics collector failed before evidence merge (exit %s)\n' \
-    "${COLLECTOR_RC}" >&2
+  printf 'stop: diagnostics bundle is incomplete (exit %s); %s names what is missing\n' \
+    "${COLLECTOR_RC}" "${COLLECTOR_DIR}/manifest.txt" >&2
 else
   # The collector deliberately requires a new or empty, non-symlink target.
   # Merge evidence before classifying failures observed in the cluster.
@@ -596,11 +614,12 @@ else
   cp -a "${COLLECTOR_DIR}/db-init/." "${EVIDENCE_DIR}/db-init/"
   cp -a "${COLLECTOR_DIR}/helm/." "${EVIDENCE_DIR}/helm/"
 
-  awk '
-    BEGIN { failed = 0 }
-    /^command=/ && $0 !~ / status=0$/ { print; failed = 1 }
-    END { exit failed }
-  ' "${COLLECTOR_DIR}/manifest.txt" || COLLECTOR_COMMAND_FAILURES=1
+  # Exit zero says both collectors produced evidence, not that every command
+  # succeeded. The failures are the manifest lines marked result=failed.
+  if grep -q ' result=failed ' "${COLLECTOR_DIR}/manifest.txt"; then
+    grep ' result=failed ' "${COLLECTOR_DIR}/manifest.txt" >&2
+    COLLECTOR_COMMAND_FAILURES=1
+  fi
 
   if test -s "${EVIDENCE_DIR}/db-init/pod-describe.txt" && \
     test -s "${EVIDENCE_DIR}/db-init/all-attempts.log"; then
@@ -624,10 +643,11 @@ namespace state and events, and Helm status/history. For a pod that never
 started, the pod description and events are authoritative; an empty container
 log alone is not evidence that migration code ran.
 
-`COLLECTOR_RC` nonzero means the collector itself failed. A
-`COLLECTOR_COMMAND_FAILURES` value of 1 means collection succeeded but observed
-one or more failing cluster commands; preserve the merged evidence and stop for
-Support review. `COLLECTOR_EVIDENCE_COMPLETE` must be 1 for M1 qualification.
+`--namespace` and `--release` are also accepted as flags; the positional
+`DIR [NAMESPACE] [RELEASE]` form above is still supported. Both binary options
+require a value containing a `/`, because a bare name would be re-resolved
+through `PATH` when the command runs — so the binary that executes need not be
+the one that was checked.
 
 ```bash
 if [[ "${INSTALL_RC}" -ne 0 ]]; then
@@ -639,6 +659,63 @@ test "${INSTALL_RC}" -eq 0
 
 If Support approves a retry, start again with a new `RUN_ID`, `EVIDENCE_DIR`,
 and `COLLECTOR_DIR`. Never reuse or overwrite the first attempt's evidence.
+
+### If you run the collector under `sudo`
+
+`sudo` replaces `PATH` with `secure_path`. On RHEL 9 that keeps `/usr/bin`,
+where the packaged `kubectl` lives, but not `/usr/local/bin`, where `helm` is
+installed — so `helm` is the half that disappears, and the run ends at exit 1
+naming it. The `--kubectl-bin` / `--helm-bin` values above are expanded by your
+own shell before `sudo` runs, so they carry through correctly and are the form
+to use:
+
+```bash
+sudo "${COLLECTOR_COMMAND}" \
+  "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+```
+
+`KUBECTL_BIN` / `HELM_BIN` environment variables do the same job, but only for
+non-`sudo` invocations: `env_reset` strips them, and default RHEL 9 sudoers
+refuses `sudo KUBECTL_BIN=... `. Carrying your own `PATH` through instead —
+`sudo env "PATH=$PATH" ...` — also works, but it defeats `secure_path`: any
+user-writable directory on your `PATH` can then supply the `kubectl`, `helm`,
+or `bash` that runs as root. Prefer the explicit paths above on production
+hosts. `env_reset` drops more than `PATH` — `KUBECONFIG` goes with it and
+`HOME` becomes root's — so if the kubeconfig you want is not root's default,
+carry it through `env` rather than as a `sudo` variable assignment:
+`sudo env "KUBECONFIG=$KUBECONFIG" "${COLLECTOR_COMMAND}" ... --kubectl-bin ...`.
+
+### Reading the manifest and the exit status
+
+Read `manifest.txt` on every run, not only on a failure. Each line carries the
+command's exit status plus an explicit `result=`:
+
+| `result=` | Meaning |
+| --- | --- |
+| `collected` | Ran, succeeded, produced output; `bytes=` counts it. |
+| `collected-empty` | Ran and succeeded, but there was nothing to report. |
+| `failed` | Ran and failed. `bytes=` counts the command's error text, not evidence. |
+| `not-collected` | Never ran; `reason=` says why (the tool was unresolvable). |
+
+That distinction is the point of the manifest: it tells a reader who was not
+present whether an absent answer means "nothing to report", "the cluster
+refused", or "never asked". Treat a `failed` line's output as an error message,
+never as evidence.
+
+Exit status is symmetric across both halves of the bundle. `COLLECTOR_RC` of 1
+means the bundle is **incomplete** — `kubectl` or `helm` was unresolvable, or
+resolved but had every one of its invocations fail — and `manifest.txt` names
+what is missing. `COLLECTOR_RC` of 2 is a usage error or an evidence path that
+is unsafe to write (an existing non-empty directory, a symbolic link, or a
+non-directory); correct the argument or choose a new `COLLECTOR_DIR` and re-run.
+Exit zero means both collectors produced evidence — it does **not** mean every
+command succeeded. A run where some commands failed (a Job that does not exist,
+an RBAC denial on one resource) still exits zero, prints
+`warning: N collection command(s) failed` to stderr, and marks each one
+`result=failed`; that is the case `COLLECTOR_COMMAND_FAILURES` catches, and it
+is still a stop for Support review. `COLLECTOR_EVIDENCE_COMPLETE` must be 1 for
+M1 qualification.
 
 ## 6. Verify the schema from the running core image
 

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -604,7 +604,11 @@ COLLECTOR_EVIDENCE_COMPLETE=0
   "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}" || COLLECTOR_RC=$?
 
-if [[ "${COLLECTOR_RC}" -ne 0 ]]; then
+if [[ "${COLLECTOR_RC}" -eq 2 ]]; then
+  # Exit 2 is refused before the evidence tree exists, so there is no manifest
+  # to consult — the argument or the target path is what needs correcting.
+  printf 'stop: collector refused the invocation (exit 2); fix the argument or use a new COLLECTOR_DIR\n' >&2
+elif [[ "${COLLECTOR_RC}" -ne 0 ]]; then
   printf 'stop: diagnostics bundle is incomplete (exit %s); %s names what is missing\n' \
     "${COLLECTOR_RC}" "${COLLECTOR_DIR}/manifest.txt" >&2
 else
@@ -616,8 +620,20 @@ else
 
   # Exit zero says both collectors produced evidence, not that every command
   # succeeded. The failures are the manifest lines marked result=failed.
-  if grep -q ' result=failed ' "${COLLECTOR_DIR}/manifest.txt"; then
-    grep ' result=failed ' "${COLLECTOR_DIR}/manifest.txt" >&2
+  # Capture grep's status rather than branching on it directly: grep exits 1
+  # for "no failures" but 2 for "could not read the manifest", and treating
+  # those alike would report a clean bundle for one nobody could open.
+  # FAILED_LINES, not LINES — the shell keeps its own LINES.
+  FAILED_LINES=''
+  MANIFEST_GREP_RC=0
+  FAILED_LINES=$(grep ' result=failed ' "${COLLECTOR_DIR}/manifest.txt") \
+    || MANIFEST_GREP_RC=$?
+  if [[ -n "${FAILED_LINES}" ]]; then
+    printf '%s\n' "${FAILED_LINES}" >&2
+    COLLECTOR_COMMAND_FAILURES=1
+  elif [[ "${MANIFEST_GREP_RC}" -gt 1 ]]; then
+    printf 'stop: %s could not be read (grep exit %s)\n' \
+      "${COLLECTOR_DIR}/manifest.txt" "${MANIFEST_GREP_RC}" >&2
     COLLECTOR_COMMAND_FAILURES=1
   fi
 
@@ -644,10 +660,15 @@ started, the pod description and events are authoritative; an empty container
 log alone is not evidence that migration code ran.
 
 `--namespace` and `--release` are also accepted as flags; the positional
-`DIR [NAMESPACE] [RELEASE]` form above is still supported. Both binary options
-require a value containing a `/`, because a bare name would be re-resolved
-through `PATH` when the command runs — so the binary that executes need not be
-the one that was checked.
+`DIR [NAMESPACE] [RELEASE]` form above is still supported. Every option also
+takes the `--option=value` form, which is how to pass a value that legitimately
+begins with `-`. Both binary options need a path to an executable regular file
+containing a `/`: a bare name would be re-resolved through `PATH` when the
+command runs, so the binary that executes need not be the one that was checked.
+A value that fails either test is not a usage error — the tool is simply
+unresolvable, and the run ends at exit 1 with `result=not-collected` naming it.
+
+Then apply the installer gate:
 
 ```bash
 if [[ "${INSTALL_RC}" -ne 0 ]]; then
@@ -669,15 +690,30 @@ naming it. The `--kubectl-bin` / `--helm-bin` values above are expanded by your
 own shell before `sudo` runs, so they carry through correctly and are the form
 to use:
 
+Use a `COLLECTOR_DIR` no earlier run has touched: the collector refuses a
+target that already exists and is non-empty, so pointing a second run at the
+first run's directory ends at exit 2 rather than collecting anything.
+
 ```bash
 sudo "${COLLECTOR_COMMAND}" \
   "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+
+# Hand the bundle back before the merge step. The collector runs under
+# `umask 077` and `chmod 700`s its output, so a root-run bundle is root-owned
+# and unreadable to you — and the `cp -a` above would fail with EACCES.
+sudo chown -R "$(id -u):$(id -g)" "${COLLECTOR_DIR}"
 ```
+
+That `chown` is not housekeeping. Without it the merge fails, and the failure
+lands on a bundle you can no longer read to find out why.
 
 `KUBECTL_BIN` / `HELM_BIN` environment variables do the same job, but only for
 non-`sudo` invocations: `env_reset` strips them, and default RHEL 9 sudoers
-refuses `sudo KUBECTL_BIN=... `. Carrying your own `PATH` through instead —
+refuses `sudo KUBECTL_BIN=... `. `sudo -E` preserves the environment where
+sudoers grants `setenv` — the installer step above relies on exactly that — but
+it does not help here, because `secure_path` still replaces `PATH` even under
+`-E`. Carrying your own `PATH` through instead —
 `sudo env "PATH=$PATH" ...` — also works, but it defeats `secure_path`: any
 user-writable directory on your `PATH` can then supply the `kubectl`, `helm`,
 or `bash` that runs as root. Prefer the explicit paths above on production
@@ -688,15 +724,16 @@ carry it through `env` rather than as a `sudo` variable assignment:
 
 ### Reading the manifest and the exit status
 
-Read `manifest.txt` on every run, not only on a failure. Each line carries the
-command's exit status plus an explicit `result=`:
+Read `manifest.txt` on every run, not only on a failure. After four header
+lines (`collector=`, `collected_at=`, `namespace=`, `release=`), each
+`command=` line carries that command's exit status plus an explicit `result=`:
 
 | `result=` | Meaning |
 | --- | --- |
 | `collected` | Ran, succeeded, produced output; `bytes=` counts it. |
 | `collected-empty` | Ran and succeeded, but there was nothing to report. |
 | `failed` | Ran and failed. `bytes=` counts the command's error text, not evidence. |
-| `not-collected` | Never ran; `reason=` says why (the tool was unresolvable). |
+| `not-collected` | Never ran; `reason=` says why (the tool was unresolvable). Its `status=127` is a stand-in, not a command's exit code. |
 
 That distinction is the point of the manifest: it tells a reader who was not
 present whether an absent answer means "nothing to report", "the cluster

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -619,18 +619,24 @@ COLLECTOR_EVIDENCE_COMPLETE=0
   "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}" || COLLECTOR_RC=$?
 
-# Reclaim the bundle on every outcome, before anything reads it. The collector
-# runs under `umask 077` and `chmod 700`s its output, so a root-run leaves it
-# root-owned and unreadable to you — and the exit-1 path below is precisely
-# when you need to read manifest.txt. `-O` is false only when the directory is
-# not yours, so this is a no-op when you ran the collector as yourself.
-if [[ -d "${COLLECTOR_DIR}" && ! -O "${COLLECTOR_DIR}" ]]; then
+# Reclaim the bundle before anything reads it. The collector runs under
+# `umask 077` and `chmod 700`s its output, so a root-run leaves it root-owned
+# and unreadable to you — and the exit-1 path below is precisely when you need
+# to read manifest.txt. `-O` is false only when the directory is not yours, so
+# this is a no-op when you ran the collector as yourself.
+#
+# Excluding exit 2 is what keeps a recursive, root-privileged chown pointed at
+# this run's own output: exit 2 is the one outcome where the collector created
+# nothing, and it is what you get for a COLLECTOR_DIR that already existed and
+# was non-empty. Any other status means this tree is ours to reclaim.
+if [[ "${COLLECTOR_RC}" -ne 2 && -d "${COLLECTOR_DIR}" && ! -O "${COLLECTOR_DIR}" ]]; then
   sudo chown -R "$(id -u):$(id -g)" "${COLLECTOR_DIR}"
 fi
 
 if [[ "${COLLECTOR_RC}" -eq 2 ]]; then
-  # Exit 2 is refused before the evidence tree exists, so there is no manifest
-  # to consult — the argument or the target path is what needs correcting.
+  # Exit 2 is refused before this run writes anything, so it produced no
+  # manifest to consult — any file already at that path belongs to an earlier
+  # run. The argument or the target path is what needs correcting.
   printf 'stop: collector refused the invocation (exit 2); fix the argument or use a new COLLECTOR_DIR\n' >&2
 elif [[ "${COLLECTOR_RC}" -ne 0 ]]; then
   printf 'stop: diagnostics bundle is incomplete (exit %s); %s names what is missing\n' \

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -585,15 +585,30 @@ the Helm half missing. Resolve the paths in your own shell so they are correct
 on any host, and check them before the collector needs them:
 
 ```bash
-KUBECTL_PATH="$(command -v kubectl)" || KUBECTL_PATH=''
-HELM_PATH="$(command -v helm)" || HELM_PATH=''
-test -n "${KUBECTL_PATH}"
-test -n "${HELM_PATH}"
+# `type -P`, not `command -v`: the latter also resolves aliases and shell
+# functions, printing something that is not a filesystem path and passing the
+# checks below only to be rejected by the collector a step later.
+KUBECTL_PATH="$(type -P kubectl)" || KUBECTL_PATH=''
+HELM_PATH="$(type -P helm)" || HELM_PATH=''
+test -x "${KUBECTL_PATH}"
+test -x "${HELM_PATH}"
 ```
 
-An empty value here is the same finding the collector would report a step
-later: install or locate the missing tool before running the collector, rather
-than accepting a bundle without it.
+`test -x` is the same requirement the collector enforces — an executable
+regular file, reached by a path — so a failure here is the finding it would
+report a step later. Install or locate the missing tool before running the
+collector rather than accepting a bundle without it.
+
+Point `COLLECTOR_DIR` at a path no earlier run has touched: the collector
+refuses a target that already exists and is non-empty, so re-pointing a second
+run at the first run's directory ends at exit 2 rather than collecting
+anything.
+
+This is the only invocation. If your cluster access requires root, add `sudo`
+to the collector line below and read
+[running it under `sudo`](#if-you-run-the-collector-under-sudo) first — the
+ownership reclaim that follows the invocation is already part of this block, so
+there is no separate root-only recipe to splice in.
 
 ```bash
 COLLECTOR_RC=0
@@ -603,6 +618,15 @@ COLLECTOR_EVIDENCE_COMPLETE=0
 "${COLLECTOR_COMMAND}" \
   "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}" || COLLECTOR_RC=$?
+
+# Reclaim the bundle on every outcome, before anything reads it. The collector
+# runs under `umask 077` and `chmod 700`s its output, so a root-run leaves it
+# root-owned and unreadable to you — and the exit-1 path below is precisely
+# when you need to read manifest.txt. `-O` is false only when the directory is
+# not yours, so this is a no-op when you ran the collector as yourself.
+if [[ -d "${COLLECTOR_DIR}" && ! -O "${COLLECTOR_DIR}" ]]; then
+  sudo chown -R "$(id -u):$(id -g)" "${COLLECTOR_DIR}"
+fi
 
 if [[ "${COLLECTOR_RC}" -eq 2 ]]; then
   # Exit 2 is refused before the evidence tree exists, so there is no manifest
@@ -665,8 +689,11 @@ takes the `--option=value` form, which is how to pass a value that legitimately
 begins with `-`. Both binary options need a path to an executable regular file
 containing a `/`: a bare name would be re-resolved through `PATH` when the
 command runs, so the binary that executes need not be the one that was checked.
-A value that fails either test is not a usage error — the tool is simply
-unresolvable, and the run ends at exit 1 with `result=not-collected` naming it.
+A *non-empty* value that fails either test is not a usage error — the tool is
+simply unresolvable, and the run ends at exit 1 with `result=not-collected`
+naming it. An *empty* value is rejected as a usage error, at exit 2, before the
+evidence tree exists — which is why the pre-check above gates on `test -x`
+rather than passing whatever it found straight through.
 
 Then apply the installer gate:
 
@@ -683,30 +710,21 @@ and `COLLECTOR_DIR`. Never reuse or overwrite the first attempt's evidence.
 
 ### If you run the collector under `sudo`
 
+Add `sudo` to the collector line in the block above. Do not copy that line out
+into a snippet of its own: the surrounding block initializes `COLLECTOR_RC`,
+captures the collector's status into it, reclaims ownership, and gates on the
+three counters. A standalone root invocation carries none of that, and its exit
+status is silently lost — an incomplete bundle then reads as a complete one.
+
 `sudo` replaces `PATH` with `secure_path`. On RHEL 9 that keeps `/usr/bin`,
 where the packaged `kubectl` lives, but not `/usr/local/bin`, where `helm` is
 installed — so `helm` is the half that disappears, and the run ends at exit 1
-naming it. The `--kubectl-bin` / `--helm-bin` values above are expanded by your
-own shell before `sudo` runs, so they carry through correctly and are the form
-to use:
+naming it. That is what `--kubectl-bin` / `--helm-bin` are for: their values are
+expanded by your own shell before `sudo` runs, so they carry through intact.
 
-Use a `COLLECTOR_DIR` no earlier run has touched: the collector refuses a
-target that already exists and is non-empty, so pointing a second run at the
-first run's directory ends at exit 2 rather than collecting anything.
-
-```bash
-sudo "${COLLECTOR_COMMAND}" \
-  "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
-  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
-
-# Hand the bundle back before the merge step. The collector runs under
-# `umask 077` and `chmod 700`s its output, so a root-run bundle is root-owned
-# and unreadable to you — and the `cp -a` above would fail with EACCES.
-sudo chown -R "$(id -u):$(id -g)" "${COLLECTOR_DIR}"
-```
-
-That `chown` is not housekeeping. Without it the merge fails, and the failure
-lands on a bundle you can no longer read to find out why.
+The reclaim step matters most on the paths where something already went wrong.
+It runs on every outcome, not just success, because the exit-1 branch tells you
+to read `manifest.txt` — a file a root-run leaves at mode 600, owned by root.
 
 `KUBECTL_BIN` / `HELM_BIN` environment variables do the same job, but only for
 non-`sudo` invocations: `env_reset` strips them, and default RHEL 9 sudoers


### PR DESCRIPTION
## Summary

`deploy`'s `scripts/collect-core-db-init-diagnostics.sh` changed under ENG-10263
(kamiwaza-internal/deploy#767). The internal docs were updated in that PR; the
public runbook operators actually follow during a production upgrade was not.

The most consequential piece of drift is not cosmetic. The collector's manifest
lines gained an explicit `result=` field, so the published parser —

```awk
/^command=/ && $0 !~ / status=0$/ { print; failed = 1 }
```

— no longer matches any healthy line, because `status=0` is no longer at
end-of-line. On a completely successful collection it flags every command as a
failure, and the runbook's own `test "${COLLECTOR_COMMAND_FAILURES}" -eq 0` gate
then stops a healthy 1.0.0→1.2.0 upgrade. This PR parses `result=failed`
instead.

Two further corrections:

- **Invocation.** The collector now resolves `kubectl` and `helm` once, up
  front, and exits 1 when either is unresolvable rather than silently omitting
  the Helm half. The runbook passes both binaries explicitly, resolved in the
  operator's own shell so they survive `sudo`'s `secure_path`, with a dedicated
  subsection on the `sudo` form. `sudo env "PATH=$PATH" ...` is documented but
  explicitly not the primary snippet, since it defeats `secure_path`.
- **Exit codes and manifest vocabulary.** A new "Reading the manifest and the
  exit status" subsection explains the four `result=` values (`collected`,
  `collected-empty`, `failed`, `not-collected`) and what each exit code now
  means — 1 is an incomplete bundle, 2 is a usage or unsafe-path error, and 0
  means both collectors produced evidence, *not* that every command succeeded
  (a partial-failure run exits 0 and prints `warning: N collection command(s)
  failed`).

The `INSTALL_RC` gate moved up to sit directly after the collector block rather
than being stranded under the new reference subsections; no wording changed.

Docs only — one file, no code change. No versioned copy of this runbook exists,
so `docs/docs/` is the only place it lives.

## Test plan

Verified against the real collector at `deploy@origin/develop` (803cc9a1),
driven with stub `kubectl`/`helm` binaries so every case is reproducible without
a cluster:

- **The bug reproduces.** On a fully healthy bundle (7 commands, all
  `result=collected` / `collected-empty`, collector exit 0), the published awk
  printed all 7 lines and set `COLLECTOR_COMMAND_FAILURES=1`. The replacement
  `grep ' result=failed '` returned 0 on the same manifest, and 1 on a manifest
  with a `result=failed` line appended.
- **All four documented exit codes confirmed.** `--helm-bin helm` (a bare name)
  → exit 1 with `command=helm-status status=127 result=not-collected
  reason=not-a-path:helm`. Existing non-empty evidence dir → exit 2. Missing
  option value → exit 2. One failing kubectl subcommand with both collectors
  still producing evidence → exit 0 with `warning: 1 collection command(s)
  failed` and `result=failed` in the manifest.
- **The new invocation parses.** Positional `DIR NAMESPACE RELEASE` mixed with
  `--kubectl-bin` / `--helm-bin` exits 0 and records the right namespace and
  release; the flags do not displace the positionals.
- **Site builds.** `npm ci` at root and in `docs/`, then `npm run build:docs`
  (what `.github/workflows/deploy.yml` runs) exits 0. No broken-link or
  broken-anchor warning names this page. The rendered
  `build/runbooks/core-database-upgrade-1.2.html` contains the new flags, the
  four `result=` values, and the new subsection heading, and zero occurrences of
  the old `status=0$` parser or the old exit-code prose.

Refs ENG-10271

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.11.0"
generated_at: "2026-08-13T06:14:43Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 194
linear_issues: [ENG-10271]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "Docs tests and production build, Validate package locks, and check-linear-issue all green on head f042a6d at bundle-author time. Gate re-verifies."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-13T05:24:17Z; eligible 45 minutes later. Gate re-verifies against GitHub's clock."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Markdown-only change to a runbook page; no cluster-running code is touched, so the pr-evidence cluster-smoke sentinel does not apply."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-10271 in the head branch name, the PR title, and a Refs line in the PR body."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff is one Markdown file. The shell it documents contains printf calls that are part of the documented procedure, not debug statements; no console.log/debugger/pdb.set_trace/breakpoint anywhere in the diff."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review verdict APPROVE (2/2 engines, zero Critical/High) posted as a SHA-pinned issue comment against head f042a6d70505ae331f412858a061ebfdce8da1b9, after 4 rounds."

manual_steps:
  - id: ms-1
    description: "Reproduce the bug this PR fixes: run the published runbook's manifest parser against a manifest produced by the current collector (deploy@origin/develop 803cc9a1) with stub kubectl/helm so all commands succeed."
    observation: "Collector exited 0 and wrote 7 command= lines, all result=collected or result=collected-empty. The published awk (/^command=/ && $0 !~ / status=0$/) printed all 7 lines and set COLLECTOR_COMMAND_FAILURES=1, so the runbook's own gate 'test ${COLLECTOR_COMMAND_FAILURES} -eq 0' fails on a fully successful collection. The replacement grep ' result=failed ' returned 0 matches on the same manifest, and 1 on a manifest with 'command=db-init-job status=1 result=failed bytes=42' appended."
    status: pass

  - id: ms-2
    description: "Confirm the four exit codes the PR documents against the real collector."
    observation: "--helm-bin helm (bare name) -> exit 1 with 'command=helm-status status=127 result=not-collected reason=not-a-path:helm'. Pre-existing non-empty evidence dir -> exit 2, no tree created. Symlink target -> exit 2, no manifest. --namespace with no value -> exit 2. --helm-bin '' -> exit 2, no manifest. One failing kubectl subcommand while both collectors still produce evidence -> exit 0 with 'warning: 1 collection command(s) failed' on stderr and 'command=db-init-job status=1 result=failed bytes=0' in the manifest."
    status: pass

  - id: ms-3
    description: "Run the runbook's revised code block verbatim, extracted by line range from the Markdown, under set -euo pipefail against the real collector."
    observation: "bash -n clean. healthy -> collector_rc=0 command_failures=0; partial failure -> collector_rc=0 command_failures=1 with the failing line echoed to stderr; unresolvable helm -> collector_rc=1 and 'stop: diagnostics bundle is incomplete (exit 1); <dir>/manifest.txt names what is missing'; usage error -> collector_rc=2 and 'stop: collector refused the invocation (exit 2)'. No set -e aborts, no unbound-variable errors on any path."
    status: pass

  - id: ms-4
    description: "Verify the manifest scan fails closed on an unreadable manifest, and that the ownership-reclaim guard only fires for a tree the collector created."
    observation: "manifest.txt at mode 000: grep exits 2; the earlier 'if grep -q' form took the false branch leaving command_failures=0 (fail-open) where the awk it replaced set 1. After the fix the same input gives 'stop: <path> could not be read (grep exit 2)' and command_failures=1, while the readable-healthy control still gives 0. Guard truth table against a not-owned directory: rc=0 fires, rc=1 fires, rc=2 no-op; a pre-existing non-empty COLLECTOR_DIR seeded with an unrelated file returned exit 2 and that file was still present afterwards."
    status: pass

  - id: ms-5
    description: "Build the site the way .github/workflows/deploy.yml does (npm ci at root and in docs/, then npm run build:docs) and inspect the rendered page."
    observation: "Build exited 0 with '[SUCCESS] Generated static files in \"build\"'. No broken-link or broken-anchor warning names core-database-upgrade. In build/runbooks/core-database-upgrade-1.2.html the #if-you-run-the-collector-under-sudo anchor has both a matching id and href; 'sudo \"${COLLECTOR_COMMAND}\"' occurs 0 times (duplicate invocation removed); 'type -P' occurs 3 times; the old 'status=0$' parser and the old 'means the collector itself failed' prose occur 0 times."
    status: pass

gate:
  approval_submitted: false
  approval_blocked_reason: "Formal APPROVE is submitted by the central dispatcher (pr-verify-approve.yml) in CI, not from this machine."

verdict:
  decision: approve
  rationale: "Docs-only fix to a production runbook whose published manifest parser provably halted a healthy 1.0.0-to-1.2.0 upgrade. Every documented exit code, flag, and result= value was verified by executing the real collector; the revised block was run verbatim under set -euo pipefail across all four paths; the site builds as CI builds it. All required auto-checks pass; 5 manual steps verified."
```

</details>

# pr-verify bundle — ENG-10271

Verification for this PR is execution-backed rather than cluster-backed: the change documents `deploy`'s `collect-core-db-init-diagnostics.sh`, so the manual steps drive that collector directly with stub `kubectl`/`helm` binaries, and build the Docusaurus site with the same command `.github/workflows/deploy.yml` runs. No Kamiwaza stack interaction is involved.

Deferred: ENG-10281 tracks `manifest.txt` never reaching the shareable evidence bundle, which spans this repo and the validator allowlist in `kamiwaza`.

<!-- pr-verify-end -->