### PR TITLE
ENG-10281: carry the diagnostics manifest into the evidence bundle

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -647,6 +647,10 @@ else
   cp -a "${COLLECTOR_DIR}/cluster/." "${EVIDENCE_DIR}/cluster/"
   cp -a "${COLLECTOR_DIR}/db-init/." "${EVIDENCE_DIR}/db-init/"
   cp -a "${COLLECTOR_DIR}/helm/." "${EVIDENCE_DIR}/helm/"
+  # manifest.txt is the key to everything above it: without it, a reader who
+  # was not present cannot tell a file the cluster had nothing to say about
+  # from one the cluster refused to produce.
+  cp -a "${COLLECTOR_DIR}/manifest.txt" "${EVIDENCE_DIR}/manifest.txt"
 
   # Exit zero says both collectors produced evidence, not that every command
   # succeeded. The failures are the manifest lines marked result=failed.
@@ -763,6 +767,11 @@ That distinction is the point of the manifest: it tells a reader who was not
 present whether an absent answer means "nothing to report", "the cluster
 refused", or "never asked". Treat a `failed` line's output as an error message,
 never as evidence.
+
+That reader is usually Support or the release owner rather than you, which is
+why the merge step above copies `manifest.txt` into `${EVIDENCE_DIR}` and both
+bundle lists carry it. Left behind on the operator host, the taxonomy above
+would describe a file its intended audience never receives.
 
 Exit status is symmetric across both halves of the bundle. `COLLECTOR_RC` of 1
 means the bundle is **incomplete** — `kubectl` or `helm` was unresolvable, or
@@ -981,6 +990,7 @@ kamiwaza/scripts/db_migration_m1/runbook_bundle.py EVIDENCE_FILES. -->
 
 ```text
 metadata.json
+manifest.txt
 backup/manifest.json
 installer/exit-status.txt
 installer/postinst-debug.log
@@ -1071,6 +1081,7 @@ kamiwaza/scripts/db_migration_m1/runbook_bundle.py EVIDENCE_FILES. -->
 
 ```text
 metadata.json
+manifest.txt
 backup/manifest.json
 installer/exit-status.txt
 installer/postinst-debug.log


### PR DESCRIPTION
This PR is the second half of a two-repo change for ENG-10281. The first half
is kamiwaza-internal/kamiwaza#2547, which adds `manifest.txt` to
`EVIDENCE_FILES` in `scripts/db_migration_m1/runbook_bundle.py`.

**Merge order matters: #2547 must land first.** The validator has to accept
`manifest.txt` before any bundle produced by this runbook starts carrying it,
or those bundles fail their own allowlist.

## Summary

The runbook explains how to read `manifest.txt` to an audience that never
receives it.

`collect-core-db-init-diagnostics.sh` writes `manifest.txt` at the root of
`COLLECTOR_DIR`. The runbook's merge step copied only `cluster/`, `db-init/`
and `helm/` into `EVIDENCE_DIR`, and both bundle file lists are exhaustive
("may contain **only** the following paths" / "contains exactly these nonempty
files") and omitted it. So the `result=` taxonomy added in ENG-10271 describes
a file that stays behind on the operator host: a Support engineer reading a
bundle with no `helm/history.txt` still cannot tell "helm had nothing to
report" from "the collector never resolved helm" — which is the exact
distinction ENG-10263 introduced the field to preserve.

Three changes:

1. `cp -a "${COLLECTOR_DIR}/manifest.txt" "${EVIDENCE_DIR}/manifest.txt"` in
   the merge block.
2. `manifest.txt` added to both the customer-support and M1-20 qualification
   lists, positioned immediately after `metadata.json` to match the ordering
   `EVIDENCE_FILES` uses in #2547 — the lists carry an in-file comment pinning
   them to that tuple.
3. One paragraph in "Reading the manifest and the exit status" naming who the
   absent reader actually is, so the reason the file travels with the bundle is
   on the page rather than implied.

It goes in **both** bundles. It carries command labels, exit statuses,
`result=`/`bytes=`/`reason=` fields, and the namespace and release names — no
credentials, tokens, keys, or Secret/ConfigMap content — so it passes the
runbook's own secret scan, and the customer-support case needs the
refused-vs-never-asked distinction as much as M1 does. #2547 puts it in the
single `EVIDENCE_FILES` tuple, which is what makes it reach both.

## Test plan

- **The two lists still agree with each other and with #2547.** Parsed both
  fenced lists out of the Markdown: 17 and 18 entries, `manifest.txt` at index
  1 in each, and the customer list is exactly the M1 list minus
  `recovery/restore-rehearsal.json` — the documented relationship, unchanged.
  Placement matches `EVIDENCE_FILES` in #2547 byte-for-byte.
- **The merge block still runs.** Extracted the runbook's code block verbatim
  by line range and ran it under `set -euo pipefail` against the real collector
  from `deploy@origin/develop` with stub `kubectl`/`helm`. `bash -n` clean;
  `collector_rc=0 command_failures=0`; `manifest.txt` lands in `EVIDENCE_DIR`
  at 523 bytes, byte-identical to the collector's copy.
- **The enlarged bundle is still safe to share.** Ran the runbook's own secret
  scan (the `awk` in "Customer support bundle", which reports path and line
  only, never the match) over the resulting `EVIDENCE_DIR`: `secret_locations=0`.
- **Site builds.** `npm ci` at root and in `docs/`, then `npm run build:docs` —
  the command `.github/workflows/deploy.yml` runs — exits 0, `[SUCCESS]
  Generated static files`. No broken-link or broken-anchor warning names this
  page.

Refs ENG-10281

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.11.0"
generated_at: "2026-08-13T06:53:29Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 195
linear_issues: [ENG-10281]

auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "Docs tests and production build, Validate package locks, check-linear-issue all green on head 9a0c57d at bundle-author time. Gate re-verifies."

  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "PR created 2026-08-13T06:44:37Z; eligible 45 minutes later. Gate re-verifies against GitHub's clock."

  - kind: pr-evidence
    required: false
    status: skipped
    detail: "Markdown-only change to a runbook page; no cluster-running code is touched."

  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-10281 in the head branch name, the PR title, and a Refs line in the PR body."

  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff is 11 added lines of Markdown; no debug statements anywhere in it."

  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review verdict APPROVE (2/2 engines, zero Critical/High) posted as a SHA-pinned issue comment against head 9a0c57dcd595f93d8684a6561088960ee75f817c."

manual_steps:
  - id: ms-1
    description: "Verify the two runbook bundle lists match EVIDENCE_FILES in the companion PR kamiwaza-internal/kamiwaza#2547, which the lists carry an in-file comment pinning them to."
    observation: "Parsed both fenced text lists out of the Markdown: 17 and 18 entries, manifest.txt at index 1 in each (immediately after metadata.json). The M1-20 list is byte-for-byte equal to EVIDENCE_FILES at #2547 head, order preserved; the customer list equals the M1 list minus recovery/restore-rehearsal.json, which is the documented relationship and is unchanged by this PR."
    status: pass

  - id: ms-2
    description: "Run the runbook's revised merge block verbatim (extracted by line range from the Markdown) under set -euo pipefail against the real collector from deploy@origin/develop with stub kubectl/helm, and confirm manifest.txt reaches EVIDENCE_DIR intact."
    observation: "bash -n clean. Healthy path: collector_rc=0, command_failures=0, and EVIDENCE_DIR/manifest.txt present at 523 bytes, byte-identical to the collector's own copy (diff -q clean). Both failure paths skip the copy without aborting: RC=1 and RC=2 take branches that copy nothing at all, so the new cp is on the only branch where the source file is guaranteed to exist."
    status: pass

  - id: ms-3
    description: "Confirm the enlarged bundle is still safe to share, now that manifest.txt ships to customers."
    observation: "Ran the runbook's own secret scan — the awk block under 'Customer support bundle', which reports path and line only and never the matched value — over the generated EVIDENCE_DIR: secret_locations=0. The manifest's content is limited to command labels, exit statuses, result=/bytes=/reason= fields, and the namespace and release names; no credentials, tokens, keys, or Secret/ConfigMap content are written into it by the collector."
    status: pass

  - id: ms-4
    description: "Build the site the way .github/workflows/deploy.yml does (npm ci at root and in docs/, then npm run build:docs)."
    observation: "Build exited 0 with '[SUCCESS] Generated static files in \"build\"'. No broken-link or broken-anchor warning names core-database-upgrade."
    status: pass

gate:
  approval_submitted: false
  approval_blocked_reason: "Formal APPROVE is submitted by the central dispatcher (pr-verify-approve.yml) in CI, not from this machine."

verdict:
  decision: approve
  rationale: "Eleven lines of Markdown making the diagnostics manifest reach the evidence bundle the runbook tells operators to read. Cross-repo list consistency verified against the companion PR's EVIDENCE_FILES byte-for-byte; the merge block executed verbatim against the real collector on all three paths; the runbook's own secret scan clean over the enlarged bundle. All required auto-checks pass; 4 manual steps verified."
```

</details>

# pr-verify bundle — ENG-10281 (kamiwaza-docs half)

Second half of a two-repo change. **Merge ordering: kamiwaza-internal/kamiwaza#2547 must land first**, so the bundle validator accepts `manifest.txt` before any bundle produced by this runbook carries it.

<!-- pr-verify-end -->