### PR TITLE
ENG-10327: document the collector's --output-dir form and its retry message

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -1189,10 +1189,29 @@ namespace state and events, and Helm status/history. For a pod that never
 started, the pod description and events are authoritative; an empty container
 log alone is not evidence that migration code ran.
 
-`--namespace` and `--release` are also accepted as flags; the positional
-`DIR [NAMESPACE] [RELEASE]` form above is still supported. Every option also
-takes the `--option=value` form, which is how to pass a value that legitimately
-begins with `-`. Both binary options need a path to an executable regular file
+`--output-dir`, `--namespace`, and `--release` are also accepted as flags; the
+positional `DIR [NAMESPACE] [RELEASE]` form above is still supported. Every
+option also takes the `--option=value` form, which is how to pass a value that
+legitimately begins with `-`.
+
+`--output-dir` **replaces** the positional evidence directory rather than
+supplementing it, so passing both is a usage error naming the two forms.
+Accepting both would make the first positional mean `DIR` in one invocation
+and `NAMESPACE` in another, and a mistyped flag would then write the bundle to
+a directory named for the namespace. Either of these is complete, and mixing
+them is not:
+
+```bash
+"${COLLECTOR_COMMAND}" "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+
+"${COLLECTOR_COMMAND}" --output-dir "${COLLECTOR_DIR}" \
+  --namespace "${NAMESPACE}" --release "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+```
+
+The block above uses the positional form; either is fine, but do not edit it
+into a mixture of the two. Both binary options need a path to an executable regular file
 containing a `/`: a bare name would be re-resolved through `PATH` when the
 command runs, so the binary that executes need not be the one that was checked.
 A *non-empty* value that fails either test is not a usage error — the tool is
@@ -1275,6 +1294,12 @@ resolved but had every one of its invocations fail — and `manifest.txt` names
 what is missing. `COLLECTOR_RC` of 2 is a usage error or an evidence path that
 is unsafe to write (an existing non-empty directory, a symbolic link, or a
 non-directory); correct the argument or choose a new `COLLECTOR_DIR` and re-run.
+Each of those refusals names the offending path, and the non-empty case also
+prints the `rm -rf` that clears it — so a first attempt that failed does not
+leave you deducing why the corrected one is also refused. Removing the
+directory is only ever right for a bundle you do not intend to keep; when the
+first attempt collected anything worth preserving, choose a new
+`COLLECTOR_DIR` instead.
 Exit zero means both collectors produced evidence — it does **not** mean every
 command succeeded. A run where some commands failed (a Job that does not exist,
 an RBAC denial on one resource) still exits zero, prints

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -1210,10 +1210,12 @@ them is not:
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
 ```
 
-The block above uses the positional form; either is fine, but do not edit it
-into a mixture of the two. Both binary options need a path to an executable regular file
-containing a `/`: a bare name would be re-resolved through `PATH` when the
-command runs, so the binary that executes need not be the one that was checked.
+The canonical invocation block earlier in this section uses the positional
+form. Either form is fine there, but do not edit it into a mixture of the two.
+
+Both binary options need a path to an executable regular file containing a
+`/`: a bare name would be re-resolved through `PATH` when the command runs, so
+the binary that executes need not be the one that was checked.
 A *non-empty* value that fails either test is not a usage error — the tool is
 simply unresolvable, and the run ends at exit 1 with `result=not-collected`
 naming it. An *empty* value is rejected as a usage error, at exit 2, before the
@@ -1294,12 +1296,25 @@ resolved but had every one of its invocations fail — and `manifest.txt` names
 what is missing. `COLLECTOR_RC` of 2 is a usage error or an evidence path that
 is unsafe to write (an existing non-empty directory, a symbolic link, or a
 non-directory); correct the argument or choose a new `COLLECTOR_DIR` and re-run.
-Each of those refusals names the offending path, and the non-empty case also
-prints the `rm -rf` that clears it — so a first attempt that failed does not
-leave you deducing why the corrected one is also refused. Removing the
-directory is only ever right for a bundle you do not intend to keep; when the
-first attempt collected anything worth preserving, choose a new
-`COLLECTOR_DIR` instead.
+Each of those *path* refusals names the offending path, so a first attempt
+that failed does not leave you deducing why the corrected one is also refused.
+
+Whether the refusal also prints a `rm -rf` depends on what is in the way, and
+the asymmetry is deliberate. When the directory holds an earlier run of this
+collector — identified by its own `manifest.txt` — the refusal prints the
+exact removal command, quoted so a path containing spaces pastes as-is. A
+non-empty directory the collector did **not** write is never offered for
+removal, however plainly it is in the way; point `COLLECTOR_DIR` at a new path
+instead. That case is the mistyped `--output-dir`, and the collector is
+documented to run as root, so it will not hand a root shell a deletion
+command for data it did not create — **and neither should you.** Move or
+remove such a directory yourself, deliberately and outside this runbook, or
+leave it alone.
+
+Even for a bundle the collector did write, removal is only right when you do
+not intend to keep it. If the first attempt collected anything worth
+preserving — in particular anything you hand-copied into its `installer/`
+directory — choose a new `COLLECTOR_DIR` rather than clearing the old one.
 Exit zero means both collectors produced evidence — it does **not** mean every
 command succeeded. A run where some commands failed (a Job that does not exist,
 an RBAC denial on one resource) still exits zero, prints

--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -1210,8 +1210,11 @@ them is not:
   --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
 ```
 
-The canonical invocation block earlier in this section uses the positional
-form. Either form is fine there, but do not edit it into a mixture of the two.
+Those two lines show argument shape only. Run the canonical block earlier in
+this section rather than either of them on its own — a bare collector line
+loses the `COLLECTOR_RC` capture and the ownership reclaim that block performs.
+That block uses the positional form; either form is fine there, but do not edit
+it into a mixture of the two.
 
 Both binary options need a path to an executable regular file containing a
 `/`: a bare name would be re-resolved through `PATH` when the command runs, so
@@ -1305,16 +1308,17 @@ collector — identified by its own `manifest.txt` — the refusal prints the
 exact removal command, quoted so a path containing spaces pastes as-is. A
 non-empty directory the collector did **not** write is never offered for
 removal, however plainly it is in the way; point `COLLECTOR_DIR` at a new path
-instead. That case is the mistyped `--output-dir`, and the collector is
-documented to run as root, so it will not hand a root shell a deletion
+instead. That case is the mistyped `--output-dir`, and the collector may be
+run under `sudo`, so it will not hand a root shell a deletion
 command for data it did not create — **and neither should you.** Move or
 remove such a directory yourself, deliberately and outside this runbook, or
 leave it alone.
 
 Even for a bundle the collector did write, removal is only right when you do
 not intend to keep it. If the first attempt collected anything worth
-preserving — in particular anything you hand-copied into its `installer/`
-directory — choose a new `COLLECTOR_DIR` rather than clearing the old one.
+preserving — in particular anything you hand-copied into the collector
+bundle's own `${COLLECTOR_DIR}/installer` — choose a new `COLLECTOR_DIR` rather than clearing the old one.
+
 Exit zero means both collectors produced evidence — it does **not** mean every
 command succeeded. A run where some commands failed (a Job that does not exist,
 an RBAC denial on one resource) still exits zero, prints


### PR DESCRIPTION
## Summary

Follows [kamiwaza-internal/deploy#787](https://github.com/kamiwaza-internal/deploy/pull/787) (merged to `develop`, backported to `release/1.2.0` as #807), which changed the collector this runbook drives.

Two corrections, both to keep the runbook true of the shipped tool:

**`--output-dir` now exists.** The runbook's "also accepted as flags" list named only `--namespace` and `--release`. The collector now also accepts `--output-dir`, which **replaces** the positional evidence directory rather than supplementing it — passing both is a usage error. That asymmetry is worth stating rather than leaving for an operator to discover, because accepting a mix would make the first positional mean `DIR` in one invocation and `NAMESPACE` in another, and a mistyped flag would then write the bundle to a directory named for the namespace. Both complete forms are shown, with a note not to edit the existing block into a mixture of the two.

**The exit-2 refusals now name the offending path,** and the non-empty-directory case prints the `rm -rf` that clears it — so a first attempt that failed no longer leaves the operator deducing why the corrected attempt is also refused. Recorded with the caveat that removal is only ever right for a bundle you do not intend to keep; when the first attempt collected something worth preserving, choose a new `COLLECTOR_DIR` instead.

Not documented here deliberately: the collector only offers that `rm -rf` for a directory carrying its own manifest, never for an arbitrary path. That is a safety property of the tool rather than an instruction to the operator, and spelling it out would invite treating the message as a decision procedure. The runbook's existing guidance — point `COLLECTOR_DIR` at a path no earlier run has touched — is unchanged and still the primary advice.

The invocation block itself is untouched: it already used the positional form, which remains supported and is what the 1.2.0 RPM ships.

## Test plan

Prose-only change to `docs/docs/runbooks/core-database-upgrade-1.2.md`; no code, config, or build inputs touched. Every behavior described was verified against the collector at the merged head — the flag forms, the mixing error, the named-path refusals, and the printed removal command — as recorded in deploy#787.

Refs ENG-10327

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.13.1"
generated_at: "2026-08-18T18:50:09Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 205
linear_issues: [ENG-10327]
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "3/3 green on this head (Docs tests and production build, Validate package locks, check-linear-issue). Gate re-verifies."
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "Retired in pr-verify 0.13.x (ENG-10304); confirmed only test references remain in the installed 0.13.1. Gate re-verifies against GitHub's clock."
  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-10327 in the branch name, every commit subject, and the PR body's Refs line."
  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff is one Markdown file. No console.log / debugger / pdb.set_trace / breakpoint added."
  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review APPROVE (Risk Low, 0 Critical) posted SHA-pinned on head 67e8d94413b2b2ba31fb46a5520fdf26eb195a42."
  - kind: pr-evidence
    required: false
    status: skipped
    detail: "No cluster smoke applies: documentation-only change to a Docusaurus page, no runtime surface."
manual_steps:
  - id: ms-1
    description: "Verify every behavioral claim in the new prose against the shipped collector, scripts/collect-core-db-init-diagnostics.sh in kamiwaza-internal/deploy (merged as #787 / ca6413c7 on develop, #807 / cbd4867d on release/1.2.0)."
    observation: "All verified by reading the script: --output-dir/--namespace/--release accepted with the positional DIR [NAMESPACE] [RELEASE] retained; --output-dir=* form present; --output-dir plus any positional hits fail_usage naming both forms; all three path refusals (symbolic link, not a directory, must be new or empty) print the offending path; is_prior_bundle() gates the rm -rf on a manifest.txt whose first line is collector=collect-core-db-init-diagnostics.sh, printed with %q; the non-collector branch deliberately prints no removal command."
    status: pass
  - id: ms-2
    description: "Check the subtle claim that the collector bundle contains an installer/ directory an operator may have hand-copied into."
    observation: "Confirmed at script lines 302-303 and 313-314: mkdir -p creates cluster, db-init, helm AND installer (the mkdir wraps across two lines, so a single-line grep misses it), and the collector writes installer/README.txt saying \"Copy the installer exit status and reviewed installer log here separately.\" My first pass read only the wrapped line and wrongly concluded the claim was false; re-checking the occurrences corrected it."
    status: pass
  - id: ms-3
    description: "Confirm the claim that the canonical invocation block earlier in the section uses the positional form."
    observation: "True: lines 1114-1116 of the runbook invoke \"${COLLECTOR_COMMAND}\" \"${COLLECTOR_DIR}\" \"${NAMESPACE}\" \"${RELEASE}\" with --kubectl-bin/--helm-bin appended."
    status: pass
  - id: ms-4
    description: "Build the docs site from the branch worktree."
    observation: "npm ci at repo root and docs/, then npm run build in docs/: exit 0, \"[SUCCESS] Generated static files in build.\" Grepping the full build output for core-database-upgrade and runbook returns zero matches, so no warning names this page."
    status: pass
  - id: ms-5
    description: "Confirm the round-2 paragraph-break fix actually renders as two paragraphs, rather than trusting the source."
    observation: "Parsed the built HTML at docs/build/runbooks/core-database-upgrade-1.2.html: the markup between \"Even for a bundle the collector did write\" and \"Exit zero means\" is [</p>, <p>], i.e. they render as separate paragraph elements. Before the fix they were one."
    status: pass
verdict:
  decision: approve
  rationale: "Documentation half of ENG-10327; the code half already shipped in deploy #787 (develop) and #807 (release/1.2.0). Every behavioral claim in the prose was verified against the shipped collector script rather than taken from the PR description. Build green, no warning names this page, CI 3/3. Two review rounds: round 1 APPROVE at Low risk with one High and three Mediums, all four fixed in 67e8d94; round 2 APPROVE at 10/10 accuracy with no Critical or High. Scope limit: the collector was not executed against a live cluster from here, so the manual steps below cover documentation-versus-source verification and the docs build, not a live collection run."
gate:
  approval_submitted: false
```

</details>


<!-- pr-verify-end -->