### PR TITLE
ENG-10473: document Traefik removal and migration

### DIFF
--- a/docs/docs/architecture/architecture.md
+++ b/docs/docs/architecture/architecture.md
@@ -12,7 +12,7 @@ graph TD
     Gardens[App Garden and Tool Shed]
     Workrooms[Workrooms]
     Logs[Logger and Audit Services]
-    Ingress[Traefik or Istio]
+    Ingress[Istio or Greymatter]
     IdP[Identity Provider]
     DataStores[Postgres, etcd, DataHub, Object Storage]
     Compute[Kubernetes and Ray]
@@ -34,4 +34,6 @@ graph TD
     Logs --> DataStores
 ```
 
-**Ingress Note:** The platform ingress uses Traefik for default `Kind` deployments and Istio (1.28+) for `k0s` runtime deployments (introduced via Kamiwaza Mesh M1).
+**Ingress note:** Istio is the default platform ingress. Greymatter is the
+supported alternative on EKS, AKS, and OpenShift/ROSA deployments that already
+run Greymatter Core outside the Kamiwaza chart.

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -25,7 +25,7 @@ flowchart BT
     end
 
     subgraph Platform[Shared Platform Layer]
-        Routing[Traefik or Istio Ingress]
+        Routing[Istio or Greymatter Ingress]
         IdP[Identity Provider]
         Postgres[(Postgres or SQLite in lite mode)]
         Etcd[(etcd)]
@@ -69,7 +69,7 @@ This layer contains the platform APIs and business logic.
 
 This layer provides the shared services the platform depends on.
 
-- **Traefik or Istio** for ingress and routing, depending on environment
+- **Istio or Greymatter** for ingress and routing, depending on environment
 - **Identity provider integration** for authenticated deployments
 - **Postgres** as the standard persistent database in auth-enabled deployments
 - **SQLite** as a reduced-scope database option in lite mode
@@ -93,7 +93,7 @@ This layer runs the workloads that power the platform.
 | Backend | Python, FastAPI, Ray |
 | Frontend | React |
 | Data and metadata | Postgres, SQLite in lite mode, etcd, DataHub |
-| Routing and ingress | Traefik, optional Istio |
+| Routing and ingress | Istio, or Greymatter on supported external-mesh deployments |
 | Deployment | Kubernetes, Helm |
 
 ## Design Principles

--- a/docs/docs/federal/cac-overview.md
+++ b/docs/docs/federal/cac-overview.md
@@ -40,7 +40,7 @@ Set the equivalent deployment values, ConfigMap entries, or environment variable
 
 ## Ingress/Header Expectations
 
-The ingress (e.g., Traefik) must:
+The configured ingress provider must:
 
 - Request/require client certificates on auth routes.
 - Forward the sanitized client cert PEM in X-Forwarded-Tls-Client-Cert (required).

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -211,7 +211,7 @@ export KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG="${APP_TAG}"
 export KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG="${CONTAINERS_TAG}"
 export KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG="${CONTAINERS_TAG}"
 
-export KAMIWAZA_IMAGE_OVERRIDES="keycloak=${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,chainguard-base=${CONTAINERS_TAG},kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=${CONTAINERS_TAG},datahub-frontend=${CONTAINERS_TAG},datahub-upgrade=${CONTAINERS_TAG},datahub-postgres-setup=${CONTAINERS_TAG},vram-plugin=${APP_TAG},opensearch=v2.19.5,extension-operator=${EXTENSION_OPERATOR_TAG}"
+export KAMIWAZA_IMAGE_OVERRIDES="keycloak=${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,chainguard-base=${CONTAINERS_TAG},traefik=v3.6.20-kz.1,kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=${CONTAINERS_TAG},datahub-frontend=${CONTAINERS_TAG},datahub-upgrade=${CONTAINERS_TAG},datahub-postgres-setup=${CONTAINERS_TAG},vram-plugin=${APP_TAG},opensearch=v2.19.5,extension-operator=${EXTENSION_OPERATOR_TAG}"
 
 sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -211,7 +211,7 @@ export KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG="${APP_TAG}"
 export KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG="${CONTAINERS_TAG}"
 export KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG="${CONTAINERS_TAG}"
 
-export KAMIWAZA_IMAGE_OVERRIDES="keycloak=${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,traefik=v3.6.20-kz.1,chainguard-base=${CONTAINERS_TAG},kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=${CONTAINERS_TAG},datahub-frontend=${CONTAINERS_TAG},datahub-upgrade=${CONTAINERS_TAG},datahub-postgres-setup=${CONTAINERS_TAG},vram-plugin=${APP_TAG},opensearch=v2.19.5,extension-operator=${EXTENSION_OPERATOR_TAG}"
+export KAMIWAZA_IMAGE_OVERRIDES="keycloak=${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,chainguard-base=${CONTAINERS_TAG},kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=${CONTAINERS_TAG},datahub-frontend=${CONTAINERS_TAG},datahub-upgrade=${CONTAINERS_TAG},datahub-postgres-setup=${CONTAINERS_TAG},vram-plugin=${APP_TAG},opensearch=v2.19.5,extension-operator=${EXTENSION_OPERATOR_TAG}"
 
 sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \

--- a/docs/docs/routing-modes.md
+++ b/docs/docs/routing-modes.md
@@ -43,7 +43,9 @@ For customer-facing documentation, integrations, bookmarks, and extension guidan
 - treat the platform HTTPS origin as the stable entrypoint
 - avoid documenting port-specific runtime URLs as the preferred access pattern
 
-This aligns with the current Kubernetes deployment model, which uses Istio for `k0s` runtime deployments (Kamiwaza Mesh M1) and Traefik for `Kind` deployments, along with the runtime routing API.
+This aligns with the current Kubernetes deployment model. Istio is the default
+routing provider. Greymatter is the supported alternative on deployments where
+Greymatter Core is installed and managed outside the Kamiwaza chart.
 
 *(Note: In local development deployments using the `k0s-podman` or `k0s-lima` Mesh M1 configuration, TLS is handled via a self-signed placeholder certificate. For production, see [Production Certificate Swaps](#production-certificate-swaps).)*
 
@@ -80,7 +82,7 @@ The deployment charts seed routing with path-based defaults similar to:
   "routing": {
     "mode": "path",
     "model_routing_method": "path",
-    "base_host": "https://<internal-traefik-url-or-origin>",
+    "base_host": "https://<platform-origin>",
     "service_prefixes": {
       "api": "/api",
       "frontend": "/",
@@ -110,6 +112,26 @@ Best practice:
 Some code paths still retain compatibility for legacy port-based or dual-mode routing behavior. That exists for backward compatibility, internal transitions, or older integrations.
 
 For public docs and new integrations, path-based routing should be considered the supported standard unless your deployment team has explicitly documented a different compatibility requirement.
+
+## Migrating from Traefik
+
+Traefik routing support was removed after the platform moved to Istio and
+Envoy `ext_authz`. An installation that explicitly sets
+`KAMIWAZA_ROUTING_PROVIDER=traefik` now fails during startup with migration
+guidance instead of silently selecting another provider.
+
+To migrate an older installation:
+
+1. Remove the `traefik` provider override and any `network.traefik` values.
+2. Set `KAMIWAZA_ROUTING_PROVIDER=istio`, or select `greymatter` only when the
+   cluster has a supported Greymatter Core installation.
+3. Replace custom Traefik `IngressRoute` and `Middleware` resources with the
+   route mechanism owned by the selected provider.
+4. Render the deployment values and verify the canonical runtime paths before
+   upgrading production traffic.
+
+Do not translate Traefik ForwardAuth headers into application configuration.
+Both surviving providers carry the authoritative request path in `:path`.
 
 ## App and Tool URL Behavior
 

--- a/docs/docs/routing-modes.md
+++ b/docs/docs/routing-modes.md
@@ -123,8 +123,11 @@ guidance instead of silently selecting another provider.
 To migrate an older installation:
 
 1. Remove the `traefik` provider override and any `network.traefik` values.
-2. Set `KAMIWAZA_ROUTING_PROVIDER=istio`, or select `greymatter` only when the
-   cluster has a supported Greymatter Core installation.
+2. For chart installs, set `global.mesh.provider=istio` and
+   `global.ingress.provider=istio`. Select `greymatter` in both keys only when
+   the cluster has a supported Greymatter Core installation. The chart renders
+   `KAMIWAZA_ROUTING_PROVIDER`; set that environment variable directly only
+   for a non-chart process launch.
 3. Replace custom Traefik `IngressRoute` and `Middleware` resources with the
    route mechanism owned by the selected provider.
 4. Render the deployment values and verify the canonical runtime paths before

--- a/docs/extensions/developer-guide.md
+++ b/docs/extensions/developer-guide.md
@@ -345,10 +345,10 @@ What you do is wire up the provided libraries to read user identity from platfor
 The platform flow:
 
 ```
-Browser → Traefik → ForwardAuth (validates session) → Your Extension
-                                                       ↓
-                                         Request includes identity headers
-                                         set by the platform auth service
+Browser → supported ingress → platform authorization → Your Extension
+                                                          ↓
+                                            Request includes identity headers
+                                            set by the platform auth service
 ```
 
 Your extension receives identity headers on every authenticated request. The exact headers are part of the **platform runtime contract** (see below).


### PR DESCRIPTION
## Summary

- state Istio as the default routing provider and Greymatter as the supported alternative
- add an explicit migration path for legacy Traefik overrides and custom resources
- remove Traefik from architecture, CAC, and offline-install guidance

## Verification

- `npm run build:docs` (pass; existing broken-anchor warnings remain)
- docs style check found no new style issue; the only error in the edited routing guide is the proper product name `Let’s Encrypt`

## Delivery

Part of the Remove Traefik Remnants project DoD-6. Merge with the coordinated deploy documentation PR after core provider removal lands.