### PR TITLE
ENG-10370: make offline install provenance-driven and SSM-safe

### DIFF
--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -38,7 +38,7 @@ You need:
 - A connected staging machine if the target cannot download the artifacts.
 - Root access on the target. For a remote private host, Session Manager (SSM)
   or an equivalent managed shell is preferred over SSH.
-- Bash 4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
+- Bash 4.4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
   `tar` on the connected staging machine. The verification snippets use GNU
   options and do not run in stock macOS Bash; use a trusted Linux staging host
   or container when the connected workstation is a Mac. If the target has no
@@ -192,7 +192,7 @@ cp /secure/path/artifacts.tsv "${ARTIFACT_DIR}/artifacts.tsv"
 cd "${ARTIFACT_DIR}"
 
 artifact_count=0
-while IFS=$'\t' read -r file expected_sha extra; do
+while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
   [[ -n "${file}" && "${file}" != \#* ]] || continue
   [[ -z "${extra:-}" ]]
   [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
@@ -399,7 +399,7 @@ existing_bundle_file="$({
 })"
 if [[ -n "${existing_bundle_file}" ]]; then
   printf 'existing staged bundle artifact: %s\n' "${existing_bundle_file}" >&2
-  printf 'verify and archive or remove the complete old set before staging this release\n' >&2
+  printf 'verify and archive or remove the complete staged set before retrying, even for the same release\n' >&2
   exit 1
 fi
 
@@ -407,7 +407,7 @@ sudo install -o root -g root -m 0600 "${ARTIFACT_DIR}/artifacts.tsv" \
   /opt/kamiwaza/prereqs/artifacts.tsv
 
 declare -A INVENTORY=()
-while IFS=$'\t' read -r file expected_sha extra; do
+while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
   [[ -n "${file}" && "${file}" != \#* ]] || continue
   [[ -z "${extra:-}" ]]
   [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
@@ -474,9 +474,8 @@ sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
 )
 ```
 
-If this exact packaged bootstrap does not support `--yes`, use its documented
-noninteractive option. Do not pipe repeated `yes` or press Enter to drive a
-long unattended install.
+The release/1.2.0 RPM overlay accepts `--yes` for noninteractive bootstrap.
+Do not pipe repeated `yes` or press Enter to drive a long unattended install.
 
 The install runs as root, so verify tools using root's actual environment:
 
@@ -524,6 +523,7 @@ set -euo pipefail
 [[ "${EXT_BUNDLE}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
 HELPER_DIR="$(sudo mktemp -d -p /var/tmp \
   "kamiwaza-extension-helper-${RUN_ID}.XXXXXX")"
+trap 'sudo rm -rf -- "${HELPER_DIR}"' EXIT
 
 sudo cp "${ARTIFACT_DIR}/${EXT_BUNDLE}" \
   "${ARTIFACT_DIR}/${EXT_BUNDLE}.sha256" \
@@ -696,6 +696,7 @@ unset NAMESPACE
 
 CONTRACT=/run/kamiwaza-install-contract.json
 PASSWORD_FILE=/run/kamiwaza-admin-password
+DOMAIN='<domain>'
 RUN_ID="${1:?pass the recorded run ID}"
 ATTEMPT_ID="${2:?pass the recorded attempt number}"
 [[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
@@ -725,6 +726,7 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
 test -s "${CONTRACT}"
 test -s "${PASSWORD_FILE}"
 test -f /opt/kamiwaza/prereqs/kamiwaza-helm.sha256
@@ -760,7 +762,7 @@ KAMIWAZA_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
   /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
   --skip-prereq-bootstrap \
-  --domain '<domain>' \
+  --domain "${DOMAIN}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
@@ -911,14 +913,18 @@ export DOMAIN="<domain>"
 
 (
 set -euo pipefail
-NODES_JSON="$(sudo kubectl get nodes -o json)"
+ROOT_TOOLS=(sudo env \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  HELM_PLUGINS=/usr/local/share/helm/plugins \
+  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
+NODES_JSON="$("${ROOT_TOOLS[@]}" kubectl get nodes -o json)"
 jq -e '
   (.items | length) > 0 and
   all(.items[]; any(.status.conditions[]?;
     .type == "Ready" and .status == "True"))
 ' <<<"${NODES_JSON}" >/dev/null
 
-PODS_JSON="$(sudo kubectl get pods -A -o json)"
+PODS_JSON="$("${ROOT_TOOLS[@]}" kubectl get pods -A -o json)"
 jq -e '
   (.items | length) > 0 and
   all(.items[];
@@ -933,11 +939,11 @@ jq -e '
       (.imageID // "") | contains("sha256:")))
 ' <<<"${PODS_JSON}" >/dev/null
 
-HELM_JSON="$(sudo helm list -A -o json)"
+HELM_JSON="$("${ROOT_TOOLS[@]}" helm list -A -o json)"
 jq -e 'length > 0 and all(.[]; .status == "deployed")' \
   <<<"${HELM_JSON}" >/dev/null
 
-NODE_IP="$(sudo kubectl get nodes \
+NODE_IP="$("${ROOT_TOOLS[@]}" kubectl get nodes \
   -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
 test -n "${NODE_IP}"
 HTTP_CODE="$(curl -kfsS --resolve "${DOMAIN}:443:${NODE_IP}" \
@@ -945,9 +951,9 @@ HTTP_CODE="$(curl -kfsS --resolve "${DOMAIN}:443:${NODE_IP}" \
   "https://${DOMAIN}/api/auth/health")"
 test "${HTTP_CODE}" = 200
 
-sudo kubectl get nodes -o wide
-sudo kubectl get pods -A
-sudo helm list -A
+"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
+"${ROOT_TOOLS[@]}" kubectl get pods -A
+"${ROOT_TOOLS[@]}" helm list -A
 printf 'health HTTP %s\n' "${HTTP_CODE}"
 )
 ```
@@ -1002,6 +1008,7 @@ export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export HELM_PLUGINS=/usr/local/share/helm/plugins
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+unset NAMESPACE
 
 DOMAIN='<domain>'
 RUN_ID="${1:?pass the recorded run ID}"
@@ -1033,6 +1040,7 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
 test -d "${BUNDLE_ROOT}"
 test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
 
@@ -1118,7 +1126,10 @@ for expected in \
 done
 grep -Eq '^InvocationID=.+$' <<<"${EXT_STATE}"
 test "$(sudo cat "${EXT_STATUS}")" = 0
-sudo kubectl get pods -A
+sudo env \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  KUBECONFIG=/var/lib/k0s/pki/admin.conf \
+  kubectl get pods -A
 )
 ```
 
@@ -1190,6 +1201,7 @@ export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export HELM_PLUGINS=/usr/local/share/helm/plugins
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+unset NAMESPACE
 
 DOMAIN='<domain>'
 RUN_ID="${1:?pass the recorded run ID}"
@@ -1222,6 +1234,9 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
+[[ "${GATE_TEMPLATE}" != *'<'* ]]
+[[ "${GATE_WAIT_TIMEOUT}" != *'<'* ]]
 test -x "${GATE_SCRIPT}"
 ADMIN_PASSWORD="$(
   kubectl -n kamiwaza get secret kamiwaza-user-admin \
@@ -1350,14 +1365,18 @@ extension bundle installed.
 Useful focused diagnostics:
 
 ```bash
+ROOT_TOOLS=(sudo env \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  HELM_PLUGINS=/usr/local/share/helm/plugins \
+  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
 sudo systemctl show <unit>.service \
   -p LoadState -p ActiveState -p SubState -p Result \
   -p ExecMainCode -p ExecMainStatus -p InvocationID
 sudo journalctl -u <unit>.service -o cat
-sudo kubectl get nodes -o wide
-sudo kubectl get pods -A -o wide
-sudo kubectl get events -A --sort-by=.lastTimestamp
-sudo helm list -A
+"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
+"${ROOT_TOOLS[@]}" kubectl get pods -A -o wide
+"${ROOT_TOOLS[@]}" kubectl get events -A --sort-by=.lastTimestamp
+"${ROOT_TOOLS[@]}" helm list -A
 sudo podman ps -a
 df -hT / /tmp /var/tmp /var/lib /opt
 ```

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -17,11 +17,15 @@ An offline deployment has three separate completion levels:
 1. **Core installed:** the platform is healthy and login works.
 2. **Bundle installed:** bundled extension images are loaded and the live
    catalog is imported.
-3. **Release parity:** one bundled extension is deployed, verified, and removed
-   through the supported catalog/API path, plus any additional gates recorded
-   by the selected release run.
+3. **Release parity (publisher qualification):** one bundled extension is
+   deployed, verified, and removed through the supported catalog/API path, plus
+   any additional gates recorded by the selected release run.
 
 Do not report level 2 or 3 after only pre-staging the extension catalog.
+Level 3 requires the private, hash-recorded Kajiya gate inputs from the selected
+run and is performed by Kamiwaza release engineers; it is not a customer
+installation requirement. A customer handoff without those internal inputs can
+complete and report levels 1 and 2.
 
 ## Before you begin
 
@@ -54,16 +58,20 @@ extension size, installer scratch, image-store growth, the configured OSD image
 size, and operational headroom. Then check the backing filesystems:
 
 ```bash
-df -hT / /tmp /var/lib
+df -hT / /tmp /var/tmp /var/lib /opt
 findmnt -T /tmp
+findmnt -T /var/tmp
 findmnt -T /var/lib
+findmnt -T /opt
 lsblk -f
 ```
 
-As a planning floor for the current small profile, allow at least 30 GB free on
-`/`, 25 GB on `/tmp`, and 140 GB on `/var/lib`. These are not substitutes for
-the calculation above: a larger OSD, bundle, or image set requires more. Grow
-the correct PV/LV/filesystem before installation and run `df` again afterward.
+There is no release-independent free-space floor for this path. The verified
+staging copy, `/opt/kamiwaza/prereqs` copy, logical-wrap scratch space under
+`/var/tmp`, extracted extension tree, image store, and configured OSD can
+coexist. Calculate their peak sizes from the selected handoff and budget each
+copy on its actual backing filesystem. Grow the correct PV/LV/filesystem before
+installation and run `df` again afterward.
 
 Also confirm that no package manager, previous installer, Kubernetes bootstrap,
 or local-registry import is running. Understand any existing `/opt/kamiwaza`,
@@ -72,9 +80,12 @@ or local-registry import is running. Understand any existing `/opt/kamiwaza`,
 Verify the host before transferring large artifacts:
 
 ```bash
+(
+set -euo pipefail
 test "$(uname -m)" = x86_64
 grep -E 'release 9([. ]|$)' /etc/redhat-release
 test "$(hostnamectl --static | wc -c)" -le 55
+)
 ```
 
 If the host is reached through SSM, validate all four access paths before the
@@ -121,8 +132,8 @@ and record:
 
 - release/run identifier, attempt, source prefix, and publication inventory;
 - immutable Kajiya, Deploy, Core, Containers, and extension source commits;
-- every object name, size, and SHA-256;
-- runtime, resource profile, OSD size, Helm timeout, and compatibility flags;
+- every object name and SHA-256, plus sizes where the publisher exposes them;
+- runtime, resource profile, OSD size, and compatibility flags;
 - every product tag and the complete `KAMIWAZA_IMAGE_OVERRIDES` map;
 - extension helper names and hashes; and
 - the release's required verification gates.
@@ -144,11 +155,13 @@ Modern bundle roles normally include:
 - for files split by the distribution service, `.part-NNN` files, per-part
   sidecars, and a `.parts.json` assembly manifest.
 
-The number and names are release-specific. Export the exact package inventory
-from Keygen or the build handoff into `artifacts.tsv`, with tab-separated
-filename, byte count, and SHA-256 columns. Include the generated part manifests,
-parts, and part sidecars when present. Keep this inventory with the installation
-record.
+The number and names are release-specific. The publisher must supply a complete
+post-distribution `artifacts.tsv` with tab-separated filename and SHA-256
+columns, including any generated part manifests, parts, and part sidecars. The
+customer-reachable `release_origination.md` authenticates source-artifact
+hashes, but does not enumerate every distribution-added object or provide a
+byte count for every artifact. If the publisher does not supply the complete
+post-distribution inventory, stop. Keep it with the installation record.
 
 ## 2. Download, transfer, and verify artifacts
 
@@ -157,25 +170,36 @@ inventory. The example below is deliberately parameterized; `<release>` is the
 immutable selected release or run tag, not a version copied from this page.
 
 ```bash
-read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
-export KEYGEN_TOKEN
 export RELEASE="<release>"
 export PACKAGE_KEY="<exact-package-key-from-the-selected-release>"
 export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@${PACKAGE_KEY}/${RELEASE}"
 export ARTIFACT_DIR="${PWD}/kamiwaza-offline-${RELEASE}"
 
+(
+set -euo pipefail
+[[ "${RELEASE}" =~ ^[A-Za-z0-9._-]+$ ]]
+
+read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
+
+AUTH_HEADER="$(mktemp)"
+chmod 0600 "${AUTH_HEADER}"
+trap 'rm -f "${AUTH_HEADER}"' EXIT
+printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" >"${AUTH_HEADER}"
+unset KEYGEN_TOKEN
+
 install -d -m 0755 "${ARTIFACT_DIR}"
 cp /secure/path/artifacts.tsv "${ARTIFACT_DIR}/artifacts.tsv"
 cd "${ARTIFACT_DIR}"
 
-while IFS=$'\t' read -r file expected_size expected_sha; do
+artifact_count=0
+while IFS=$'\t' read -r file expected_sha extra; do
   [[ -n "${file}" && "${file}" != \#* ]] || continue
-  [[ "${file}" != */* && "${file}" != .* ]]
-  [[ "${expected_size}" =~ ^[0-9]+$ ]]
+  [[ -z "${extra:-}" ]]
+  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
   [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
+  ((artifact_count += 1))
 
   if [[ -f "${file}" ]] &&
-     [[ "$(stat -c %s "${file}")" = "${expected_size}" ]] &&
      printf '%s  %s\n' "${expected_sha}" "${file}" | sha256sum -c - >/dev/null; then
     printf 'already verified: %s\n' "${file}"
     continue
@@ -183,31 +207,37 @@ while IFS=$'\t' read -r file expected_size expected_sha; do
   rm -f "${file}"
 
   if [[ -f "${file}.partial" ]] &&
-     [[ "$(stat -c %s "${file}.partial")" = "${expected_size}" ]] &&
      printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c - >/dev/null; then
     mv "${file}.partial" "${file}"
     continue
   fi
-  if [[ -f "${file}.partial" ]] &&
-     (($(stat -c %s "${file}.partial") >= expected_size)); then
-    rm -f "${file}.partial"
+
+  curl_rc=0
+  curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
+    --header "@${AUTH_HEADER}" \
+    -o "${file}.partial" \
+    "${BASE}/${file}" || curl_rc=$?
+  if ((curl_rc != 0)); then
+    # A rejected/invalid range cannot become resumable without discarding it.
+    # Preserve partial bytes for ordinary transport timeouts.
+    case "${curl_rc}" in
+      22|33|36) rm -f "${file}.partial" ;;
+    esac
+    exit "${curl_rc}"
   fi
 
-  curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
-    -H "Authorization: License ${KEYGEN_TOKEN}" \
-    -o "${file}.partial" \
-    "${BASE}/${file}"
-
-  if [[ "$(stat -c %s "${file}.partial")" != "${expected_size}" ]] ||
-     ! printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c -; then
+  if ! printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c -; then
     rm -f "${file}.partial"
     printf 'download verification failed: %s\n' "${file}" >&2
     exit 1
   fi
   mv "${file}.partial" "${file}"
 done < artifacts.tsv
-
-unset KEYGEN_TOKEN
+((artifact_count > 0)) || {
+  printf 'artifacts.tsv contained no artifact records\n' >&2
+  exit 1
+}
+)
 ```
 
 Do not put license tokens in command logs, shell history, or the installation
@@ -220,23 +250,44 @@ the final target. S3 ETags are not SHA-256 integrity checks.
 Each `.parts.json` records the original filename/hash and the ordered part
 inventory. Reassemble from that manifest instead of hardcoding part counts:
 
+Skip this block when the inventory contains no `.parts.json` files.
+
 ```bash
+(
+set -euo pipefail
+cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
 shopt -s nullglob
-for manifest in *.parts.json; do
-  output="$(jq -r '.source.filename' "${manifest}")"
-  expected_size="$(jq -r '.source.size' "${manifest}")"
-  expected_sha="$(jq -r '.source.sha256' "${manifest}")"
+manifests=( *.parts.json )
+((${#manifests[@]} > 0)) || {
+  printf 'no part manifests found\n' >&2
+  exit 1
+}
+
+for manifest in "${manifests[@]}"; do
+  output="$(jq -er '.source.filename' "${manifest}")"
+  expected_size="$(jq -er '.source.size' "${manifest}")"
+  expected_sha="$(jq -er '.source.sha256' "${manifest}")"
+  [[ "${output}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+  [[ "${expected_size}" =~ ^[0-9]+$ ]]
+  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
+  jq -e '.parts | type == "array" and length > 0' "${manifest}" >/dev/null
 
   : > "${output}.assembling"
+  part_count=0
   while IFS=$'\t' read -r part part_sha; do
+    [[ "${part}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+    [[ "${part_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
     printf '%s  %s\n' "${part_sha}" "${part}" | sha256sum -c -
     cat "${part}" >> "${output}.assembling"
+    ((part_count += 1))
   done < <(jq -r '.parts[] | [.filename, .sha256] | @tsv' "${manifest}")
 
+  ((part_count > 0))
   test "$(stat -c %s "${output}.assembling")" = "${expected_size}"
   printf '%s  %s\n' "${expected_sha}" "${output}.assembling" | sha256sum -c -
   mv "${output}.assembling" "${output}"
 done
+)
 ```
 
 ### Verify source artifacts and the logical wrap
@@ -244,17 +295,28 @@ done
 Verify every artifact recorded in `release_origination.md`:
 
 ```bash
-awk '
-  $0 == "## Artifacts" { in_artifacts=1; next }
-  in_artifacts && /^## / { exit }
-  in_artifacts && /^- / {
-    name=$2; sub(/:$/, "", name); print name, $3
-  }
-' release_origination.md |
+(
+set -euo pipefail
+cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
+artifact_count=0
 while read -r file expected; do
   test -f "${file}"
   printf '%s  %s\n' "${expected}" "${file}" | sha256sum -c -
-done
+  ((artifact_count += 1))
+done < <(
+  awk '
+    $0 == "## Artifacts" { in_artifacts=1; next }
+    in_artifacts && /^## / { exit }
+    in_artifacts && /^- / {
+      name=$2; sub(/:$/, "", name); print name, $3
+    }
+  ' release_origination.md
+)
+((artifact_count > 0)) || {
+  printf 'release_origination.md contained no artifact records\n' >&2
+  exit 1
+}
+)
 ```
 
 `kamiwaza-helm.sha256` names the **logical concatenated wrap**, which might not
@@ -263,6 +325,9 @@ chunks in natural numeric order. Creating a similarly named symlink does not
 verify this contract.
 
 ```bash
+(
+set -euo pipefail
+cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
 mapfile -d '' WRAP_CHUNKS < <(
   find . -maxdepth 1 -type f -regextype posix-extended \
     -regex './kamiwaza-helm\.[0-9]+\.tar' -print0 | sort -z -V
@@ -273,6 +338,7 @@ expected="$(awk 'NR==1 {print $1}' kamiwaza-helm.sha256)"
 actual="$(cat "${WRAP_CHUNKS[@]}" | sha256sum | awk '{print $1}')"
 test "${actual}" = "${expected}"
 printf 'logical wrap checksum: OK (%s chunks)\n' "${#WRAP_CHUNKS[@]}"
+)
 ```
 
 Verify the detached signature over the checksum file. Confirm the signer
@@ -280,18 +346,22 @@ fingerprint through an independent trusted channel; a key delivered in the same
 directory proves bundle consistency, not independently anchored provenance.
 
 ```bash
+(
+set -euo pipefail
+cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
 export GNUPGHOME="$(mktemp -d)"
 chmod 0700 "${GNUPGHOME}"
+trap 'rm -rf "${GNUPGHOME}"' EXIT
 gpg --batch --import ./kamiwaza-tools-rpm.pub.gpg
 gpg --batch --verify ./kamiwaza-helm.asc ./kamiwaza-helm.sha256
 gpg --batch --with-colons --fingerprint
-rm -rf "${GNUPGHOME}"
-unset GNUPGHOME
+)
 ```
 
-Transfer the entire verified directory to the target, then repeat the hash,
-logical-wrap, and signature checks there. Perform the rest of this guide only
-from that final target copy.
+Transfer the entire verified directory to
+`/var/tmp/kamiwaza-offline/<release-or-run>` on the target, then repeat the
+hash, logical-wrap, and signature checks there. Perform the rest of this guide
+only from that final target copy.
 
 ## 3. Install and verify embedded prerequisites
 
@@ -301,19 +371,107 @@ RPM, and run its packaged bootstrap noninteractively:
 ```bash
 export ARTIFACT_DIR="/var/tmp/kamiwaza-offline/<release-or-run>"
 
+(
+set -euo pipefail
+
+mapfile -t RPM_FILES < <(
+  find "${ARTIFACT_DIR}" -maxdepth 1 -type f \
+    -name 'kamiwaza-prod-*.el9.x86_64.rpm' -print
+)
+mapfile -t WRAP_FILES < <(
+  find "${ARTIFACT_DIR}" -maxdepth 1 -type f -regextype posix-extended \
+    -regex '.*/kamiwaza-helm\.[0-9]+\.tar' -print | sort -V
+)
+test "${#RPM_FILES[@]}" -eq 1
+((${#WRAP_FILES[@]} > 0))
+
 sudo install -d -m 0755 /opt/kamiwaza/prereqs
-sudo cp "${ARTIFACT_DIR}"/kamiwaza-prod-*.el9.x86_64.rpm \
-  "${ARTIFACT_DIR}"/kamiwaza-helm.*.tar \
+existing_bundle_file="$({
+  sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
+    \( -name 'kamiwaza-prod-*.el9.x86_64.rpm' \
+       -o -name 'kamiwaza-helm.*.tar' \
+       -o -name 'kamiwaza-helm.sha256' \
+       -o -name 'kamiwaza-helm.asc' \
+       -o -name 'kamiwaza-tools-rpm.pub.gpg' \
+       -o -name '*.parts.json' \
+       -o -name 'artifacts.tsv' \) \
+    -print -quit
+})"
+if [[ -n "${existing_bundle_file}" ]]; then
+  printf 'existing staged bundle artifact: %s\n' "${existing_bundle_file}" >&2
+  printf 'verify and archive or remove the complete old set before staging this release\n' >&2
+  exit 1
+fi
+
+sudo install -o root -g root -m 0600 "${ARTIFACT_DIR}/artifacts.tsv" \
+  /opt/kamiwaza/prereqs/artifacts.tsv
+
+declare -A INVENTORY=()
+while IFS=$'\t' read -r file expected_sha extra; do
+  [[ -n "${file}" && "${file}" != \#* ]] || continue
+  [[ -z "${extra:-}" ]]
+  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
+  [[ ! -v "INVENTORY[${file}]" ]]
+  INVENTORY["${file}"]="${expected_sha}"
+done < <(sudo cat /opt/kamiwaza/prereqs/artifacts.tsv)
+((${#INVENTORY[@]} > 0))
+
+# A split source is reconstructed locally and therefore is not itself a row in
+# the post-distribution inventory. Root-stage each authenticated manifest and
+# add its source hash to the accepted source map.
+declare -A SOURCE_INVENTORY=()
+shopt -s nullglob
+PART_MANIFESTS=("${ARTIFACT_DIR}"/*.parts.json)
+for manifest in "${PART_MANIFESTS[@]}"; do
+  manifest_name="$(basename "${manifest}")"
+  [[ -v "INVENTORY[${manifest_name}]" ]]
+  sudo cp "${manifest}" /opt/kamiwaza/prereqs/
+  printf '%s  %s\n' "${INVENTORY[${manifest_name}]}" \
+    "/opt/kamiwaza/prereqs/${manifest_name}" | sudo sha256sum -c -
+  source_name="$(sudo jq -er '.source.filename' \
+    "/opt/kamiwaza/prereqs/${manifest_name}")"
+  source_sha="$(sudo jq -er '.source.sha256' \
+    "/opt/kamiwaza/prereqs/${manifest_name}")"
+  [[ "${source_name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+  [[ "${source_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
+  [[ ! -v "SOURCE_INVENTORY[${source_name}]" ]]
+  SOURCE_INVENTORY["${source_name}"]="${source_sha}"
+done
+
+sudo cp "${RPM_FILES[@]}" \
+  "${WRAP_FILES[@]}" \
   "${ARTIFACT_DIR}"/kamiwaza-helm.sha256 \
   "${ARTIFACT_DIR}"/kamiwaza-helm.asc \
   "${ARTIFACT_DIR}"/kamiwaza-tools-rpm.pub.gpg \
   /opt/kamiwaza/prereqs/
 
-sudo rpm -Uvh --replacepkgs /opt/kamiwaza/prereqs/kamiwaza-prod-*.el9.x86_64.rpm
+STAGED_FILES=(
+  "${RPM_FILES[@]}"
+  "${WRAP_FILES[@]}"
+  "${ARTIFACT_DIR}/kamiwaza-helm.sha256"
+  "${ARTIFACT_DIR}/kamiwaza-helm.asc"
+  "${ARTIFACT_DIR}/kamiwaza-tools-rpm.pub.gpg"
+)
+for source in "${STAGED_FILES[@]}"; do
+  name="$(basename "${source}")"
+  if [[ -v "INVENTORY[${name}]" ]]; then
+    expected_sha="${INVENTORY[${name}]}"
+  else
+    [[ -v "SOURCE_INVENTORY[${name}]" ]]
+    expected_sha="${SOURCE_INVENTORY[${name}]}"
+  fi
+  printf '%s  %s\n' "${expected_sha}" \
+    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
+done
+
+RPM_NAME="$(basename "${RPM_FILES[0]}")"
+sudo rpm -Uvh --replacepkgs "/opt/kamiwaza/prereqs/${RPM_NAME}"
 sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
   --yes \
   --embedded-root /opt/kamiwaza/prereqs \
   --os rhel
+)
 ```
 
 If this exact packaged bootstrap does not support `--yes`, use its documented
@@ -323,6 +481,8 @@ long unattended install.
 The install runs as root, so verify tools using root's actual environment:
 
 ```bash
+(
+set -euo pipefail
 sudo env \
   HOME=/root \
   PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
@@ -335,6 +495,7 @@ sudo env \
     helmfile --version
     helm dt version
   '
+)
 ```
 
 Do not repair a missing embedded tool by silently installing an arbitrary
@@ -356,20 +517,48 @@ export RUN_ID="<release-or-run>"
 export EXT_BUNDLE="<exact-extension-filename-from-inventory>"
 export EXTRACT_DIR="/var/lib/kajiya-reports/extensions-${RUN_ID}"
 export ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
-export HELPER_DIR="/var/tmp/kamiwaza-extension-helper-${RUN_ID}"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${EXT_BUNDLE}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+HELPER_DIR="$(sudo mktemp -d -p /var/tmp \
+  "kamiwaza-extension-helper-${RUN_ID}.XXXXXX")"
 
 sudo cp "${ARTIFACT_DIR}/${EXT_BUNDLE}" \
   "${ARTIFACT_DIR}/${EXT_BUNDLE}.sha256" \
   /opt/kamiwaza/prereqs/
 
+for name in "${EXT_BUNDLE}" "${EXT_BUNDLE}.sha256"; do
+  mapfile -t expected_rows < <(
+    sudo awk -F '\t' -v name="${name}" '$1 == name {print $2}' \
+      /opt/kamiwaza/prereqs/artifacts.tsv
+  )
+  if ((${#expected_rows[@]} == 0)); then
+    mapfile -t root_manifests < <(
+      sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
+        -name '*.parts.json' -print
+    )
+    for manifest in "${root_manifests[@]}"; do
+      if [[ "$(sudo jq -er '.source.filename' "${manifest}")" = "${name}" ]]; then
+        expected_rows+=("$(sudo jq -er '.source.sha256' "${manifest}")")
+      fi
+    done
+  fi
+  test "${#expected_rows[@]}" -eq 1
+  [[ "${expected_rows[0]}" =~ ^[0-9a-fA-F]{64}$ ]]
+  printf '%s  %s\n' "${expected_rows[0]}" \
+    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
+done
+
 mapfile -t BUNDLE_TOP_LEVELS < <(
-  tar -tzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" |
+  sudo tar -tzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" |
     awk -F/ 'NF {print $1}' | sort -u
 )
 test "${#BUNDLE_TOP_LEVELS[@]}" -eq 1
 export BUNDLE_DIR_NAME="${BUNDLE_TOP_LEVELS[0]}"
+[[ "${BUNDLE_DIR_NAME}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
 
-sudo install -d -m 0755 "${HELPER_DIR}"
 sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}"
 sudo bash "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh" \
   --bundle "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" \
@@ -383,6 +572,7 @@ sudo test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
 sudo install -d -m 0700 "$(dirname "${ROOT_RECORD}")"
 printf '%s\n' "${BUNDLE_ROOT}" | sudo tee "${ROOT_RECORD}" >/dev/null
 sudo chmod 0600 "${ROOT_RECORD}"
+)
 ```
 
 When helpers are supplied separately from the archive, use only the exact
@@ -404,9 +594,10 @@ inference image map:
   "KAMIWAZA_ROOK_OSD_IMAGE_SIZE": "<exact>",
   "KAMIWAZA_RESOURCE_PROFILE": "<exact>",
   "HELMFILE_EXTRA_SET": "<exact, including spaces>",
-  "KAMIWAZA_HELM_TIMEOUT": "<exact>",
   "KAMIWAZA_OFFLINE_APP_IMAGE_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG": "<exact>",
   "KAMIWAZA_OFFLINE_CORE_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_DATAHUB_TAG": "<exact>",
   "KAMIWAZA_OFFLINE_FRONTEND_TAG": "<exact>",
   "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG": "<exact>",
   "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG": "<exact>",
@@ -419,12 +610,13 @@ Validate that the document contains only the expected string keys, then install
 it root-owned:
 
 ```bash
+(
+set -euo pipefail
 CONTRACT_SOURCE=/secure/path/kamiwaza-install-contract.json
-jq -e '
+if ! jq -e '
   type == "object" and
   (keys | sort) == ([
     "HELMFILE_EXTRA_SET",
-    "KAMIWAZA_HELM_TIMEOUT",
     "KAMIWAZA_IMAGE_OVERRIDES",
     "KAMIWAZA_IMAGE_TAG",
     "KAMIWAZA_K8S_RUNTIME",
@@ -432,6 +624,8 @@ jq -e '
     "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
     "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
     "KAMIWAZA_OFFLINE_CORE_TAG",
+    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
     "KAMIWAZA_OFFLINE_FRONTEND_TAG",
     "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
     "KAMIWAZA_RESOURCE_PROFILE",
@@ -439,40 +633,58 @@ jq -e '
     "KAMIWAZA_VERSION"
   ] | sort) and
   all(.[]; type == "string")
-' "${CONTRACT_SOURCE}"
+' "${CONTRACT_SOURCE}" >/dev/null; then
+  printf 'install contract is missing, contains extra keys, or has non-string values\n' >&2
+  exit 1
+fi
 sudo install -o root -g root -m 0600 \
   "${CONTRACT_SOURCE}" /run/kamiwaza-install-contract.json
+)
 ```
 
 Use the exact release contract even when several values happen to share a tag.
 Do not synthesize missing values from the release number.
 `KAMIWAZA_K8S_RUNTIME` must be `k0s-podman` for this guide. If the selected
 contract names another runtime, stop and use that runtime's runbook.
+`KAMIWAZA_OFFLINE_EXTRA_IMAGES` is a Kajiya wrap-build input, not an installer
+environment variable; record it in build provenance when it is nonempty, but do
+not add it to this runtime contract.
 
-### Password limitation
+> **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
+> [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)
+> before invoking `install-prod.sh`. It requires the exact 1.2.0 candidate, a
+> pre-mutation backup, schema gates, stop rules, and recovery evidence.
 
-The current vendor installer accepts the initial admin password through
-`--admin-password`. Although the runner below keeps it out of the saved
-launcher, unit environment, and journal, the installer expands it into child
-process arguments. A privileged user can observe it during the install.
+### Password handling
 
-Proceed only if that temporary privileged-argv exposure is acceptable. Do not
-run full-command-line diagnostics such as `ps auxww` during installation. If
-your security policy requires file-descriptor, file, or standard-input secret
-transport end to end, stop until the installer provides that interface.
+The release/1.2.0 installer accepts `KAMIWAZA_ADMIN_PASSWORD`, copies it into a
+shell variable, and removes it from the environment before starting child
+processes. The launcher below uses that interface, so the password is not placed
+in installer or child-process arguments. Root can still inspect the launcher's
+memory while it is running; keep full process-environment diagnostics out of
+captures.
 
 Read the password without echoing it and create a transient root-only file:
 
 ```bash
+(
+set -euo pipefail
 read -rsp 'Initial Kamiwaza admin password: ' ADMIN_PASSWORD; printf '\n'
+sudo install -o root -g root -m 0600 /dev/null /run/kamiwaza-admin-password
 printf '%s' "${ADMIN_PASSWORD}" | sudo tee /run/kamiwaza-admin-password >/dev/null
 unset ADMIN_PASSWORD
-sudo chmod 0600 /run/kamiwaza-admin-password
+)
 ```
 
-Create `/run/kamiwaza-offline-install.sh` as root, mode 0700:
+Create `/run/kamiwaza-offline-install.sh` as root with a quoted heredoc so the
+interactive shell cannot expand the script body:
 
 ```bash
+(
+set -euo pipefail
+sudo install -o root -g root -m 0700 /dev/null \
+  /run/kamiwaza-offline-install.sh
+sudo tee /run/kamiwaza-offline-install.sh >/dev/null <<'KAMIWAZA_INSTALL'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -480,17 +692,38 @@ export HOME=/root
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export HELM_PLUGINS=/usr/local/share/helm/plugins
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+unset NAMESPACE
 
 CONTRACT=/run/kamiwaza-install-contract.json
 PASSWORD_FILE=/run/kamiwaza-admin-password
-STATUS_FILE=/run/kamiwaza-offline-install.rc
+RUN_ID="${1:?pass the recorded run ID}"
+ATTEMPT_ID="${2:?pass the recorded attempt number}"
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
+STATUS_ROOT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts"
+ATTEMPT_DIR="${STATUS_ROOT}/attempt${ATTEMPT_ID}"
+STATUS_FILE="${ATTEMPT_DIR}/result.rc"
+
+test -d "${ATTEMPT_DIR}"
+test ! -e "${STATUS_FILE}"
+umask 077
+cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
+exec >"${ATTEMPT_DIR}/console.log" 2>&1
 
 finish() {
   rc=$?
+  trap - EXIT
   rm -f "${PASSWORD_FILE}"
-  printf '%s\n' "${rc}" >"${STATUS_FILE}"
+  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
+  printf '%s\n' "${rc}" >"${status_tmp}"
+  chmod 0600 "${status_tmp}"
+  mv -f "${status_tmp}" "${STATUS_FILE}"
+  exit "${rc}"
 }
 trap finish EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 test -s "${CONTRACT}"
 test -s "${PASSWORD_FILE}"
@@ -505,9 +738,10 @@ CONTRACT_KEYS=(
   KAMIWAZA_ROOK_OSD_IMAGE_SIZE
   KAMIWAZA_RESOURCE_PROFILE
   HELMFILE_EXTRA_SET
-  KAMIWAZA_HELM_TIMEOUT
   KAMIWAZA_OFFLINE_APP_IMAGE_TAG
+  KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG
   KAMIWAZA_OFFLINE_CORE_TAG
+  KAMIWAZA_OFFLINE_DATAHUB_TAG
   KAMIWAZA_OFFLINE_FRONTEND_TAG
   KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG
   KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG
@@ -515,31 +749,36 @@ CONTRACT_KEYS=(
   KAMIWAZA_IMAGE_OVERRIDES
 )
 for name in "${CONTRACT_KEYS[@]}"; do
-  printf -v "${name}" '%s' "$(jq -er --arg name "${name}" '.[$name] | strings' "${CONTRACT}")"
+  value="$(jq -er --arg name "${name}" '.[$name] | strings' "${CONTRACT}")"
+  printf -v "${name}" '%s' "${value}"
   export "${name}"
 done
+unset value
 
 ADMIN_PASSWORD="$(<"${PASSWORD_FILE}")"
-/opt/kamiwaza/scripts/install-prod.sh \
+KAMIWAZA_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
+  /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
   --skip-prereq-bootstrap \
   --domain '<domain>' \
-  --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
   --wrap-pubkey /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg \
-  -e "helm_timeout=${KAMIWAZA_HELM_TIMEOUT}" \
   -y
 unset ADMIN_PASSWORD
+KAMIWAZA_INSTALL
+)
 ```
 
 Replace `<domain>`, then validate and protect the launcher:
 
 ```bash
+(
+set -euo pipefail
 sudo bash -n /run/kamiwaza-offline-install.sh
 sudo chmod 0700 /run/kamiwaza-offline-install.sh
-sudo rm -f /run/kamiwaza-offline-install.rc
+)
 ```
 
 ## 6. Launch through SSM without tying the install to the shell
@@ -548,42 +787,74 @@ An SSM interactive shell can time out while a healthy installation is still
 running. Launch each attempt as a distinct transient systemd unit:
 
 ```bash
+export RUN_ID="<release-or-run>"
 export ATTEMPT=1
+export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
+export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
+export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
+sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
+sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
 sudo systemd-run \
   --no-block \
-  --unit="kamiwaza-offline-install-attempt${ATTEMPT}" \
+  --service-type=oneshot \
+  --remain-after-exit \
+  --unit="${CORE_UNIT%.service}" \
   --property=KillMode=process \
   --property=Delegate=yes \
   --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-install.sh
+  /bin/bash /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}"
+printf 'record unit=%s attempt_dir=%s\n' "${CORE_UNIT}" "${CORE_ATTEMPT_DIR}"
+)
 ```
 
-Immediately record the unit name and these watch commands:
+Immediately record the unit name and follow the persistent root-only log:
 
 ```bash
-sudo journalctl -fu "kamiwaza-offline-install-attempt${ATTEMPT}.service"
-
-sudo systemctl show "kamiwaza-offline-install-attempt${ATTEMPT}.service" \
-  -p ActiveState -p SubState -p Result -p ExecMainStatus
+sudo tail -F "${CORE_ATTEMPT_DIR}/console.log"
 ```
+
+Stop following with Ctrl-C only after the unit is terminal; then run the strict
+completion gate in the next section.
 
 Journal activity—or quietness—is not a completion signal. Because
 `KillMode=process` and `Delegate=yes` allow runtime children to survive the
 launcher, a stopped unit also does not prove all children stopped after an
 error. Declare the core launcher successful only when all of these agree:
 
-- `Result=success` and `ExecMainStatus=0`;
-- `/run/kamiwaza-offline-install.rc` contains `0`;
+- `LoadState=loaded`, `ActiveState=active`, `SubState=exited`,
+  `Result=success`, `ExecMainCode=1`, and `ExecMainStatus=0` from one
+  `systemctl show` snapshot;
+- the recorded per-attempt `${CORE_STATUS}` contains `0`;
 - the final Ansible recap has `failed=0` and `unreachable=0`; and
 - the independent workload checks in the next section pass.
 
+`--remain-after-exit` keeps a successful transient unit loaded so a misspelled,
+garbage-collected, or never-created unit cannot look identical to success.
 `systemd-run` is preferred on RHEL because it preserves an authoritative exit
 status. If systemd transient units are unavailable, the launcher can be
-detached with `nohup`:
+detached with `nohup` and the same attempt argument:
 
 ```bash
-sudo nohup /bin/bash /run/kamiwaza-offline-install.sh \
-  </dev/null >/var/log/kamiwaza-offline-install.log 2>&1 &
+export ATTEMPT=2
+export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
+export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
+sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
+sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
+sudo /bin/bash -c '
+  exec nohup /bin/bash "$1" "$2" "$3" </dev/null >"$4" 2>&1 &
+' _ /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}" \
+  "${CORE_ATTEMPT_DIR}/launcher.log"
+)
 ```
 
 In that fallback, require the runner's `.rc` file plus the final recap and all
@@ -591,41 +862,112 @@ independent health gates; the background PID disappearing is not success.
 
 ## 7. Verify the core installation
 
-The `k0s-podman` topology is nested:
+The `k0s-podman` topology uses Podman as the k0s container engine on the host:
 
 ```text
-RHEL host -> Podman-contained k0s node -> Kubernetes pods
+RHEL host -> k0s with Podman container engine -> Kubernetes pods
 ```
 
 Host processes and Kubernetes workloads do not share one network namespace.
-Use the k0s admin kubeconfig and the node IP reported by Kubernetes. If an EC2
+Use the root kubeconfig installed by the playbook and the node IP reported by Kubernetes. If an EC2
 instance role is intentionally available to workloads, the instance metadata
 response hop limit must support this nested path; explicit S3 credentials
 remain supported when ambient identity is not desired.
 
-Run:
+For a same-boot verification, rebind the recorded values after reconnecting and
+run:
 
 ```bash
 export DOMAIN="<domain>"
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+export RUN_ID="<release-or-run>"
+export ATTEMPT=1
+export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
+export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
+export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
 
-sudo systemctl show "kamiwaza-offline-install-attempt${ATTEMPT}.service" \
-  -p Result -p ExecMainStatus -p ActiveState
+(
+set -euo pipefail
+test "$(sudo cat "${CORE_ATTEMPT_DIR}/boot-id")" = \
+  "$(cat /proc/sys/kernel/random/boot_id)"
+CORE_STATE="$(sudo systemctl show "${CORE_UNIT}" \
+  -p LoadState -p ActiveState -p SubState -p Result \
+  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
+printf '%s\n' "${CORE_STATE}"
+for expected in \
+  LoadState=loaded ActiveState=active SubState=exited \
+  Result=success ExecMainCode=1 ExecMainStatus=0; do
+  grep -Fxq "${expected}" <<<"${CORE_STATE}"
+done
+grep -Eq '^InvocationID=.+$' <<<"${CORE_STATE}"
+test "$(sudo cat "${CORE_STATUS}")" = 0
+)
+```
+
+Run the workload gates separately so the same block is usable after a verified
+post-success reboot:
+
+```bash
+export DOMAIN="<domain>"
+
+(
+set -euo pipefail
+NODES_JSON="$(sudo kubectl get nodes -o json)"
+jq -e '
+  (.items | length) > 0 and
+  all(.items[]; any(.status.conditions[]?;
+    .type == "Ready" and .status == "True"))
+' <<<"${NODES_JSON}" >/dev/null
+
+PODS_JSON="$(sudo kubectl get pods -A -o json)"
+jq -e '
+  (.items | length) > 0 and
+  all(.items[];
+    .status.phase == "Succeeded" or
+    (.status.phase == "Running" and
+     ((.status.containerStatuses // []) | length) > 0 and
+     all(.status.containerStatuses[]; .ready == true)))
+' <<<"${PODS_JSON}" >/dev/null
+jq -e '
+  all(.items[];
+    all((.status.containerStatuses // [])[];
+      (.imageID // "") | contains("sha256:")))
+' <<<"${PODS_JSON}" >/dev/null
+
+HELM_JSON="$(sudo helm list -A -o json)"
+jq -e 'length > 0 and all(.[]; .status == "deployed")' \
+  <<<"${HELM_JSON}" >/dev/null
+
+NODE_IP="$(sudo kubectl get nodes \
+  -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+test -n "${NODE_IP}"
+HTTP_CODE="$(curl -kfsS --resolve "${DOMAIN}:443:${NODE_IP}" \
+  -o /dev/null -w '%{http_code}' \
+  "https://${DOMAIN}/api/auth/health")"
+test "${HTTP_CODE}" = 200
+
 sudo kubectl get nodes -o wide
 sudo kubectl get pods -A
 sudo helm list -A
-
-NODE_IP="$(sudo kubectl get nodes -o wide --no-headers | awk 'NR==1 {print $6}')"
-curl -k --resolve "${DOMAIN}:443:${NODE_IP}" \
-  -o /dev/null -w 'HTTP %{http_code}\n' \
-  "https://${DOMAIN}/api/auth/health"
+printf 'health HTTP %s\n' "${HTTP_CODE}"
+)
 ```
 
-An unauthenticated endpoint can return 401 or 403 while routing is healthy, so
-that curl is only a reachability check. Also verify login and an authenticated
-API request, deployed Helm releases, expected local-registry manifests, and
-the live pod `imageID` digests against the selected release contract. Health
-without expected digest evidence proves function, not artifact provenance.
+If the host rebooted only **after** the durable `result.rc` reached `0`, the
+transient unit tuple is no longer available. Do not run the same-boot tuple
+gate. Instead require that attempt's root-only `console.log` to contain the
+final clean Ansible recap, then run the separate workload block and every login,
+digest, and provenance gate below. A missing or nonzero receipt is not
+recoverable success.
+
+The health endpoint is authentication-exempt and must return a successful HTTP
+status. Also verify login and an authenticated API request, deployed Helm
+releases, expected local-registry manifests, and the live pod `imageID` digests
+against the selected release contract. Health without expected digest evidence
+proves function, not artifact provenance. Passing the shell block alone is not
+level-1 completion; login and an authenticated request must also succeed. A
+missing expected manifest/digest comparison does not block that functional
+level, but it does block any claim that the running images match the selected
+release provenance.
 
 The domain must resolve both from the install host and from the operator's
 browser. Add one exact, reviewed `/etc/hosts` entry only when DNS is not ready;
@@ -633,7 +975,9 @@ do not append duplicates on every retry.
 
 For SSM port forwarding, map local port 8443 to target port 443, add
 `127.0.0.1 <domain>` to the operator workstation, and browse to
-`https://<domain>:8443`. Preserve `:8443` after authentication redirects.
+`https://<domain>:8443/login`. The default certificate is self-signed, so the
+browser presents a warning until the operator explicitly trusts or replaces
+it. Preserve `:8443` after authentication redirects.
 
 ## 8. Fully load bundled extensions (optional)
 
@@ -642,9 +986,15 @@ load in a **separate** detached unit after the authenticated API is ready. Reuse
 the exact root recorded during pre-stage; do not extract another copy without a
 specific reason.
 
-Create `/run/kamiwaza-offline-extensions.sh` as root, mode 0700:
+Create `/run/kamiwaza-offline-extensions.sh` through a root-owned quoted
+heredoc:
 
 ```bash
+(
+set -euo pipefail
+sudo install -o root -g root -m 0700 /dev/null \
+  /run/kamiwaza-offline-extensions.sh
+sudo tee /run/kamiwaza-offline-extensions.sh >/dev/null <<'KAMIWAZA_EXTENSIONS'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -654,8 +1004,34 @@ export HELM_PLUGINS=/usr/local/share/helm/plugins
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 DOMAIN='<domain>'
-ROOT_RECORD='/var/lib/kajiya-reports/offline-install/<release-or-run>/bundle-root'
+RUN_ID="${1:?pass the recorded run ID}"
+ATTEMPT_ID="${2:?pass the recorded attempt number}"
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
+ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${ATTEMPT_ID}"
+STATUS_FILE="${ATTEMPT_DIR}/result.rc"
+ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
 BUNDLE_ROOT="$(<"${ROOT_RECORD}")"
+
+test -d "${ATTEMPT_DIR}"
+test ! -e "${STATUS_FILE}"
+umask 077
+cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
+exec >"${ATTEMPT_DIR}/console.log" 2>&1
+
+finish() {
+  rc=$?
+  trap - EXIT
+  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
+  printf '%s\n' "${rc}" >"${status_tmp}"
+  chmod 0600 "${status_tmp}"
+  mv -f "${status_tmp}" "${STATUS_FILE}"
+  exit "${rc}"
+}
+trap finish EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 test -d "${BUNDLE_ROOT}"
 test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
@@ -676,6 +1052,8 @@ printf '%s\n' "${ADMIN_PASSWORD}" |
     --username admin \
     --password-stdin
 unset ADMIN_PASSWORD
+KAMIWAZA_EXTENSIONS
+)
 ```
 
 The current bundle helper accepts `--password-stdin`, but its catalog-import
@@ -686,55 +1064,125 @@ installer. Do not capture full process argument lists during this phase.
 Launch and monitor it like the core phase:
 
 ```bash
+export RUN_ID="<release-or-run>"
+export EXT_ATTEMPT=1
+export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
+export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
+export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${EXT_ATTEMPT}" =~ ^[0-9]+$ ]]
 sudo bash -n /run/kamiwaza-offline-extensions.sh
 sudo chmod 0700 /run/kamiwaza-offline-extensions.sh
-
-export EXT_ATTEMPT=1
+sudo install -d -o root -g root -m 0700 "$(dirname "${EXT_ATTEMPT_DIR}")"
+sudo mkdir -m 0700 "${EXT_ATTEMPT_DIR}"
 sudo systemd-run \
   --no-block \
-  --unit="kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}" \
+  --service-type=oneshot \
+  --remain-after-exit \
+  --unit="${EXT_UNIT%.service}" \
   --property=KillMode=process \
   --property=Delegate=yes \
   --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extensions.sh
+  /bin/bash /run/kamiwaza-offline-extensions.sh "${RUN_ID}" "${EXT_ATTEMPT}"
+printf 'record unit=%s attempt_dir=%s\n' "${EXT_UNIT}" "${EXT_ATTEMPT_DIR}"
+)
 
-sudo journalctl -fu "kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}.service"
-sudo systemctl show "kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}.service" \
-  -p ActiveState -p SubState -p Result -p ExecMainStatus
+sudo tail -F "${EXT_ATTEMPT_DIR}/console.log"
 ```
 
-Require unit success, all expected local-registry manifests, healthy workloads,
-and exact stored and visible catalog counts for the selected immutable bundle.
-Stored and visible counts can differ when product posture intentionally hides a
-template; verify both instead of assuming that an absent UI card means import
-failed.
+After the unit is terminal, stop following with Ctrl-C and gate the exact
+recorded attempt:
 
-The release handoff must provide the exact commands and expected digest/count
-files for these assertions. Run its hash-verified authenticated resource gate
-and diagnostics from the recorded Kajiya commit. If that executable gate or its
-expected values are absent, the operator cannot make a release-provenance claim;
-obtain them from the publisher instead of substituting dated counts from this
-page.
+```bash
+export RUN_ID="<release-or-run>"
+export EXT_ATTEMPT=1
+export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
+export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
+export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+test "$(sudo cat "${EXT_ATTEMPT_DIR}/boot-id")" = \
+  "$(cat /proc/sys/kernel/random/boot_id)"
+EXT_STATE="$(sudo systemctl show "${EXT_UNIT}" \
+  -p LoadState -p ActiveState -p SubState -p Result \
+  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
+printf '%s\n' "${EXT_STATE}"
+for expected in \
+  LoadState=loaded ActiveState=active SubState=exited \
+  Result=success ExecMainCode=1 ExecMainStatus=0; do
+  grep -Fxq "${expected}" <<<"${EXT_STATE}"
+done
+grep -Eq '^InvocationID=.+$' <<<"${EXT_STATE}"
+test "$(sudo cat "${EXT_STATUS}")" = 0
+sudo kubectl get pods -A
+)
+```
+
+Also require all expected local-registry manifests and healthy workloads.
+Record the exact stored and visible catalog counts for the selected immutable
+bundle. Stored and visible counts can differ when product posture intentionally
+hides a template; verify both instead of assuming that an absent UI card means
+import failed.
+
+Customer level-2 completion does not require private Kajiya smoke helpers or
+unpublished expected-count files. If the publisher supplies an additional
+hash-authenticated validation pack, run its resource assertions; otherwise
+record the observed evidence without substituting dated counts from this page.
 
 Do not blindly rerun only the catalog importer after success. Existing hidden
 templates can be invisible to its list call and then cause a duplicate-create
 HTTP 400.
 
-## 9. Run the release deploy gate (release parity)
+## 9. Run the internal release deploy gate (release parity)
 
-For release/nightly parity, use the exact hash-verified
-`smoke-extension-deploy.sh` and any additional guard scripts from the selected
-Kajiya commit. Store them in the session's root-only helper directory. The
-currently selected 1.2.0 gate deploys `kaizen`, but the selected release
+This section is for Kamiwaza release engineers. The normal customer bundle does
+not contain `smoke-extension-deploy.sh`, the Konnectivity guard, or expected
+release-gate values. Do not require this section for customer level-1 or level-2
+completion. For release/nightly parity, transfer the selected run's separate
+validation pack and verify its recorded hashes; never download `develop` at
+install time.
+
+Install the verified gate into a fresh root-only directory:
+
+```bash
+export RUN_ID="<release-or-run>"
+export GATE_SOURCE="/secure/validation-pack/smoke-extension-deploy.sh"
+export GATE_SHA256="<sha256-from-selected-validation-pack>"
+export GATE_HELPER_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${GATE_SHA256}" =~ ^[0-9a-fA-F]{64}$ ]]
+printf '%s  %s\n' "${GATE_SHA256}" "${GATE_SOURCE}" | sha256sum -c -
+sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_HELPER_DIR}")"
+sudo mkdir -m 0700 "${GATE_HELPER_DIR}"
+sudo install -o root -g root -m 0700 "${GATE_SOURCE}" \
+  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh"
+printf '%s  %s\n' "${GATE_SHA256}" \
+  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh" | sudo sha256sum -c -
+)
+```
+
+The currently selected 1.2.0 gate deploys `kaizen`, but the selected release
 contract controls the exact template. The gate waits for readiness, proves that
 relocation left no external image references, and removes it through the
 supported API path. A raw `kubectl apply` bypasses that behavior and is not an
 equivalent test.
 
-Create `/run/kamiwaza-offline-extension-gate.sh` as root, mode 0700, replacing
-the placeholders with the recorded helper path and domain:
+Create `/run/kamiwaza-offline-extension-gate.sh` through a root-owned quoted
+heredoc, replacing the placeholders with the recorded domain and gate values:
 
 ```bash
+(
+set -euo pipefail
+sudo install -o root -g root -m 0700 /dev/null \
+  /run/kamiwaza-offline-extension-gate.sh
+sudo tee /run/kamiwaza-offline-extension-gate.sh >/dev/null <<'KAMIWAZA_GATE'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -744,9 +1192,35 @@ export HELM_PLUGINS=/usr/local/share/helm/plugins
 export KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
 DOMAIN='<domain>'
-GATE_SCRIPT='/var/lib/kajiya-reports/offline-install/<release-or-run>/helpers/smoke-extension-deploy.sh'
+RUN_ID="${1:?pass the recorded run ID}"
+ATTEMPT_ID="${2:?pass the recorded attempt number}"
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
+ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${ATTEMPT_ID}"
+STATUS_FILE="${ATTEMPT_DIR}/result.rc"
+GATE_SCRIPT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation/smoke-extension-deploy.sh"
 GATE_TEMPLATE='<exact-gate-template-from-selected-release>'
 GATE_WAIT_TIMEOUT='<exact-gate-timeout-from-selected-release>'
+
+test -d "${ATTEMPT_DIR}"
+test ! -e "${STATUS_FILE}"
+umask 077
+cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
+exec >"${ATTEMPT_DIR}/console.log" 2>&1
+
+finish() {
+  rc=$?
+  trap - EXIT
+  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
+  printf '%s\n' "${rc}" >"${status_tmp}"
+  chmod 0600 "${status_tmp}"
+  mv -f "${status_tmp}" "${STATUS_FILE}"
+  exit "${rc}"
+}
+trap finish EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 test -x "${GATE_SCRIPT}"
 ADMIN_PASSWORD="$(
@@ -762,35 +1236,73 @@ printf '%s\n' "${ADMIN_PASSWORD}" |
     --template-name "${GATE_TEMPLATE}" \
     --wait-timeout "${GATE_WAIT_TIMEOUT}"
 unset ADMIN_PASSWORD
+KAMIWAZA_GATE
+)
 ```
 
 Launch and gate it independently:
 
 ```bash
+export RUN_ID="<release-or-run>"
+export GATE_ATTEMPT=1
+export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
+export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
+export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+[[ "${GATE_ATTEMPT}" =~ ^[0-9]+$ ]]
 sudo bash -n /run/kamiwaza-offline-extension-gate.sh
 sudo chmod 0700 /run/kamiwaza-offline-extension-gate.sh
-
-export GATE_ATTEMPT=1
+sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_ATTEMPT_DIR}")"
+sudo mkdir -m 0700 "${GATE_ATTEMPT_DIR}"
 sudo systemd-run \
   --no-block \
-  --unit="kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}" \
+  --service-type=oneshot \
+  --remain-after-exit \
+  --unit="${GATE_UNIT%.service}" \
   --property=KillMode=process \
   --property=Delegate=yes \
   --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extension-gate.sh
+  /bin/bash /run/kamiwaza-offline-extension-gate.sh "${RUN_ID}" "${GATE_ATTEMPT}"
+printf 'record unit=%s attempt_dir=%s\n' "${GATE_UNIT}" "${GATE_ATTEMPT_DIR}"
+)
 
-sudo journalctl -fu \
-  "kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}.service"
-sudo systemctl show \
-  "kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}.service" \
-  -p ActiveState -p SubState -p Result -p ExecMainStatus
+sudo tail -F "${GATE_ATTEMPT_DIR}/console.log"
 ```
 
-Require `Result=success` and `ExecMainStatus=0`. Also run any Konnectivity or
-authenticated resource gate named by the selected release contract. These
-scripts are release inputs: record their source commit and SHA-256 rather than
-downloading `develop` at install time. The temporary child-argv limitation
-described in the extension-load phase also applies to this helper.
+After the unit is terminal, require the retained unit tuple and the matching
+durable receipt:
+
+```bash
+export RUN_ID="<release-or-run>"
+export GATE_ATTEMPT=1
+export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
+export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
+export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
+
+(
+set -euo pipefail
+test "$(sudo cat "${GATE_ATTEMPT_DIR}/boot-id")" = \
+  "$(cat /proc/sys/kernel/random/boot_id)"
+GATE_STATE="$(sudo systemctl show "${GATE_UNIT}" \
+  -p LoadState -p ActiveState -p SubState -p Result \
+  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
+printf '%s\n' "${GATE_STATE}"
+for expected in \
+  LoadState=loaded ActiveState=active SubState=exited \
+  Result=success ExecMainCode=1 ExecMainStatus=0; do
+  grep -Fxq "${expected}" <<<"${GATE_STATE}"
+done
+grep -Eq '^InvocationID=.+$' <<<"${GATE_STATE}"
+test "$(sudo cat "${GATE_STATUS}")" = 0
+)
+```
+
+Also run any Konnectivity or authenticated resource gate in the same validation
+pack. Record every script's source commit and SHA-256. The temporary child-argv
+limitation described in the extension-load phase also applies to this helper.
 
 SDK tests, UAT data seeding, DNS publication, and A/B promotion are separate
 demo or publication phases. They are not required to call the base platform or
@@ -798,15 +1310,37 @@ extension bundle installed.
 
 ## Reruns, recovery, and diagnostics
 
-- Download and part assembly are safely repeatable after removing only a failed
-  `.assembling` file. Verify final-target SHA-256 again after every transfer.
+- Download and part assembly are safely repeatable. The download block removes
+  an unverifiable or unresumable `.partial`; remove a failed `.assembling`
+  before retrying assembly. Verify final-target SHA-256 after every transfer.
 - `rpm --replacepkgs` is intentional. A core installer rerun is **not** a
   generic reset: inspect the existing unit, Ansible recap, cluster, registry,
-  and surviving child processes first.
-- Use monotonically named attempt units. Never overwrite the evidence from a
-  failed attempt before its cause is understood.
+  and surviving child processes first. Recreate the root-only password file
+  before every core attempt because the launcher removes it on exit.
+- Before staging a different release, archive or remove only the previous
+  release's RPM, numbered wrap chunks, checksum, signature, public key, and
+  extension archive/sidecar, root-staged `*.parts.json` manifests, and
+  `artifacts.tsv` from `/opt/kamiwaza/prereqs`. Never mix release artifact
+  families or broadly delete the packaged prerequisite tree. For an
+  exact-release retry, verify the existing files and reuse them.
+- Use monotonically named units and fresh per-attempt directories. Never reuse
+  an attempt number or overwrite a terminal receipt, log, or recap before the
+  cause is understood. After preserving evidence, stop a retained unit to
+  release its systemd state.
 - Reuse a verified pre-extracted extension root. Do not select among stale
   directories with an unordered search.
+- Do not blindly rerun an extension or deploy-gate phase after interruption.
+  First compare its persistent log, stored and visible catalog state, local
+  manifests, and API resources. If catalog import completed, reconcile it
+  instead of creating duplicates. If the deploy gate stranded its test
+  deployment, remove that exact deployment through the supported API before a
+  new attempt.
+- An SSM disconnect does not stop a system unit. A host reboot does remove all
+  transient units and every contract, secret, and launcher under `/run`. A
+  missing durable `result.rc` after reboot is interrupted/unknown, never
+  success. Inspect partial state, recreate `/run` inputs, and allocate a new
+  attempt. A pre-reboot `result.rc` of `0` is usable only with its saved recap
+  and fresh post-reboot health and provenance gates.
 - Never delete clusters, PVCs, registry volumes, or an instance as a default
   retry. Destructive recovery requires a separate backup and rollback decision.
 - Do not treat repeated red `HEAD`/manifest-not-found lines from a local
@@ -817,15 +1351,21 @@ Useful focused diagnostics:
 
 ```bash
 sudo systemctl show <unit>.service \
-  -p ActiveState -p SubState -p Result -p ExecMainStatus
+  -p LoadState -p ActiveState -p SubState -p Result \
+  -p ExecMainCode -p ExecMainStatus -p InvocationID
 sudo journalctl -u <unit>.service -o cat
 sudo kubectl get nodes -o wide
 sudo kubectl get pods -A -o wide
 sudo kubectl get events -A --sort-by=.lastTimestamp
 sudo helm list -A
 sudo podman ps -a
-df -hT / /tmp /var/lib
+df -hT / /tmp /var/tmp /var/lib /opt
 ```
+
+If a preflight aborts at `storage_host_prep`, `/var/lib` cannot fit the
+configured storage image on its actual backing filesystem. Grow or remount that
+filesystem before retrying; do not treat the abort as a prompt or bypass the
+preflight.
 
 Keep secrets and full process argument lists out of diagnostic captures. If a
 password appears in output, treat it as exposed and rotate it through a

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -39,12 +39,12 @@ You need:
 - Root access on the target. For a remote private host, Session Manager (SSM)
   or an equivalent managed shell is preferred over SSH.
 - Bash 4.4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
-  `tar` on the connected staging machine. The verification snippets use GNU
-  options and do not run in stock macOS Bash; use a trusted Linux staging host
-  or container when the connected workstation is a Mac. If the target has no
-  reachable RHEL repositories, those tools and all OS packages required by the
-  selected prerequisite bootstrap must already be available through a trusted
-  local repository or the verified handoff.
+  `tar` on every machine that runs the snippets. They use GNU options and do not
+  run in stock macOS Bash; use a trusted Linux staging host or container when
+  the connected workstation is a Mac. If the target has no reachable RHEL
+  repositories, those tools and all OS packages required by the selected
+  prerequisite bootstrap must already be available through a trusted local
+  repository or the verified handoff.
 
 ### Check the actual filesystems
 
@@ -85,6 +85,13 @@ set -euo pipefail
 test "$(uname -m)" = x86_64
 grep -E 'release 9([. ]|$)' /etc/redhat-release
 test "$(hostnamectl --static | wc -c)" -le 55
+((BASH_VERSINFO[0] > 4 ||
+  (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)))
+for command_name in \
+  awk curl find findmnt gpg jq lsblk rpm sha256sum sort stat sudo systemctl \
+  systemd-run tar; do
+  command -v "${command_name}" >/dev/null
+done
 )
 ```
 
@@ -174,10 +181,13 @@ export RELEASE="<release>"
 export PACKAGE_KEY="<exact-package-key-from-the-selected-release>"
 export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@${PACKAGE_KEY}/${RELEASE}"
 export ARTIFACT_DIR="${PWD}/kamiwaza-offline-${RELEASE}"
+export INVENTORY_SOURCE="<secure-path-to-artifacts.tsv>"
 
 (
 set -euo pipefail
 [[ "${RELEASE}" =~ ^[A-Za-z0-9._-]+$ ]]
+[[ "${INVENTORY_SOURCE}" != *'<'* ]]
+test -f "${INVENTORY_SOURCE}"
 
 read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
 
@@ -188,7 +198,7 @@ printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" >"${AUTH_HEADER}"
 unset KEYGEN_TOKEN
 
 install -d -m 0755 "${ARTIFACT_DIR}"
-cp /secure/path/artifacts.tsv "${ARTIFACT_DIR}/artifacts.tsv"
+cp "${INVENTORY_SOURCE}" "${ARTIFACT_DIR}/artifacts.tsv"
 cd "${ARTIFACT_DIR}"
 
 artifact_count=0
@@ -559,7 +569,10 @@ test "${#BUNDLE_TOP_LEVELS[@]}" -eq 1
 export BUNDLE_DIR_NAME="${BUNDLE_TOP_LEVELS[0]}"
 [[ "${BUNDLE_DIR_NAME}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
 
-sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}"
+sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}" -- \
+  "${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
+sudo test -x \
+  "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
 sudo bash "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh" \
   --bundle "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" \
   --sha256-file "/opt/kamiwaza/prereqs/${EXT_BUNDLE}.sha256" \
@@ -612,7 +625,9 @@ it root-owned:
 ```bash
 (
 set -euo pipefail
-CONTRACT_SOURCE=/secure/path/kamiwaza-install-contract.json
+CONTRACT_SOURCE='<secure-path-to-kamiwaza-install-contract.json>'
+[[ "${CONTRACT_SOURCE}" != *'<'* ]]
+test -f "${CONTRACT_SOURCE}"
 if ! jq -e '
   type == "object" and
   (keys | sort) == ([
@@ -632,9 +647,27 @@ if ! jq -e '
     "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
     "KAMIWAZA_VERSION"
   ] | sort) and
-  all(.[]; type == "string")
+  all(.[]; type == "string") and
+  all(.[]; (contains("<") or contains(">")) | not) and
+  .KAMIWAZA_K8S_RUNTIME == "k0s-podman" and
+  (. as $contract | all([
+    "KAMIWAZA_IMAGE_OVERRIDES",
+    "KAMIWAZA_IMAGE_TAG",
+    "KAMIWAZA_K8S_RUNTIME",
+    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
+    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_CORE_TAG",
+    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
+    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
+    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
+    "KAMIWAZA_RESOURCE_PROFILE",
+    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
+    "KAMIWAZA_VERSION"
+  ][]; ($contract[.] | length > 0)))
 ' "${CONTRACT_SOURCE}" >/dev/null; then
-  printf 'install contract is missing, contains extra keys, or has non-string values\n' >&2
+  printf 'install contract has missing, extra, empty, placeholder, or topology-invalid values\n' >&2
   exit 1
 fi
 sudo install -o root -g root -m 0600 \
@@ -657,12 +690,12 @@ not add it to this runtime contract.
 
 ### Password handling
 
-The release/1.2.0 installer accepts `KAMIWAZA_ADMIN_PASSWORD`, copies it into a
-shell variable, and removes it from the environment before starting child
-processes. The launcher below uses that interface, so the password is not placed
-in installer or child-process arguments. Root can still inspect the launcher's
-memory while it is running; keep full process-environment diagnostics out of
-captures.
+The packaged release/1.2.0 RPM passes unknown arguments through to Ansible. The
+launcher below writes `admin_password` to a root-only, attempt-bound JSON
+extra-vars file under `/run` and passes only that file's path. The password is
+not placed in the installer or child-process arguments or environment. Root can
+still read the temporary file while the phase is running; the launcher's exit
+trap removes it.
 
 Read the password without echoing it and create a transient root-only file:
 
@@ -704,9 +737,11 @@ ATTEMPT_ID="${2:?pass the recorded attempt number}"
 STATUS_ROOT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts"
 ATTEMPT_DIR="${STATUS_ROOT}/attempt${ATTEMPT_ID}"
 STATUS_FILE="${ATTEMPT_DIR}/result.rc"
+ADMIN_VARS_FILE="/run/kamiwaza-admin-extra-vars-${RUN_ID}-attempt${ATTEMPT_ID}.json"
 
 test -d "${ATTEMPT_DIR}"
 test ! -e "${STATUS_FILE}"
+test ! -e "${ADMIN_VARS_FILE}"
 umask 077
 cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
 exec >"${ATTEMPT_DIR}/console.log" 2>&1
@@ -714,7 +749,7 @@ exec >"${ATTEMPT_DIR}/console.log" 2>&1
 finish() {
   rc=$?
   trap - EXIT
-  rm -f "${PASSWORD_FILE}"
+  rm -f "${PASSWORD_FILE}" "${ADMIN_VARS_FILE}"
   status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
   printf '%s\n' "${rc}" >"${status_tmp}"
   chmod 0600 "${status_tmp}"
@@ -757,9 +792,10 @@ for name in "${CONTRACT_KEYS[@]}"; do
 done
 unset value
 
-ADMIN_PASSWORD="$(<"${PASSWORD_FILE}")"
-KAMIWAZA_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
-  /opt/kamiwaza/scripts/install-prod.sh \
+jq -Rs '{admin_password: .}' <"${PASSWORD_FILE}" >"${ADMIN_VARS_FILE}"
+test -s "${ADMIN_VARS_FILE}"
+rm -f "${PASSWORD_FILE}"
+/opt/kamiwaza/scripts/install-prod.sh \
   --offline \
   --skip-prereq-bootstrap \
   --domain "${DOMAIN}" \
@@ -767,13 +803,14 @@ KAMIWAZA_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
   --wrap-pubkey /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg \
+  --extra-vars "@${ADMIN_VARS_FILE}" \
   -y
-unset ADMIN_PASSWORD
 KAMIWAZA_INSTALL
 )
 ```
 
-Replace `<domain>`, then validate and protect the launcher:
+Replace `<domain>` with `sudoedit /run/kamiwaza-offline-install.sh`, then
+validate and protect the launcher:
 
 ```bash
 (
@@ -898,7 +935,10 @@ printf '%s\n' "${CORE_STATE}"
 for expected in \
   LoadState=loaded ActiveState=active SubState=exited \
   Result=success ExecMainCode=1 ExecMainStatus=0; do
-  grep -Fxq "${expected}" <<<"${CORE_STATE}"
+  if ! grep -Fxq "${expected}" <<<"${CORE_STATE}"; then
+    printf 'core unit state gate failed: missing %s\n' "${expected}" >&2
+    exit 1
+  fi
 done
 grep -Eq '^InvocationID=.+$' <<<"${CORE_STATE}"
 test "$(sudo cat "${CORE_STATUS}")" = 0
@@ -1122,7 +1162,10 @@ printf '%s\n' "${EXT_STATE}"
 for expected in \
   LoadState=loaded ActiveState=active SubState=exited \
   Result=success ExecMainCode=1 ExecMainStatus=0; do
-  grep -Fxq "${expected}" <<<"${EXT_STATE}"
+  if ! grep -Fxq "${expected}" <<<"${EXT_STATE}"; then
+    printf 'extension unit state gate failed: missing %s\n' "${expected}" >&2
+    exit 1
+  fi
 done
 grep -Eq '^InvocationID=.+$' <<<"${EXT_STATE}"
 test "$(sudo cat "${EXT_STATUS}")" = 0
@@ -1161,7 +1204,7 @@ Install the verified gate into a fresh root-only directory:
 
 ```bash
 export RUN_ID="<release-or-run>"
-export GATE_SOURCE="/secure/validation-pack/smoke-extension-deploy.sh"
+export GATE_SOURCE="<secure-path-to-smoke-extension-deploy.sh>"
 export GATE_SHA256="<sha256-from-selected-validation-pack>"
 export GATE_HELPER_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation"
 
@@ -1169,6 +1212,8 @@ export GATE_HELPER_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/releas
 set -euo pipefail
 [[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
 [[ "${GATE_SHA256}" =~ ^[0-9a-fA-F]{64}$ ]]
+[[ "${GATE_SOURCE}" != *'<'* ]]
+test -f "${GATE_SOURCE}"
 printf '%s  %s\n' "${GATE_SHA256}" "${GATE_SOURCE}" | sha256sum -c -
 sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_HELPER_DIR}")"
 sudo mkdir -m 0700 "${GATE_HELPER_DIR}"
@@ -1308,7 +1353,10 @@ printf '%s\n' "${GATE_STATE}"
 for expected in \
   LoadState=loaded ActiveState=active SubState=exited \
   Result=success ExecMainCode=1 ExecMainStatus=0; do
-  grep -Fxq "${expected}" <<<"${GATE_STATE}"
+  if ! grep -Fxq "${expected}" <<<"${GATE_STATE}"; then
+    printf 'deploy-gate unit state gate failed: missing %s\n' "${expected}" >&2
+    exit 1
+  fi
 done
 grep -Eq '^InvocationID=.+$' <<<"${GATE_STATE}"
 test "$(sudo cat "${GATE_STATUS}")" = 0
@@ -1341,7 +1389,9 @@ extension bundle installed.
 - Use monotonically named units and fresh per-attempt directories. Never reuse
   an attempt number or overwrite a terminal receipt, log, or recap before the
   cause is understood. After preserving evidence, stop a retained unit to
-  release its systemd state.
+  release its systemd state. If a launcher was killed before its exit trap,
+  confirm that its unit and children have stopped, then remove its exact
+  `/run/kamiwaza-admin-extra-vars-<run>-attempt<n>.json` file before retrying.
 - Reuse a verified pre-extracted extension root. Do not select among stale
   directories with an unordered search.
 - Do not blindly rerun an extension or deploy-gate phase after interruption.

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -1,271 +1,837 @@
 # Offline Installation
 
-The offline installer is for **air-gapped or restricted RHEL 9 environments** with no outbound internet access on the target host. You download the Kamiwaza bundle on a connected machine, transfer it to the target host, and install without pulling anything from the internet during installation.
+This guide installs Kamiwaza on a standalone RHEL 9 x86_64 host from a
+previously published offline bundle. The target does not pull product images
+during the install. Whether the **host bootstrap** can also run without any
+network access depends on the selected bundle: do not call an installation
+fully air-gapped unless that exact build was tested with disconnected RHEL
+package sources.
 
-**Supported host:** RHEL-compatible 9.x (x86_64).
+> This is an advanced, operator-driven path. If the target has normal internet
+> access, use [Online Installation](online_install.md). This page describes the
+> standalone `k0s-podman` topology; an EKS recipe is not an alternative source
+> of truth for this installation.
 
-> This is an advanced, operator-driven path. If your host has internet access, use the simpler [Online Installation](online_install.md) instead.
+An offline deployment has three separate completion levels:
 
-## Prerequisites
+1. **Core installed:** the platform is healthy and login works.
+2. **Bundle installed:** bundled extension images are loaded and the live
+   catalog is imported.
+3. **Release parity:** one bundled extension is deployed, verified, and removed
+   through the supported catalog/API path, plus any additional gates recorded
+   by the selected release run.
 
-- A **Kamiwaza Prod license key**, used to download the bundle artifacts from Keygen.
-- A RHEL-compatible 9.x host (x86_64) that meets the [System Requirements](system_requirements.md).
-- **Free disk space, on the right filesystems.** The offline flow stages large artifacts and provisions cluster storage under `/`, `/tmp`, and `/var/lib`. Confirm each path has room on the **volume that actually backs it** — on hosts with LVM or separate partitions (most cloud RHEL images ship this way), a large total disk does **not** help if `/var` is a small separate volume. Recommended free space:
-  - **`/var/lib` ≥ 140 GB** — the largest consumer. Holds the Rook/Ceph storage OSD image (80 GB by default, set via `KAMIWAZA_ROOK_OSD_IMAGE_SIZE`), the container images under `/var/lib/k0s` and `/var/lib/containers`, and the extracted extension bundle staged under `/var/lib/kajiya-reports`.
-  - **`/tmp` ≥ 25 GB** — bundle extraction and install scratch space.
-  - **`/` ≥ 30 GB** — installed tooling under `/opt` and `/usr/local`, plus general headroom.
+Do not report level 2 or 3 after only pre-staging the extension catalog.
 
-  A small default `/tmp` or `/var` is the most common cause of install failure — the preflight aborts at `storage_host_prep` if `/var/lib` cannot fit the storage image. Grow the backing LV or partition (or mount adequate storage at `/var/lib`) **before** you begin.
-- A machine with internet access to download the bundle, and a way to transfer files to the target host.
+## Before you begin
 
-Throughout this guide, replace the placeholders:
+You need:
 
-- `<license-key>` — your Kamiwaza Prod license key.
-- `<domain>` — the base domain to serve Kamiwaza from (for example `kamiwaza.example.com`).
-- `<admin-password>` — the initial admin password.
+- A supported RHEL-compatible 9.x x86_64 host that meets the
+  [System Requirements](system_requirements.md).
+- A host name no longer than 54 characters.
+- A Kamiwaza license and access to one **immutable** release or Kajiya run.
+- A connected staging machine if the target cannot download the artifacts.
+- Root access on the target. For a remote private host, Session Manager (SSM)
+  or an equivalent managed shell is preferred over SSH.
+- Bash 4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
+  `tar` on the connected staging machine. The verification snippets use GNU
+  options and do not run in stock macOS Bash; use a trusted Linux staging host
+  or container when the connected workstation is a Mac. If the target has no
+  reachable RHEL repositories, those tools and all OS packages required by the
+  selected prerequisite bootstrap must already be available through a trusted
+  local repository or the verified handoff.
 
-## Step 1: Download the Bundle Artifacts
+### Check the actual filesystems
 
-The 1.0.1 offline bundle is published to Keygen as a set of split, checksummed artifacts. Download them (on a connected machine or on the host if it has temporary access), verify the checksums, and recombine the split parts.
+The bundle, extracted extensions, container images, and the Rook/Ceph OSD can
+live on different filesystems. A large virtual disk is not proof that
+`/var/lib` or `/tmp` has room; cloud RHEL images commonly put `/var` on a small
+logical volume.
 
-The extension-bundle filename is release-specific. The value below matches the published 1.0.1 bundle; if `release_origination.md` lists a different name for your build, use that instead.
+Before transfer, calculate the compressed bundle total, the extracted
+extension size, installer scratch, image-store growth, the configured OSD image
+size, and operational headroom. Then check the backing filesystems:
 
 ```bash
-export KEYGEN_TOKEN="<license-key>"
-export RELEASE="1.0.1"
-export EXT_BUNDLE="kamiwaza-extensions-bundle-20260715-151239.tar.gz"
-export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
+df -hT / /tmp /var/lib
+findmnt -T /tmp
+findmnt -T /var/lib
+lsblk -f
+```
 
-sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
-cd /opt/kamiwaza/prereqs
+As a planning floor for the current small profile, allow at least 30 GB free on
+`/`, 25 GB on `/tmp`, and 140 GB on `/var/lib`. These are not substitutes for
+the calculation above: a larger OSD, bundle, or image set requires more. Grow
+the correct PV/LV/filesystem before installation and run `df` again afterward.
 
-for file in \
-  release_origination.md \
-  kamiwaza-tools-rpm.pub.gpg \
-  kamiwaza-helm.sha256 \
-  kamiwaza-helm.asc \
-  kamiwaza-helm.00.tar.part-000 \
-  kamiwaza-helm.00.tar.part-000.sha256 \
-  kamiwaza-helm.00.tar.part-001 \
-  kamiwaza-helm.00.tar.part-001.sha256 \
-  kamiwaza-helm.00.tar.part-002 \
-  kamiwaza-helm.00.tar.part-002.sha256 \
-  kamiwaza-helm.00.tar.parts.json \
-  kamiwaza-prod-1.0.1-1.el9.x86_64.rpm \
-  "${EXT_BUNDLE}.sha256" \
-  "${EXT_BUNDLE}.part-000" \
-  "${EXT_BUNDLE}.part-000.sha256" \
-  "${EXT_BUNDLE}.part-001" \
-  "${EXT_BUNDLE}.part-001.sha256" \
-  "${EXT_BUNDLE}.part-002" \
-  "${EXT_BUNDLE}.part-002.sha256" \
-  "${EXT_BUNDLE}.part-003" \
-  "${EXT_BUNDLE}.part-003.sha256" \
-  "${EXT_BUNDLE}.parts.json"
-do
-  # Always attempt a resume: curl --continue-at - fetches a fresh file or
-  # resumes a partial one, so rerunning the block after an interruption
-  # repairs truncated downloads instead of skipping them.
+Also confirm that no package manager, previous installer, Kubernetes bootstrap,
+or local-registry import is running. Understand any existing `/opt/kamiwaza`,
+`/var/lib/k0s`, Podman, or cluster state before rerunning an installer.
+
+Verify the host before transferring large artifacts:
+
+```bash
+test "$(uname -m)" = x86_64
+grep -E 'release 9([. ]|$)' /etc/redhat-release
+test "$(hostnamectl --static | wc -c)" -le 55
+```
+
+If the host is reached through SSM, validate all four access paths before the
+install window: the instance is `Online`, a harmless Run Command succeeds, an
+interactive Session Manager shell opens, and local port forwarding starts.
+Resolve any configured Session Manager RunAs user mismatch first; do not enable
+SSH as an ad hoc fallback.
+
+```bash
+aws ssm describe-instance-information \
+  --filters Key=InstanceIds,Values=<instance-id> \
+  --region <region> --profile <profile>
+
+COMMAND_ID="$(aws ssm send-command \
+  --instance-ids <instance-id> \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["id","true"]' \
+  --query 'Command.CommandId' --output text \
+  --region <region> --profile <profile>)"
+aws ssm wait command-executed \
+  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
+  --region <region> --profile <profile>
+aws ssm get-command-invocation \
+  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
+  --query '{Status:Status,ResponseCode:ResponseCode}' \
+  --region <region> --profile <profile>
+
+aws ssm start-session \
+  --target <instance-id> \
+  --region <region> --profile <profile>
+
+aws ssm start-session \
+  --target <instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}' \
+  --region <region> --profile <profile>
+```
+
+## 1. Select and record the exact bundle
+
+Never copy artifact names, tags, or image overrides from another release. Start
+with the Keygen release or exact Kajiya workflow run selected for this install
+and record:
+
+- release/run identifier, attempt, source prefix, and publication inventory;
+- immutable Kajiya, Deploy, Core, Containers, and extension source commits;
+- every object name, size, and SHA-256;
+- runtime, resource profile, OSD size, Helm timeout, and compatibility flags;
+- every product tag and the complete `KAMIWAZA_IMAGE_OVERRIDES` map;
+- extension helper names and hashes; and
+- the release's required verification gates.
+
+Download `release_origination.md` first. Its `## Artifacts` section is the
+authoritative hash list for source artifacts and its repository section records
+provenance. It is **not** by itself the full launcher contract: settings such as
+the complete image-override map can come from the exact Kajiya run. If the
+publisher cannot supply both provenance and the complete install contract, stop
+instead of guessing from a previous release.
+
+Modern bundle roles normally include:
+
+- `release_origination.md`;
+- one `kamiwaza-prod-*.el9.x86_64.rpm`;
+- one or more `kamiwaza-helm.<number>.tar` wrap chunks;
+- `kamiwaza-helm.sha256`, `kamiwaza-helm.asc`, and the signing public key;
+- optionally, one extension bundle plus its `.sha256`; and
+- for files split by the distribution service, `.part-NNN` files, per-part
+  sidecars, and a `.parts.json` assembly manifest.
+
+The number and names are release-specific. Export the exact package inventory
+from Keygen or the build handoff into `artifacts.tsv`, with tab-separated
+filename, byte count, and SHA-256 columns. Include the generated part manifests,
+parts, and part sidecars when present. Keep this inventory with the installation
+record.
+
+## 2. Download, transfer, and verify artifacts
+
+On the connected staging machine, use the selected package URL and the exact
+inventory. The example below is deliberately parameterized; `<release>` is the
+immutable selected release or run tag, not a version copied from this page.
+
+```bash
+read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
+export KEYGEN_TOKEN
+export RELEASE="<release>"
+export PACKAGE_KEY="<exact-package-key-from-the-selected-release>"
+export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@${PACKAGE_KEY}/${RELEASE}"
+export ARTIFACT_DIR="${PWD}/kamiwaza-offline-${RELEASE}"
+
+install -d -m 0755 "${ARTIFACT_DIR}"
+cp /secure/path/artifacts.tsv "${ARTIFACT_DIR}/artifacts.tsv"
+cd "${ARTIFACT_DIR}"
+
+while IFS=$'\t' read -r file expected_size expected_sha; do
+  [[ -n "${file}" && "${file}" != \#* ]] || continue
+  [[ "${file}" != */* && "${file}" != .* ]]
+  [[ "${expected_size}" =~ ^[0-9]+$ ]]
+  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
+
+  if [[ -f "${file}" ]] &&
+     [[ "$(stat -c %s "${file}")" = "${expected_size}" ]] &&
+     printf '%s  %s\n' "${expected_sha}" "${file}" | sha256sum -c - >/dev/null; then
+    printf 'already verified: %s\n' "${file}"
+    continue
+  fi
+  rm -f "${file}"
+
+  if [[ -f "${file}.partial" ]] &&
+     [[ "$(stat -c %s "${file}.partial")" = "${expected_size}" ]] &&
+     printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c - >/dev/null; then
+    mv "${file}.partial" "${file}"
+    continue
+  fi
+  if [[ -f "${file}.partial" ]] &&
+     (($(stat -c %s "${file}.partial") >= expected_size)); then
+    rm -f "${file}.partial"
+  fi
+
   curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
     -H "Authorization: License ${KEYGEN_TOKEN}" \
-    -o "$file" \
+    -o "${file}.partial" \
     "${BASE}/${file}"
-done
 
-# Verify part checksums
-for checksum in \
-  kamiwaza-helm.00.tar.part-*.sha256 \
-  "${EXT_BUNDLE}".part-*.sha256
-do
-  sha256sum -c "${checksum}"
-done
+  if [[ "$(stat -c %s "${file}.partial")" != "${expected_size}" ]] ||
+     ! printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c -; then
+    rm -f "${file}.partial"
+    printf 'download verification failed: %s\n' "${file}" >&2
+    exit 1
+  fi
+  mv "${file}.partial" "${file}"
+done < artifacts.tsv
 
-# Recombine split parts and verify the full-artifact checksums
-cat kamiwaza-helm.00.tar.part-{000..002} > kamiwaza-helm.00.tar
-cat "${EXT_BUNDLE}".part-{000..003} > "${EXT_BUNDLE}"
-ln -sf kamiwaza-helm.00.tar kamiwaza-helm.tar
-sha256sum -c kamiwaza-helm.sha256
-sha256sum -c "${EXT_BUNDLE}.sha256"
+unset KEYGEN_TOKEN
 ```
 
-The `release_origination.md` artifact records the exact build provenance and image tags for this bundle. Refer to it if any of the version tags below differ from what shipped in your release.
+Do not put license tokens in command logs, shell history, or the installation
+record. A cloud-to-cloud relay may be faster than a local upload, but use a
+managed identity or short-lived prefix-scoped credential and verify again on
+the final target. S3 ETags are not SHA-256 integrity checks.
 
-> If a download stalls, rerun the block — `curl --continue-at -` resumes partial files. If you downloaded on a separate connected machine, transfer the entire `/opt/kamiwaza/prereqs` directory to the same path on the target host before continuing.
+### Reassemble distribution parts
 
-## Step 2: Install Prerequisites
-
-Install the prerequisites RPM and run the bootstrap script, which installs the container runtime, cluster tooling, and Ansible from the embedded artifacts:
+Each `.parts.json` records the original filename/hash and the ordered part
+inventory. Reassemble from that manifest instead of hardcoding part counts:
 
 ```bash
-cd /opt/kamiwaza/prereqs
+shopt -s nullglob
+for manifest in *.parts.json; do
+  output="$(jq -r '.source.filename' "${manifest}")"
+  expected_size="$(jq -r '.source.size' "${manifest}")"
+  expected_sha="$(jq -r '.source.sha256' "${manifest}")"
 
-sudo dnf install -y perl
-sudo rpm -Uvh --replacepkgs ./kamiwaza-prod-*.x86_64.rpm
+  : > "${output}.assembling"
+  while IFS=$'\t' read -r part part_sha; do
+    printf '%s  %s\n' "${part_sha}" "${part}" | sha256sum -c -
+    cat "${part}" >> "${output}.assembling"
+  done < <(jq -r '.parts[] | [.filename, .sha256] | @tsv' "${manifest}")
+
+  test "$(stat -c %s "${output}.assembling")" = "${expected_size}"
+  printf '%s  %s\n' "${expected_sha}" "${output}.assembling" | sha256sum -c -
+  mv "${output}.assembling" "${output}"
+done
+```
+
+### Verify source artifacts and the logical wrap
+
+Verify every artifact recorded in `release_origination.md`:
+
+```bash
+awk '
+  $0 == "## Artifacts" { in_artifacts=1; next }
+  in_artifacts && /^## / { exit }
+  in_artifacts && /^- / {
+    name=$2; sub(/:$/, "", name); print name, $3
+  }
+' release_origination.md |
+while read -r file expected; do
+  test -f "${file}"
+  printf '%s  %s\n' "${expected}" "${file}" | sha256sum -c -
+done
+```
+
+`kamiwaza-helm.sha256` names the **logical concatenated wrap**, which might not
+exist as a physical file. Hash the bytewise concatenation of all numbered wrap
+chunks in natural numeric order. Creating a similarly named symlink does not
+verify this contract.
+
+```bash
+mapfile -d '' WRAP_CHUNKS < <(
+  find . -maxdepth 1 -type f -regextype posix-extended \
+    -regex './kamiwaza-helm\.[0-9]+\.tar' -print0 | sort -z -V
+)
+((${#WRAP_CHUNKS[@]} > 0))
+
+expected="$(awk 'NR==1 {print $1}' kamiwaza-helm.sha256)"
+actual="$(cat "${WRAP_CHUNKS[@]}" | sha256sum | awk '{print $1}')"
+test "${actual}" = "${expected}"
+printf 'logical wrap checksum: OK (%s chunks)\n' "${#WRAP_CHUNKS[@]}"
+```
+
+Verify the detached signature over the checksum file. Confirm the signer
+fingerprint through an independent trusted channel; a key delivered in the same
+directory proves bundle consistency, not independently anchored provenance.
+
+```bash
+export GNUPGHOME="$(mktemp -d)"
+chmod 0700 "${GNUPGHOME}"
+gpg --batch --import ./kamiwaza-tools-rpm.pub.gpg
+gpg --batch --verify ./kamiwaza-helm.asc ./kamiwaza-helm.sha256
+gpg --batch --with-colons --fingerprint
+rm -rf "${GNUPGHOME}"
+unset GNUPGHOME
+```
+
+Transfer the entire verified directory to the target, then repeat the hash,
+logical-wrap, and signature checks there. Perform the rest of this guide only
+from that final target copy.
+
+## 3. Install and verify embedded prerequisites
+
+Move the verified artifacts into the fixed prerequisite path, install the exact
+RPM, and run its packaged bootstrap noninteractively:
+
+```bash
+export ARTIFACT_DIR="/var/tmp/kamiwaza-offline/<release-or-run>"
+
+sudo install -d -m 0755 /opt/kamiwaza/prereqs
+sudo cp "${ARTIFACT_DIR}"/kamiwaza-prod-*.el9.x86_64.rpm \
+  "${ARTIFACT_DIR}"/kamiwaza-helm.*.tar \
+  "${ARTIFACT_DIR}"/kamiwaza-helm.sha256 \
+  "${ARTIFACT_DIR}"/kamiwaza-helm.asc \
+  "${ARTIFACT_DIR}"/kamiwaza-tools-rpm.pub.gpg \
+  /opt/kamiwaza/prereqs/
+
+sudo rpm -Uvh --replacepkgs /opt/kamiwaza/prereqs/kamiwaza-prod-*.el9.x86_64.rpm
 sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
+  --yes \
   --embedded-root /opt/kamiwaza/prereqs \
   --os rhel
-
-if [[ -x /usr/local/bin/kubectl ]]; then
-  sudo ln -sfn /usr/local/bin/kubectl /usr/bin/kubectl
-fi
 ```
 
-Verify the tools are present:
+If this exact packaged bootstrap does not support `--yes`, use its documented
+noninteractive option. Do not pipe repeated `yes` or press Enter to drive a
+long unattended install.
+
+The install runs as root, so verify tools using root's actual environment:
 
 ```bash
-export HELM_PLUGINS="/usr/local/share/helm/plugins"
+sudo env \
+  HOME=/root \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  HELM_PLUGINS=/usr/local/share/helm/plugins \
+  bash -euo pipefail -c '
+    ansible-playbook --version | head -n1
+    podman --version
+    kubectl version --client
+    helm version --short
+    helmfile --version
+    helm dt version
+  '
+```
 
-checks=(
-  "ansible::ansible-playbook --version | head -n1"
-  "podman::podman --version"
-  "kubectl::kubectl version --client"
-  "helm::helm version --short"
-  "helmfile::helmfile --version"
-  "helm diff::helm dt version"
+Do not repair a missing embedded tool by silently installing an arbitrary
+internet version. Reconcile the selected RPM/bootstrap contract first.
+
+## 4. Pre-stage the extension bundle (optional)
+
+Skip this section when the selected bundle has no extension archive. Pre-stage
+loads the bundled catalog files and writes offline catalog values needed by the
+core install. It does **not** load all images or import the live catalog.
+
+Copy the verified extension archive and sidecar into `/opt/kamiwaza/prereqs`.
+Derive and validate its single top-level directory, then record the exact final
+bundle root. Do not rediscover it later with `find | head`; stale extractions
+can coexist after a retry.
+
+```bash
+export RUN_ID="<release-or-run>"
+export EXT_BUNDLE="<exact-extension-filename-from-inventory>"
+export EXTRACT_DIR="/var/lib/kajiya-reports/extensions-${RUN_ID}"
+export ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
+export HELPER_DIR="/var/tmp/kamiwaza-extension-helper-${RUN_ID}"
+
+sudo cp "${ARTIFACT_DIR}/${EXT_BUNDLE}" \
+  "${ARTIFACT_DIR}/${EXT_BUNDLE}.sha256" \
+  /opt/kamiwaza/prereqs/
+
+mapfile -t BUNDLE_TOP_LEVELS < <(
+  tar -tzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" |
+    awk -F/ 'NF {print $1}' | sort -u
 )
+test "${#BUNDLE_TOP_LEVELS[@]}" -eq 1
+export BUNDLE_DIR_NAME="${BUNDLE_TOP_LEVELS[0]}"
 
-for check in "${checks[@]}"; do
-  label="${check%%::*}"; command="${check#*::}"
-  if output="$(bash -o pipefail -c "${command}" 2>&1)"; then
-    result=GOOD
-  else
-    result=BAD
-  fi
-  output="$(printf '%s' "${output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
-  printf '[%-4s] %s: %s\n' "${result}" "${label}" "${output:-no output}"
-done
-```
-
-If verification reports a missing tool, install it from the OS package manager and re-verify:
-
-```bash
-sudo dnf install -y ansible-core podman kubectl
-```
-
-## Step 3: Create the Overrides File
-
-Create the cluster overrides file with your domain. This is also where you add optional deployment customizations.
-
-```bash
-sudo install -d -m 0755 /opt/kamiwaza/cluster/values
-sudo tee /opt/kamiwaza/cluster/values/overrides.yaml > /dev/null <<'EOF'
-global:
-  domain: <domain>
-EOF
-```
-
-> Advanced deployments (for example, external S3-backed workroom storage or a classification banner) add further keys under `global:` and `core:` in this file. Those are optional and not required for a standard install.
-
-## Step 4: Pre-Extract the Extension Bundle
-
-Stage the extension bundle before installing the platform:
-
-```bash
-cd /opt/kamiwaza/prereqs
-
-EXT_BUNDLE="$(ls -1 kamiwaza-extensions-bundle-*.tar.gz | head -1)"
-rm -rf /tmp/kamiwaza-ext-extract
-mkdir -p /tmp/kamiwaza-ext-extract
-tar -xzf "$EXT_BUNDLE" -C /tmp/kamiwaza-ext-extract
-
-sudo /tmp/kamiwaza-ext-extract/kamiwaza-extensions-bundle-*/scripts/install-extensions-bundle.sh \
+sudo install -d -m 0755 "${HELPER_DIR}"
+sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}"
+sudo bash "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh" \
   --bundle "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" \
   --sha256-file "/opt/kamiwaza/prereqs/${EXT_BUNDLE}.sha256" \
-  --extract-dir /var/lib/kajiya-reports/extensions-bundle-preinstall \
+  --extract-dir "${EXTRACT_DIR}" \
   --skip-images \
   --skip-catalog
+
+export BUNDLE_ROOT="${EXTRACT_DIR}/${BUNDLE_DIR_NAME}"
+sudo test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
+sudo install -d -m 0700 "$(dirname "${ROOT_RECORD}")"
+printf '%s\n' "${BUNDLE_ROOT}" | sudo tee "${ROOT_RECORD}" >/dev/null
+sudo chmod 0600 "${ROOT_RECORD}"
 ```
 
-## Step 5: Install Kamiwaza
+When helpers are supplied separately from the archive, use only the exact
+Kajiya commit recorded by the selected run and verify each helper SHA-256 before
+execution.
 
-> **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
-> [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)
-> before invoking `install-prod.sh`. The runbook requires the exact 1.2.0
-> candidate and its `release_origination.md`; the 1.0.1 values below are not
-> upgrade inputs for 1.2.0.
+## 5. Prepare a durable core launcher
 
-Set the image tags for the bundle and run the offline installer. The tag and image-override values below match the published 1.0.1 bundle; if `release_origination.md` lists different values for your build, use those instead.
+The selected immutable run must supply a complete, non-secret install contract.
+Record it as JSON so values containing spaces cannot become shell syntax. Fill
+every value from the selected run, including the complete infrastructure and
+inference image map:
+
+```json
+{
+  "KAMIWAZA_VERSION": "<exact>",
+  "KAMIWAZA_IMAGE_TAG": "<exact>",
+  "KAMIWAZA_K8S_RUNTIME": "k0s-podman",
+  "KAMIWAZA_ROOK_OSD_IMAGE_SIZE": "<exact>",
+  "KAMIWAZA_RESOURCE_PROFILE": "<exact>",
+  "HELMFILE_EXTRA_SET": "<exact, including spaces>",
+  "KAMIWAZA_HELM_TIMEOUT": "<exact>",
+  "KAMIWAZA_OFFLINE_APP_IMAGE_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_CORE_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_FRONTEND_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG": "<exact>",
+  "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG": "<exact>",
+  "KAMIWAZA_IMAGE_OVERRIDES": "<exact comma-separated map>"
+}
+```
+
+Validate that the document contains only the expected string keys, then install
+it root-owned:
 
 ```bash
-export DOMAIN="<domain>"
-export ADMIN_PASSWORD="<admin-password>"
+CONTRACT_SOURCE=/secure/path/kamiwaza-install-contract.json
+jq -e '
+  type == "object" and
+  (keys | sort) == ([
+    "HELMFILE_EXTRA_SET",
+    "KAMIWAZA_HELM_TIMEOUT",
+    "KAMIWAZA_IMAGE_OVERRIDES",
+    "KAMIWAZA_IMAGE_TAG",
+    "KAMIWAZA_K8S_RUNTIME",
+    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
+    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
+    "KAMIWAZA_OFFLINE_CORE_TAG",
+    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
+    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
+    "KAMIWAZA_RESOURCE_PROFILE",
+    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
+    "KAMIWAZA_VERSION"
+  ] | sort) and
+  all(.[]; type == "string")
+' "${CONTRACT_SOURCE}"
+sudo install -o root -g root -m 0600 \
+  "${CONTRACT_SOURCE}" /run/kamiwaza-install-contract.json
+```
 
-export APP_TAG="release-1.0.1"
-export FRONTEND_TAG="${APP_TAG}"
-export CONTAINERS_TAG="release-1.0.1"
-export EXTENSION_OPERATOR_TAG="release-1.0.1"
+Use the exact release contract even when several values happen to share a tag.
+Do not synthesize missing values from the release number.
+`KAMIWAZA_K8S_RUNTIME` must be `k0s-podman` for this guide. If the selected
+contract names another runtime, stop and use that runtime's runbook.
 
-export KAMIWAZA_VERSION="${APP_TAG}"
-export KAMIWAZA_IMAGE_TAG="${APP_TAG}"
-export KAMIWAZA_K8S_RUNTIME="k0s-podman"
-export KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G
-export KAMIWAZA_RESOURCE_PROFILE=small
-export HELMFILE_EXTRA_SET="--set global.security.allowInsecureImages=true"
+### Password limitation
 
-export KAMIWAZA_OFFLINE_APP_IMAGE_TAG="${APP_TAG}"
-export KAMIWAZA_OFFLINE_CORE_TAG="${APP_TAG}"
-export KAMIWAZA_OFFLINE_FRONTEND_TAG="${FRONTEND_TAG}"
-export KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG="${APP_TAG}"
-export KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG="${CONTAINERS_TAG}"
-export KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG="${CONTAINERS_TAG}"
+The current vendor installer accepts the initial admin password through
+`--admin-password`. Although the runner below keeps it out of the saved
+launcher, unit environment, and journal, the installer expands it into child
+process arguments. A privileged user can observe it during the install.
 
-export KAMIWAZA_IMAGE_OVERRIDES="keycloak=${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,traefik=v3.6.20-kz.1,chainguard-base=${CONTAINERS_TAG},kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=${CONTAINERS_TAG},datahub-frontend=${CONTAINERS_TAG},datahub-upgrade=${CONTAINERS_TAG},datahub-postgres-setup=${CONTAINERS_TAG},vram-plugin=${APP_TAG},opensearch=v2.19.5,extension-operator=${EXTENSION_OPERATOR_TAG}"
+Proceed only if that temporary privileged-argv exposure is acceptable. Do not
+run full-command-line diagnostics such as `ps auxww` during installation. If
+your security policy requires file-descriptor, file, or standard-input secret
+transport end to end, stop until the installer provides that interface.
 
-sudo -E /opt/kamiwaza/scripts/install-prod.sh \
+Read the password without echoing it and create a transient root-only file:
+
+```bash
+read -rsp 'Initial Kamiwaza admin password: ' ADMIN_PASSWORD; printf '\n'
+printf '%s' "${ADMIN_PASSWORD}" | sudo tee /run/kamiwaza-admin-password >/dev/null
+unset ADMIN_PASSWORD
+sudo chmod 0600 /run/kamiwaza-admin-password
+```
+
+Create `/run/kamiwaza-offline-install.sh` as root, mode 0700:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME=/root
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export HELM_PLUGINS=/usr/local/share/helm/plugins
+export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+
+CONTRACT=/run/kamiwaza-install-contract.json
+PASSWORD_FILE=/run/kamiwaza-admin-password
+STATUS_FILE=/run/kamiwaza-offline-install.rc
+
+finish() {
+  rc=$?
+  rm -f "${PASSWORD_FILE}"
+  printf '%s\n' "${rc}" >"${STATUS_FILE}"
+}
+trap finish EXIT
+
+test -s "${CONTRACT}"
+test -s "${PASSWORD_FILE}"
+test -f /opt/kamiwaza/prereqs/kamiwaza-helm.sha256
+test -f /opt/kamiwaza/prereqs/kamiwaza-helm.asc
+test -f /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg
+
+CONTRACT_KEYS=(
+  KAMIWAZA_VERSION
+  KAMIWAZA_IMAGE_TAG
+  KAMIWAZA_K8S_RUNTIME
+  KAMIWAZA_ROOK_OSD_IMAGE_SIZE
+  KAMIWAZA_RESOURCE_PROFILE
+  HELMFILE_EXTRA_SET
+  KAMIWAZA_HELM_TIMEOUT
+  KAMIWAZA_OFFLINE_APP_IMAGE_TAG
+  KAMIWAZA_OFFLINE_CORE_TAG
+  KAMIWAZA_OFFLINE_FRONTEND_TAG
+  KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG
+  KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG
+  KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG
+  KAMIWAZA_IMAGE_OVERRIDES
+)
+for name in "${CONTRACT_KEYS[@]}"; do
+  printf -v "${name}" '%s' "$(jq -er --arg name "${name}" '.[$name] | strings' "${CONTRACT}")"
+  export "${name}"
+done
+
+ADMIN_PASSWORD="$(<"${PASSWORD_FILE}")"
+/opt/kamiwaza/scripts/install-prod.sh \
   --offline \
-  --domain "${DOMAIN}" \
+  --skip-prereq-bootstrap \
+  --domain '<domain>' \
   --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
   --wrap-pubkey /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg \
-  -e helm_timeout=12m \
+  -e "helm_timeout=${KAMIWAZA_HELM_TIMEOUT}" \
   -y
+unset ADMIN_PASSWORD
 ```
 
-## Step 6: Finish Extension Installation
+Replace `<domain>`, then validate and protect the launcher:
 
-Make sure `${DOMAIN}` resolves from the install host, then install the extensions from the pre-staged bundle:
+```bash
+sudo bash -n /run/kamiwaza-offline-install.sh
+sudo chmod 0700 /run/kamiwaza-offline-install.sh
+sudo rm -f /run/kamiwaza-offline-install.rc
+```
+
+## 6. Launch through SSM without tying the install to the shell
+
+An SSM interactive shell can time out while a healthy installation is still
+running. Launch each attempt as a distinct transient systemd unit:
+
+```bash
+export ATTEMPT=1
+sudo systemd-run \
+  --no-block \
+  --unit="kamiwaza-offline-install-attempt${ATTEMPT}" \
+  --property=KillMode=process \
+  --property=Delegate=yes \
+  --property=TimeoutStartSec=infinity \
+  /bin/bash /run/kamiwaza-offline-install.sh
+```
+
+Immediately record the unit name and these watch commands:
+
+```bash
+sudo journalctl -fu "kamiwaza-offline-install-attempt${ATTEMPT}.service"
+
+sudo systemctl show "kamiwaza-offline-install-attempt${ATTEMPT}.service" \
+  -p ActiveState -p SubState -p Result -p ExecMainStatus
+```
+
+Journal activity—or quietness—is not a completion signal. Because
+`KillMode=process` and `Delegate=yes` allow runtime children to survive the
+launcher, a stopped unit also does not prove all children stopped after an
+error. Declare the core launcher successful only when all of these agree:
+
+- `Result=success` and `ExecMainStatus=0`;
+- `/run/kamiwaza-offline-install.rc` contains `0`;
+- the final Ansible recap has `failed=0` and `unreachable=0`; and
+- the independent workload checks in the next section pass.
+
+`systemd-run` is preferred on RHEL because it preserves an authoritative exit
+status. If systemd transient units are unavailable, the launcher can be
+detached with `nohup`:
+
+```bash
+sudo nohup /bin/bash /run/kamiwaza-offline-install.sh \
+  </dev/null >/var/log/kamiwaza-offline-install.log 2>&1 &
+```
+
+In that fallback, require the runner's `.rc` file plus the final recap and all
+independent health gates; the background PID disappearing is not success.
+
+## 7. Verify the core installation
+
+The `k0s-podman` topology is nested:
+
+```text
+RHEL host -> Podman-contained k0s node -> Kubernetes pods
+```
+
+Host processes and Kubernetes workloads do not share one network namespace.
+Use the k0s admin kubeconfig and the node IP reported by Kubernetes. If an EC2
+instance role is intentionally available to workloads, the instance metadata
+response hop limit must support this nested path; explicit S3 credentials
+remain supported when ambient identity is not desired.
+
+Run:
 
 ```bash
 export DOMAIN="<domain>"
-export ADMIN_PASSWORD="<admin-password>"
+export KUBECONFIG=/var/lib/k0s/pki/admin.conf
 
-# Add a hosts-file entry if the domain does not already resolve locally
-if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
-  NODE_IP="$(sudo kubectl get nodes -o wide --no-headers | awk 'NR==1 {print $6}')"
-  echo "${NODE_IP:-127.0.0.1} ${DOMAIN}" | sudo tee -a /etc/hosts
-fi
+sudo systemctl show "kamiwaza-offline-install-attempt${ATTEMPT}.service" \
+  -p Result -p ExecMainStatus -p ActiveState
+sudo kubectl get nodes -o wide
+sudo kubectl get pods -A
+sudo helm list -A
 
-BUNDLE_ROOT="$(sudo find /var/lib/kajiya-reports/extensions-bundle-preinstall \
-  -maxdepth 1 -type d -name 'kamiwaza-extensions-bundle-*' | head -1)"
-
-test -n "${BUNDLE_ROOT}" || { echo "No pre-extracted extension bundle found"; exit 1; }
-
-printf '%s\n' "${ADMIN_PASSWORD}" | sudo "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
-  --bundle-root "${BUNDLE_ROOT}" \
-  --container-cli podman \
-  --sudo-mode always \
-  --api-url "https://${DOMAIN}/api" \
-  --username admin \
-  --password-stdin
+NODE_IP="$(sudo kubectl get nodes -o wide --no-headers | awk 'NR==1 {print $6}')"
+curl -k --resolve "${DOMAIN}:443:${NODE_IP}" \
+  -o /dev/null -w 'HTTP %{http_code}\n' \
+  "https://${DOMAIN}/api/auth/health"
 ```
 
-## Step 7: Verify the Installation
+An unauthenticated endpoint can return 401 or 403 while routing is healthy, so
+that curl is only a reachability check. Also verify login and an authenticated
+API request, deployed Helm releases, expected local-registry manifests, and
+the live pod `imageID` digests against the selected release contract. Health
+without expected digest evidence proves function, not artifact provenance.
+
+The domain must resolve both from the install host and from the operator's
+browser. Add one exact, reviewed `/etc/hosts` entry only when DNS is not ready;
+do not append duplicates on every retry.
+
+For SSM port forwarding, map local port 8443 to target port 443, add
+`127.0.0.1 <domain>` to the operator workstation, and browse to
+`https://<domain>:8443`. Preserve `:8443` after authentication redirects.
+
+## 8. Fully load bundled extensions (optional)
+
+Core success does not finish a bundle that contains extensions. Run the full
+load in a **separate** detached unit after the authenticated API is ready. Reuse
+the exact root recorded during pre-stage; do not extract another copy without a
+specific reason.
+
+Create `/run/kamiwaza-offline-extensions.sh` as root, mode 0700:
 
 ```bash
-sudo kubectl get pods -A
-sudo kubectl get kamiwazaextensions -A
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME=/root
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export HELM_PLUGINS=/usr/local/share/helm/plugins
+export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+
+DOMAIN='<domain>'
+ROOT_RECORD='/var/lib/kajiya-reports/offline-install/<release-or-run>/bundle-root'
+BUNDLE_ROOT="$(<"${ROOT_RECORD}")"
+
+test -d "${BUNDLE_ROOT}"
+test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
+
+# Do not persist the seeded credential in a second file. Feed it to the helper
+# on stdin; see the argv limitation immediately below.
+ADMIN_PASSWORD="$(
+  kubectl -n kamiwaza get secret kamiwaza-user-admin \
+    -o jsonpath='{.data.password}' | base64 -d
+)"
+
+printf '%s\n' "${ADMIN_PASSWORD}" |
+  "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
+    --bundle-root "${BUNDLE_ROOT}" \
+    --container-cli podman \
+    --sudo-mode always \
+    --api-url "https://${DOMAIN}/api" \
+    --username admin \
+    --password-stdin
+unset ADMIN_PASSWORD
 ```
 
-All pods should be `Running`, `Ready`, or `Completed`. On a fresh install `kubectl get kamiwazaextensions -A` reports `No resources found` — the extension templates are cataloged but none is deployed until you launch one, so this is expected. Then log in at `https://<domain>/login` with `admin` and the password you set. The installer serves the site with a self-signed certificate by default, so your browser will show a security warning on first access — continue past it to reach the login page.
+The current bundle helper accepts `--password-stdin`, but its catalog-import
+subprocess can still expand that value into a child command's arguments. This
+has the same temporary privileged-process visibility limitation as the core
+installer. Do not capture full process argument lists during this phase.
 
-## Troubleshooting
+Launch and monitor it like the core phase:
 
-- **Output appears stalled during `bootstrap-prereqs.sh` or `install-prod.sh`.** The `dnf`/`rpm` output can appear to hang while these scripts run. This is not a prompt waiting for input; if output appears stalled, press Enter several times until it resumes.
-- **Disk pressure or staging failures.** Confirm `/`, `/tmp`, and `/var/lib` each have enough free space before installing (see [Prerequisites](#prerequisites)).
+```bash
+sudo bash -n /run/kamiwaza-offline-extensions.sh
+sudo chmod 0700 /run/kamiwaza-offline-extensions.sh
 
-## Next Steps
+export EXT_ATTEMPT=1
+sudo systemd-run \
+  --no-block \
+  --unit="kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}" \
+  --property=KillMode=process \
+  --property=Delegate=yes \
+  --property=TimeoutStartSec=infinity \
+  /bin/bash /run/kamiwaza-offline-extensions.sh
 
-- [Quickstart](../quickstart.md) — confirm the service is running and take your first steps.
+sudo journalctl -fu "kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}.service"
+sudo systemctl show "kamiwaza-offline-extensions-attempt${EXT_ATTEMPT}.service" \
+  -p ActiveState -p SubState -p Result -p ExecMainStatus
+```
+
+Require unit success, all expected local-registry manifests, healthy workloads,
+and exact stored and visible catalog counts for the selected immutable bundle.
+Stored and visible counts can differ when product posture intentionally hides a
+template; verify both instead of assuming that an absent UI card means import
+failed.
+
+The release handoff must provide the exact commands and expected digest/count
+files for these assertions. Run its hash-verified authenticated resource gate
+and diagnostics from the recorded Kajiya commit. If that executable gate or its
+expected values are absent, the operator cannot make a release-provenance claim;
+obtain them from the publisher instead of substituting dated counts from this
+page.
+
+Do not blindly rerun only the catalog importer after success. Existing hidden
+templates can be invisible to its list call and then cause a duplicate-create
+HTTP 400.
+
+## 9. Run the release deploy gate (release parity)
+
+For release/nightly parity, use the exact hash-verified
+`smoke-extension-deploy.sh` and any additional guard scripts from the selected
+Kajiya commit. Store them in the session's root-only helper directory. The
+currently selected 1.2.0 gate deploys `kaizen`, but the selected release
+contract controls the exact template. The gate waits for readiness, proves that
+relocation left no external image references, and removes it through the
+supported API path. A raw `kubectl apply` bypasses that behavior and is not an
+equivalent test.
+
+Create `/run/kamiwaza-offline-extension-gate.sh` as root, mode 0700, replacing
+the placeholders with the recorded helper path and domain:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME=/root
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export HELM_PLUGINS=/usr/local/share/helm/plugins
+export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+
+DOMAIN='<domain>'
+GATE_SCRIPT='/var/lib/kajiya-reports/offline-install/<release-or-run>/helpers/smoke-extension-deploy.sh'
+GATE_TEMPLATE='<exact-gate-template-from-selected-release>'
+GATE_WAIT_TIMEOUT='<exact-gate-timeout-from-selected-release>'
+
+test -x "${GATE_SCRIPT}"
+ADMIN_PASSWORD="$(
+  kubectl -n kamiwaza get secret kamiwaza-user-admin \
+    -o jsonpath='{.data.password}' | base64 -d
+)"
+
+printf '%s\n' "${ADMIN_PASSWORD}" |
+  bash "${GATE_SCRIPT}" \
+    --api-url "https://${DOMAIN}/api" \
+    --username admin \
+    --password-stdin \
+    --template-name "${GATE_TEMPLATE}" \
+    --wait-timeout "${GATE_WAIT_TIMEOUT}"
+unset ADMIN_PASSWORD
+```
+
+Launch and gate it independently:
+
+```bash
+sudo bash -n /run/kamiwaza-offline-extension-gate.sh
+sudo chmod 0700 /run/kamiwaza-offline-extension-gate.sh
+
+export GATE_ATTEMPT=1
+sudo systemd-run \
+  --no-block \
+  --unit="kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}" \
+  --property=KillMode=process \
+  --property=Delegate=yes \
+  --property=TimeoutStartSec=infinity \
+  /bin/bash /run/kamiwaza-offline-extension-gate.sh
+
+sudo journalctl -fu \
+  "kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}.service"
+sudo systemctl show \
+  "kamiwaza-offline-extension-gate-attempt${GATE_ATTEMPT}.service" \
+  -p ActiveState -p SubState -p Result -p ExecMainStatus
+```
+
+Require `Result=success` and `ExecMainStatus=0`. Also run any Konnectivity or
+authenticated resource gate named by the selected release contract. These
+scripts are release inputs: record their source commit and SHA-256 rather than
+downloading `develop` at install time. The temporary child-argv limitation
+described in the extension-load phase also applies to this helper.
+
+SDK tests, UAT data seeding, DNS publication, and A/B promotion are separate
+demo or publication phases. They are not required to call the base platform or
+extension bundle installed.
+
+## Reruns, recovery, and diagnostics
+
+- Download and part assembly are safely repeatable after removing only a failed
+  `.assembling` file. Verify final-target SHA-256 again after every transfer.
+- `rpm --replacepkgs` is intentional. A core installer rerun is **not** a
+  generic reset: inspect the existing unit, Ansible recap, cluster, registry,
+  and surviving child processes first.
+- Use monotonically named attempt units. Never overwrite the evidence from a
+  failed attempt before its cause is understood.
+- Reuse a verified pre-extracted extension root. Do not select among stale
+  directories with an unordered search.
+- Never delete clusters, PVCs, registry volumes, or an instance as a default
+  retry. Destructive recovery requires a separate backup and rollback decision.
+- Do not treat repeated red `HEAD`/manifest-not-found lines from a local
+  registry as fatal by color alone. Determine whether the importer is probing
+  before upload, then use the unit result and final manifest/digest gates.
+
+Useful focused diagnostics:
+
+```bash
+sudo systemctl show <unit>.service \
+  -p ActiveState -p SubState -p Result -p ExecMainStatus
+sudo journalctl -u <unit>.service -o cat
+sudo kubectl get nodes -o wide
+sudo kubectl get pods -A -o wide
+sudo kubectl get events -A --sort-by=.lastTimestamp
+sudo helm list -A
+sudo podman ps -a
+df -hT / /tmp /var/lib
+```
+
+Keep secrets and full process argument lists out of diagnostic captures. If a
+password appears in output, treat it as exposed and rotate it through a
+supported path after the installation is stable.
+
+## Next steps
+
+- [Quickstart](../quickstart.md) — verify the user-facing platform.
 - [Uninstalling Kamiwaza](uninstall.md).


### PR DESCRIPTION
## Summary
Replace the stale 1.0.1 offline recipe with a release-provenance-driven, SSM-safe RHEL operator runbook for release/1.2.0.

## Type
- [ ] Feature - New functionality
- [ ] Bug Fix - Corrects existing behavior
- [ ] Refactor - Code improvement without behavior change
- [x] Documentation - Docs only
- [ ] Test - Test coverage improvement
- [ ] Chore - Dependencies, config, CI/CD

## Change Flags
- [ ] API change - Endpoints added, modified, or removed
- [ ] Configuration change - New or modified config parameters
- [ ] Requirements change - Dependencies added, updated, or removed
- [ ] Schema change - Database or Pydantic model changes

## Breaking Changes
- [x] None - Fully backward compatible
- [ ] API contract - Existing clients may need updates
- [ ] Database schema - Migration required before/after deploy
- [ ] Configuration format - Existing config files need updating
- [ ] Internal interface - Other services/modules need coordinated updates

## Motivation
The release branch still documented hard-coded 1.0.1 artifacts, tags, split counts, and image overrides. It also ran the long core install in the foreground, confused extension pre-stage with a full bundle load, rediscovered stale extraction roots nondeterministically, and omitted operational constraints proven by the release/1.2.0 two-node offline installation.

## Source
- [x] Issue/Ticket: [ENG-10370](https://linear.app/kamiwaza/issue/ENG-10370/docs-make-the-release120-rhel-offline-install-runbook-provenance)
- [ ] Spec/Design Doc: N/A
- [x] Conversation/Discussion: two-node release/1.2.0 offline/Tomo/UDL installation aftermath
- [ ] Self-identified: N/A

## Alternatives Considered
Updating the old example to another dated release was rejected because the artifact inventory, tags, override map, helper scripts, and parity gates vary by immutable build. Treating the EKS recipe as the RHEL authority was rejected because this guide installs standalone k0s-podman.

## Changes Made
- derive artifacts, tags, image overrides, runtime settings, helpers, and gates from `release_origination.md` plus the exact Kajiya run contract;
- validate SSM inventory, Run Command, interactive shell, and port forwarding before installation;
- add resumable hash-gated downloads, manifest-driven part assembly, logical sorted-wrap checksum, and signature verification;
- document RHEL/hostname/backing-filesystem constraints and the nested k0s-podman topology;
- make root `HOME`, `PATH`, `HELM_PLUGINS`, and `KUBECONFIG` deterministic;
- use strict JSON for the non-secret install contract so values containing spaces cannot become shell syntax;
- launch core, extension load, and deploy/remove parity gate as separate detached systemd units with authoritative completion checks;
- record and reuse one exact extension bundle root and distinguish pre-stage, full image/catalog load, and release parity;
- keep the core admin password out of argv and environment via a root-only Ansible extra-vars file, and disclose the remaining extension-helper privileged-argv limitation;
- document safe rerun, idempotency, diagnosis, and destructive-recovery boundaries.

## Technical Notes
The guide deliberately does not freeze an image map or extension count. A selected release handoff must provide the complete immutable values and executable provenance gates; missing evidence is a stop condition.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No tests needed - explain below

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local Node 22 | `npm test` | PASS: 54/54 |
| Local Node 22 | `npm run build:docs` | PASS; only pre-existing broken-anchor/blog/OpenAPI warnings |
| Local | `git diff --check` | PASS |
| Local Node 22 | `npm run build:docs:offline` | Baseline blocker: untouched `sdk_versioned_sidebars/version-0.13.0-sidebars.json` references missing `api-reference`; regular production docs build passes |

## Test Coverage
Docusaurus parsed and built the rewritten page and validated its links. Independent docs review covered shell safety, resumable downloads, SSM detachment, secret handling, extension lifecycle, and provenance consistency; no Critical or High findings remain.

## Review Focus
Please verify that the required release handoff inputs are available to customers and that the selected 1.2.0 gate/helper names match the promoted artifact contract.

## Deployment Notes
Merge to `release/1.2.0`. Then open an audited forward-port to `develop`; the two branches have diverged, so do not assume a blind cherry-pick is conflict-free.

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [x] Verified on live system (see Verification above)
- [x] Documentation updated (if applicable)

## Vibe Check
The runbook now describes the installation that actually succeeded, without freezing the accidents of one run.

