### PR TITLE
ENG-10473: refresh public OpenAPI after Traefik removal

### DIFF
--- a/docs/api/openapi-metadata.json
+++ b/docs/api/openapi-metadata.json
@@ -1,6 +1,6 @@
 {
-  "syncedAt": "2026-08-18T15:53:37.115Z",
-  "sourceRemote": "git@github.com:kamiwaza-internal/kamiwaza.git",
+  "syncedAt": "2026-08-18T16:02:41.900Z",
+  "sourceRemote": "https://github.com/kamiwaza-internal/kamiwaza",
   "sourceBranch": "develop",
   "sourceCommit": "32fbf6acb4965aaa7328926555469bfe3095e247",
   "originalApiVersion": "0.1.0",

--- a/docs/api/openapi-metadata.json
+++ b/docs/api/openapi-metadata.json
@@ -1,5 +1,5 @@
 {
-  "syncedAt": "2026-08-18T16:02:41.900Z",
+  "syncedAt": "2026-08-18T16:12:15.112Z",
   "sourceRemote": "https://github.com/kamiwaza-internal/kamiwaza",
   "sourceBranch": "develop",
   "sourceCommit": "32fbf6acb4965aaa7328926555469bfe3095e247",

--- a/docs/api/openapi-metadata.json
+++ b/docs/api/openapi-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-07-27T12:28:54.489Z",
-  "sourceRemote": "https://github.com/kamiwaza-internal/kamiwaza",
+  "syncedAt": "2026-08-18T15:53:37.115Z",
+  "sourceRemote": "git@github.com:kamiwaza-internal/kamiwaza.git",
   "sourceBranch": "develop",
-  "sourceCommit": "08b8525d892aae066b6d11f10170945ba5ab0f71",
+  "sourceCommit": "32fbf6acb4965aaa7328926555469bfe3095e247",
   "originalApiVersion": "0.1.0",
-  "patchedApiVersion": "1.0.1",
-  "endpoints": 394,
-  "schemas": 498
+  "patchedApiVersion": "1.0.2",
+  "endpoints": 438,
+  "schemas": 578
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Kamiwaza REST API",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "servers": [
     {
@@ -46,7 +46,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/whoami": {
@@ -85,7 +97,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/token": {
@@ -243,7 +267,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/callback": {
@@ -386,7 +422,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/idp/{alias}": {
@@ -462,7 +510,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -536,7 +596,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -600,7 +672,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/idp/providers": {
@@ -657,7 +741,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/idp/public/providers": {
@@ -743,7 +839,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/resolve/{identifier}": {
@@ -812,7 +920,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/me/password-capability": {
@@ -871,7 +991,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/me/password": {
@@ -940,7 +1072,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/{user_id}": {
@@ -1009,7 +1153,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -1086,7 +1242,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -1153,7 +1321,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/local": {
@@ -1222,7 +1402,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/users/{user_id}/password": {
@@ -1301,7 +1493,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/saml/metadata": {
@@ -1403,7 +1607,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_post_get",
+        "operationId": "saml_sls_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1422,7 +1626,7 @@
           "auth"
         ],
         "summary": "Saml Sls",
-        "operationId": "saml_sls_auth_saml_sls_post_post",
+        "operationId": "saml_sls_post",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1612,7 +1816,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/runtime-launches/exchange": {
@@ -1680,7 +1896,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/runtime-refresh": {
@@ -1738,7 +1966,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/": {
@@ -1862,7 +2102,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/pats": {
@@ -2005,7 +2257,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -2061,7 +2325,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/pats/{jti}": {
@@ -2126,7 +2402,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/mint": {
@@ -3051,7 +3339,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/tuples/diff": {
@@ -3118,7 +3418,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/tuples/revoke": {
@@ -3187,7 +3499,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/tuples/export": {
@@ -3276,7 +3600,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/audit/decisions/export": {
@@ -3422,7 +3758,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/sessions/{session_id}": {
@@ -3483,7 +3831,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/sessions/purge": {
@@ -3552,7 +3912,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/tuples": {
@@ -3613,7 +3985,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -3672,7 +4056,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/tuples/object": {
@@ -3733,7 +4129,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/check": {
@@ -3801,7 +4209,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/auth/forward/validate/{path}": {
@@ -5240,7 +5660,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/cleanup_stale_deployments": {
@@ -5283,7 +5715,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/{model_id}/deployment_info": {
@@ -5338,7 +5782,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/{model_id}": {
@@ -5391,7 +5847,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -5456,7 +5924,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/": {
@@ -5521,7 +6001,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -5576,7 +6068,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/{model_file_id}": {
@@ -5631,7 +6135,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -5682,7 +6198,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/search/": {
@@ -5733,7 +6261,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/": {
@@ -5778,7 +6318,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -5827,7 +6379,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/search/": {
@@ -5882,7 +6446,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/download/": {
@@ -5935,7 +6511,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_configs/": {
@@ -6000,7 +6588,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -6055,7 +6655,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/{model_id}/configs": {
@@ -6122,7 +6734,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_configs/{model_config_id}": {
@@ -6175,7 +6799,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -6228,7 +6864,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -6301,7 +6949,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/{model_id}/memory_usage": {
@@ -6355,7 +7015,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/{model_file_id}/memory_usage": {
@@ -6409,7 +7081,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/download_status/": {
@@ -6460,7 +7144,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/{model_file_id}/download": {
@@ -6513,7 +7209,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/model_files/downloads/cancel_all": {
@@ -6575,7 +7283,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/download_and_deploy": {
@@ -6628,7 +7348,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/models/deploy_after_download/{model_key}": {
@@ -6708,7 +7440,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/guide/": {
@@ -6753,7 +7497,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/guide/import": {
@@ -6808,7 +7564,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/guide/refresh": {
@@ -6851,7 +7619,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/config/routing": {
@@ -6892,7 +7672,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -6941,7 +7733,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/config/runtime-posture": {
@@ -6982,7 +7786,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/start": {
@@ -7048,7 +7864,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/routes/greymatter": {
@@ -7133,7 +7961,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/routes/greymatter/{route_id}": {
@@ -7218,7 +8058,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/status": {
@@ -7257,7 +8109,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/estimate_model_vram": {
@@ -7310,7 +8174,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deploy_model": {
@@ -7370,7 +8246,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployments": {
@@ -7453,7 +8341,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployment/{deployment_id}": {
@@ -7506,7 +8406,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -7568,7 +8480,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployment/{deployment_id}/delete": {
@@ -7632,7 +8556,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployment/{deployment_id}/status": {
@@ -7686,7 +8622,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/model_instances": {
@@ -7750,7 +8698,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/model_instance/{instance_id}": {
@@ -7803,7 +8763,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/health": {
@@ -7851,7 +8823,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployment/{deployment_id}/logs": {
@@ -7904,7 +8888,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/deployment/{deployment_id}/logs/patterns": {
@@ -7957,7 +8953,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/logs/{engine_type}": {
@@ -8009,7 +9017,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/serving/external-endpoints/discover": {
@@ -8090,7 +9110,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/vectordb/": {
@@ -8153,7 +9185,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/{urn}/gate": {
@@ -8215,7 +9259,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -8265,7 +9321,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -8317,7 +9385,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/health": {
@@ -8357,7 +9437,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/": {
@@ -8411,7 +9503,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -8476,7 +9580,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/by-urn": {
@@ -8532,7 +9648,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -8596,7 +9724,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -8643,7 +9783,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/by-urn/schema": {
@@ -8699,7 +9851,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -8761,7 +9925,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}": {
@@ -8815,7 +9991,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -8877,7 +10065,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -8922,7 +10122,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}/schema": {
@@ -8976,7 +10188,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -9036,7 +10260,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}/objects": {
@@ -9100,7 +10336,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -9173,7 +10421,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}/objects/{item_id}": {
@@ -9237,7 +10497,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -9325,7 +10597,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -9403,7 +10687,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}/objects/{item_id}/content": {
@@ -9465,7 +10761,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/v2/{dataset_urn}/objects/{item_id}/purge": {
@@ -9529,7 +10837,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/datasets/{dataset_urn}": {
@@ -9583,7 +10903,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -9645,7 +10977,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -9690,7 +11034,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/by-urn": {
@@ -9784,7 +11140,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -9848,7 +11216,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -9895,7 +11275,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/by-urn/datasets": {
@@ -9959,7 +11351,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -10022,7 +11426,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/v2/{container_urn}": {
@@ -10114,7 +11530,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -10176,7 +11604,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -10221,7 +11661,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/v2/{container_urn}/datasets": {
@@ -10283,7 +11735,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/v2/{container_urn}/datasets/{dataset_urn}": {
@@ -10344,7 +11808,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/{container_urn}/datasets": {
@@ -10406,7 +11882,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/{container_urn}/datasets/{dataset_urn}": {
@@ -10467,7 +11955,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/": {
@@ -10521,7 +12021,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -10586,7 +12098,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/containers/{container_urn}": {
@@ -10678,7 +12202,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -10740,7 +12276,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -10785,7 +12333,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/secrets/": {
@@ -10869,7 +12429,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -10949,7 +12521,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/secrets/by-urn": {
@@ -11021,7 +12605,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -11068,7 +12664,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/secrets/{secret_urn}": {
@@ -11138,7 +12746,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -11183,7 +12803,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/secrets/v2/{secret_urn}": {
@@ -11253,7 +12885,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -11298,7 +12942,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/catalog/": {
@@ -11338,7 +12994,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/roles/": {
@@ -11390,7 +13058,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/roles/{role_id}": {
@@ -11444,7 +13124,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/systems/": {
@@ -11496,7 +13188,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/systems/{system_id}": {
@@ -11550,7 +13254,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/elements/": {
@@ -11602,7 +13318,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/elements/{element_id}": {
@@ -11656,7 +13384,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/templates/": {
@@ -11708,7 +13448,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/prompts/templates/{template_id}": {
@@ -11762,7 +13514,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/generate": {
@@ -11824,7 +13588,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/generate/{text}": {
@@ -11952,7 +13728,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/chunk": {
@@ -12078,7 +13866,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/batch": {
@@ -12222,7 +14022,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/providers": {
@@ -12268,7 +14080,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/embedding/health": {
@@ -12341,7 +14165,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/location/{location_id}": {
@@ -12404,7 +14240,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -12454,7 +14302,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/locations": {
@@ -12532,7 +14392,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/cluster": {
@@ -12582,7 +14454,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/cluster/{cluster_id}": {
@@ -12634,7 +14518,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/clusters": {
@@ -12712,7 +14608,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/node/{node_id}": {
@@ -12771,7 +14679,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/get_running_nodes": {
@@ -12815,7 +14735,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/nodes": {
@@ -12909,7 +14841,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/hardware": {
@@ -12959,7 +14903,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -13035,7 +14991,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/hardware/{hardware_id}": {
@@ -13087,7 +15055,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/runtime_config": {
@@ -13130,7 +15110,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/cluster_capabilities": {
@@ -13173,7 +15165,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/attach_pairing": {
@@ -13221,7 +15225,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/detach_pairing": {
@@ -13259,7 +15275,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/refresh_hardware": {
@@ -13298,7 +15326,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/get_hostname": {
@@ -13337,7 +15377,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations": {
@@ -13388,7 +15440,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -13483,7 +15547,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}": {
@@ -13536,7 +15612,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -13599,7 +15687,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -13648,7 +15748,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/users": {
@@ -13711,7 +15823,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -13760,7 +15884,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/users/{external_id}/revoke": {
@@ -13830,7 +15966,109 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/cluster/federations/{federation_id}/users/{external_id}/restore": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "Restore Federation User",
+        "description": "Re-enable a revoked brokered user without changing its tuple recipe.",
+        "operationId": "restore_federation_user_cluster_federations__federation_id__users__external_id__restore_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "federation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Federation Id"
+            }
+          },
+          {
+            "name": "external_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "External Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/pair": {
@@ -13883,7 +16121,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/preflight": {
@@ -13932,7 +16182,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/resolve-address": {
@@ -13981,7 +16243,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/diagnose": {
@@ -14032,7 +16306,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/disconnect": {
@@ -14093,7 +16379,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/federations/{federation_id}/ping": {
@@ -14144,7 +16442,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/remote/pair": {
@@ -14193,7 +16503,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/remote/ping": {
@@ -14222,7 +16544,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/remote/disconnect": {
@@ -14271,7 +16605,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/submit": {
@@ -14322,7 +16668,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/run": {
@@ -14373,7 +16731,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/": {
@@ -14444,7 +16814,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/{job_id}/status": {
@@ -14497,7 +16879,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/{job_id}/result": {
@@ -14550,7 +16944,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/{job_id}/logs": {
@@ -14603,7 +17009,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/jobs/{job_id}/cancel": {
@@ -14656,7 +17074,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/diagnose": {
@@ -14697,7 +17127,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/gates/discover": {
@@ -14748,7 +17190,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/execution-gate": {
@@ -14789,7 +17243,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -14838,7 +17304,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -14879,7 +17357,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/subjects/by-id": {
@@ -14951,7 +17441,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -15011,7 +17513,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -15091,7 +17605,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/subjects/{id_or_username}": {
@@ -15153,7 +17679,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -15203,7 +17741,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -15273,7 +17823,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/subjects/by-id/grants": {
@@ -15345,7 +17907,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -15409,7 +17983,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -15481,7 +18067,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/subjects/{id_or_username}/grants": {
@@ -15543,7 +18141,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -15597,7 +18207,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -15659,7 +18281,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/groups/": {
@@ -15703,7 +18337,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -15751,7 +18397,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/groups/{group_id}": {
@@ -15802,7 +18460,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -15860,7 +18530,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/groups/{group_id}/members": {
@@ -15914,7 +18596,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -15963,7 +18657,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/groups/{group_id}/members/{user_id}": {
@@ -16016,7 +18722,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/group-mappings": {
@@ -16066,7 +18784,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -16126,7 +18856,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/group-mappings/{mapping_id}": {
@@ -16177,7 +18919,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -16219,7 +18973,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/resources/{namespace}/grants": {
@@ -16280,7 +19046,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -16344,7 +19122,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -16437,7 +19227,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/resources/{namespace}/grant-capability": {
@@ -16499,7 +19301,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/resources/{namespace}/access": {
@@ -16593,7 +19407,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/access/resources": {
@@ -16692,7 +19518,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/policy": {
@@ -16734,7 +19572,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/gate-packages": {
@@ -16775,7 +19625,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -16824,7 +19686,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/authz/gate-packages/{name}": {
@@ -16876,7 +19750,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -16936,7 +19822,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -16979,7 +19877,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/attribute-schema/{name}": {
@@ -17041,7 +19951,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -17118,7 +20040,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/cluster/attribute-schema": {
@@ -17173,17 +20107,29 @@
             }
           }
         },
-        "x-auth-role": "viewer"
+        "x-auth-role": "viewer",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/mesh/{cluster_selector}/{path}": {
-      "get": {
+      "options": {
         "tags": [
           "mesh",
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_get",
+        "operationId": "proxy_mesh_options",
         "security": [
           {
             "BearerAuth": []
@@ -17232,7 +20178,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "head": {
         "tags": [
@@ -17240,7 +20198,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_head",
+        "operationId": "proxy_mesh_head",
         "security": [
           {
             "BearerAuth": []
@@ -17289,7 +20247,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -17297,7 +20267,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_delete",
+        "operationId": "proxy_mesh_delete",
         "security": [
           {
             "BearerAuth": []
@@ -17346,121 +20316,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
-      },
-      "put": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_put",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
-      },
-      "options": {
-        "tags": [
-          "mesh",
-          "mesh"
-        ],
-        "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_options",
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "OAuth2Login": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "cluster_selector",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cluster Selector"
-            }
-          },
-          {
-            "name": "path",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Path"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -17468,7 +20336,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_patch",
+        "operationId": "proxy_mesh_patch",
         "security": [
           {
             "BearerAuth": []
@@ -17517,7 +20385,88 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "put": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -17525,7 +20474,7 @@
           "mesh"
         ],
         "summary": "Proxy Mesh",
-        "operationId": "proxy_mesh_mesh__cluster_selector___path__get_post",
+        "operationId": "proxy_mesh_post",
         "security": [
           {
             "BearerAuth": []
@@ -17574,7 +20523,88 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "get": {
+        "tags": [
+          "mesh",
+          "mesh"
+        ],
+        "summary": "Proxy Mesh",
+        "operationId": "proxy_mesh_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "cluster_selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cluster Selector"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/activity/activities/": {
@@ -17619,7 +20649,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/ingestion/health": {
@@ -17658,7 +20700,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/ingestion/ingest/run": {
@@ -17707,7 +20761,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/ingestion/ingest/emit": {
@@ -17756,7 +20822,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/ingestion/ingest/jobs": {
@@ -17805,7 +20883,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/ingestion/ingest/status/{job_id}": {
@@ -17855,7 +20945,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/dde/connectors/": {
@@ -17987,7 +21089,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -18036,7 +21150,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/dde/connectors/{connector_id}": {
@@ -18089,7 +21215,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -18150,7 +21288,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -18201,7 +21351,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/dde/connectors/{connector_id}/trigger_ingest": {
@@ -18254,7 +21416,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/dde/documents/": {
@@ -18305,7 +21479,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -18411,7 +21597,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/dde/documents/{document_id}": {
@@ -18474,7 +21672,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/retrieval/jobs": {
@@ -18525,7 +21735,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -18591,7 +21813,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/retrieval/jobs/{job_id}/cancel": {
@@ -18645,7 +21879,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/retrieval/jobs/{job_id}": {
@@ -18698,7 +21944,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/retrieval/jobs/{job_id}/stream": {
@@ -18749,7 +22007,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs": {
@@ -18813,7 +22083,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -18881,7 +22163,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/{vectordb_id}": {
@@ -18951,7 +22245,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -19029,7 +22335,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -19101,7 +22419,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/{vectordb_id}/scale": {
@@ -19181,7 +22511,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/{vectordb_id}/insert": {
@@ -19261,7 +22603,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/insert": {
@@ -19331,7 +22685,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/{vectordb_id}/query": {
@@ -19411,7 +22777,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/vectordbs/query": {
@@ -19481,7 +22859,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies": {
@@ -19545,7 +22935,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -19623,7 +23025,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}": {
@@ -19693,7 +23107,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -19765,7 +23191,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/global-settings": {
@@ -19805,7 +23243,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -19853,7 +23303,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/omniparses": {
@@ -19917,7 +23379,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -19985,7 +23459,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/omniparses/{omniparse_id}": {
@@ -20055,7 +23541,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -20133,7 +23631,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -20205,7 +23715,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/audio-readiness": {
@@ -20303,7 +23825,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/collections/": {
@@ -20388,7 +23922,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -20458,7 +24004,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/collections/{collection_name}": {
@@ -20561,7 +24119,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -20642,7 +24212,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/": {
@@ -20714,7 +24296,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -20821,7 +24415,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/supported-types": {
@@ -20887,7 +24493,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/import-options": {
@@ -20949,7 +24567,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -21019,7 +24649,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/imports": {
@@ -21091,7 +24733,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/items": {
@@ -21153,7 +24807,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/items/rerun": {
@@ -21225,7 +24891,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/{job_id}/items": {
@@ -21297,7 +24975,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/{job_id}": {
@@ -21369,7 +25059,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -21432,7 +25134,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/{job_id}/cancel": {
@@ -21504,7 +25218,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/{job_id}/retry": {
@@ -21586,7 +25312,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/pipelines/{job_id}/rerun": {
@@ -21668,7 +25406,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/search": {
@@ -21763,7 +25513,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/search/unified": {
@@ -21848,7 +25610,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/search/simple": {
@@ -21934,7 +25708,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/search/retrieve": {
@@ -22020,7 +25806,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/search/agentic": {
@@ -22103,7 +25901,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/dataset-indexes": {
@@ -22175,7 +25985,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -22255,7 +26077,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/dataset-indexes/{binding_id}": {
@@ -22327,7 +26161,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -22399,7 +26245,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/dataset-index-jobs/{job_id}": {
@@ -22471,7 +26329,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/dataset-indexes/{binding_id}/retry": {
@@ -22543,7 +26413,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/dataset-indexes/{binding_id}/search": {
@@ -22625,7 +26507,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/readiness": {
@@ -22687,7 +26581,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/knowledge": {
@@ -22758,18 +26664,68 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
+          "413": {
+            "description": "The ontology backend rejected an over-large request.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/OntologyUpstreamErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The request failed FastAPI validation, or the ontology backend rejected its entity schema or another request-derived field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/OntologyUpstreamErrorResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RequestValidationErrorResponse"
+                    }
+                  ],
+                  "title": "Response 422 Add Knowledge Context Ontologies  Ontology Id  Knowledge Post"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "The ontology backend returned a substrate failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OntologyUpstreamErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The ontology backend timed out while ingesting knowledge.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OntologyUpstreamErrorResponse"
                 }
               }
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/entity": {
@@ -22851,7 +26807,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/workrooms/{workroom_id}/subgraph": {
@@ -22939,7 +26907,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/search": {
@@ -23021,7 +27001,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/memory": {
@@ -23103,7 +27095,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/episodes/{group_id}": {
@@ -23196,7 +27200,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/groups/{group_id}": {
@@ -23277,7 +27293,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/model-bindings": {
@@ -23340,7 +27368,19 @@
             "description": "Discovery temporarily unavailable, the operator pinned to a currently-unroutable deployment, OR the K8s extension patch failed (rollback semantics: the reconciler reverts the persisted binding so the next retry is idempotent). Carries ``Retry-After: 5``."
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/ontologies/{ontology_id}/health": {
@@ -23414,7 +27454,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/upload/": {
@@ -23518,7 +27570,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/storage/raw": {
@@ -23605,7 +27669,19 @@
             "description": "Stored raw file could not be reloaded after persistence (replica lag or scoping race; the underlying object and metadata row are committed)"
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -23756,7 +27832,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/storage/raw/{file_id}": {
@@ -23860,7 +27948,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -23973,7 +28073,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/documents/{source_urn}": {
@@ -24044,7 +28156,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/download/raw/{file_id}": {
@@ -24136,7 +28260,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/download/documents/{source_urn}": {
@@ -24207,7 +28343,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/embedding-model": {
@@ -24277,7 +28425,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -24347,7 +28507,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/context/health": {
@@ -24386,7 +28558,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/news/quadrants": {
@@ -24428,7 +28612,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/news/latest": {
@@ -24470,7 +28666,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployments/all": {
@@ -24511,7 +28719,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployments/type/{deployment_type}": {
@@ -24564,7 +28784,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployments/orphaned": {
@@ -24605,7 +28837,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployments/{deployment_type}/{deployment_id}": {
@@ -24670,7 +28914,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -24744,7 +29000,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployments/{deployment_type}/{deployment_id}/patterns": {
@@ -24809,7 +29077,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/stats": {
@@ -24850,7 +29130,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/cleanup": {
@@ -24933,7 +29225,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployment/{deployment_id}/logs": {
@@ -24986,7 +29290,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/deployment/{deployment_id}/logs/patterns": {
@@ -25039,7 +29355,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/logger/engine/{engine_type}": {
@@ -25091,7 +29419,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/config/ephemeral_forced": {
@@ -25132,7 +29472,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/deploy_app": {
@@ -25183,7 +29535,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/deployments": {
@@ -25266,7 +29630,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/deployment/{deployment_id}": {
@@ -25319,7 +29695,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -25371,7 +29759,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/deployment/{deployment_id}/purge": {
@@ -25425,7 +29825,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/sessions/heartbeat": {
@@ -25456,7 +29868,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/sessions/end": {
@@ -25507,7 +29931,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/instances": {
@@ -25571,7 +30007,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/instance/{instance_id}": {
@@ -25624,7 +30072,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/deployment/{deployment_id}/status": {
@@ -25678,7 +30138,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/app_templates": {
@@ -25728,7 +30200,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -25790,7 +30274,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/app_templates/{template_id}": {
@@ -25842,7 +30338,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -25903,7 +30411,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -25952,7 +30472,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/garden/status": {
@@ -25995,7 +30527,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/remote/sync": {
@@ -26044,7 +30588,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/app_templates/catalog/overlay/{name}": {
@@ -26107,7 +30663,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -26158,7 +30726,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/app_templates/catalog/overlay": {
@@ -26203,7 +30783,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/remote/status": {
@@ -26246,7 +30838,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/remote/apps": {
@@ -26304,7 +30908,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/garden/import": {
@@ -26343,7 +30959,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/images/status/{template_id}": {
@@ -26394,7 +31022,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/apps/images/pull/{template_id}": {
@@ -26445,7 +31085,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/deploy": {
@@ -26497,7 +31149,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/deploy-template/{template_name}": {
@@ -26560,7 +31224,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/deployments": {
@@ -26606,7 +31282,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/deployment/{deployment_id}": {
@@ -26662,7 +31350,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -26718,7 +31418,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/discover": {
@@ -26760,7 +31472,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/deployment/{deployment_id}/health": {
@@ -26816,7 +31540,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/templates/available": {
@@ -26863,7 +31599,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/templates": {
@@ -26910,7 +31658,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/tool_templates/{template_id}": {
@@ -26974,7 +31734,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -27028,7 +31800,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/garden/status": {
@@ -27072,7 +31856,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/remote/status": {
@@ -27116,7 +31912,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/remote/sync": {
@@ -27166,7 +31974,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/remote/tools": {
@@ -27225,7 +32045,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/tool/garden/import": {
@@ -27265,7 +32097,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/extensions": {
@@ -27330,7 +32174,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -27379,7 +32235,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/extensions/audits/workroom-scope": {
@@ -27438,7 +32306,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/extensions/{name}/status": {
@@ -27490,7 +32370,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/extensions/{name}": {
@@ -27542,14 +32434,26 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
           "extensions"
         ],
         "summary": "Patch Extension",
-        "description": "Partially update an extension CR (image tag, replicas, env).",
+        "description": "Partially update an extension CR's services and annotations.",
         "operationId": "patch_extension_extensions__name__patch",
         "security": [
           {
@@ -27602,7 +32506,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -27645,7 +32561,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/extensions/upgrade-all": {
@@ -27706,7 +32634,135 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/security/admin/config": {
+      "get": {
+        "tags": [
+          "security",
+          "security"
+        ],
+        "summary": "Get Admin Security Config",
+        "description": "Return complete settings to the authenticated admin editor.",
+        "operationId": "get_admin_security_config_security_admin_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecurityConfigResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "put": {
+        "tags": [
+          "security",
+          "security"
+        ],
+        "summary": "Update Security Config",
+        "description": "Persist audited consent-gate and classification-banner settings.",
+        "operationId": "update_security_config_security_admin_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecurityConfigUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecurityConfigResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/security/public/config": {
@@ -27782,6 +32838,659 @@
         "x-auth-exempt-reason": "Embeddable JS bundle (pre-login), bypasses ForwardAuth"
       }
     },
+    "/copilot/actions": {
+      "get": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "List Copilot Actions",
+        "description": "Return the server mirror after capability filtering, including seam honesty.",
+        "operationId": "list_copilot_actions_copilot_actions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActionDescriptor"
+                  },
+                  "type": "array",
+                  "title": "Response List Copilot Actions Copilot Actions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/threads": {
+      "get": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "List Threads",
+        "operationId": "list_threads_copilot_threads_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ThreadView"
+                  },
+                  "type": "array",
+                  "title": "Response List Threads Copilot Threads Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "post": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Create Thread",
+        "operationId": "create_thread_copilot_threads_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/threads/{thread_id}/runs": {
+      "get": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "List Thread Runs",
+        "operationId": "list_thread_runs_copilot_threads__thread_id__runs_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Thread Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RunView"
+                  },
+                  "title": "Response List Thread Runs Copilot Threads  Thread Id  Runs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/runs": {
+      "post": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Create Run",
+        "operationId": "create_run_copilot_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/runs/{run_id}": {
+      "get": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Get Run",
+        "operationId": "get_run_copilot_runs__run_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/runs/{run_id}/answers": {
+      "post": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Answer Run Question",
+        "operationId": "answer_run_question_copilot_runs__run_id__answers_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionAnswer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/runs/{run_id}/confirm": {
+      "post": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Confirm Run Write",
+        "operationId": "confirm_run_write_copilot_runs__run_id__confirm_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WriteConfirmation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/runs/{run_id}/cancel": {
+      "post": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Cancel Run",
+        "operationId": "cancel_run_copilot_runs__run_id__cancel_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/copilot/results/{result_id}": {
+      "get": {
+        "tags": [
+          "copilot",
+          "copilot"
+        ],
+        "summary": "Get Result",
+        "operationId": "get_result_copilot_results__result_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "result_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Result Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultHandleView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
     "/connectors/": {
       "get": {
         "tags": [
@@ -27839,7 +33548,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -27907,7 +33628,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/subscriptions": {
@@ -27977,7 +33710,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/catalog": {
@@ -28037,7 +33782,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -28105,7 +33862,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/catalog/{connector_type}": {
@@ -28174,7 +33943,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -28251,7 +34032,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -28320,7 +34113,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/register": {
@@ -28390,7 +34195,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/available": {
@@ -28450,7 +34267,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/types": {
@@ -28510,7 +34339,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}": {
@@ -28580,7 +34421,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -28658,7 +34511,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -28719,7 +34584,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/deploy": {
@@ -28789,7 +34666,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/remote/sync": {
@@ -28851,7 +34740,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/connect": {
@@ -28923,7 +34824,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/connect/poll": {
@@ -29007,7 +34920,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/connection": {
@@ -29079,7 +35004,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/disconnect": {
@@ -29142,7 +35079,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/{connector_id}/verify": {
@@ -29214,7 +35163,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/surfaces/workrooms/{workroom_id}/catalog": {
@@ -29284,7 +35245,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/surfaces/workrooms/{workroom_id}/{connector_id}/browse": {
@@ -29467,7 +35440,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/surfaces/workrooms/{workroom_id}/{connector_id}/search": {
@@ -29613,7 +35598,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/surfaces/workrooms/{workroom_id}/{connector_id}/content/{node_id}": {
@@ -29743,7 +35740,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/connectors/public/{provider}/callback": {
@@ -29869,7 +35878,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -29948,7 +35969,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/apps/{app_id}": {
@@ -30002,7 +36035,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -30064,7 +36109,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -30109,7 +36166,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/auth/google/start": {
@@ -30174,7 +36243,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/auth/google/callback": {
@@ -30258,7 +36339,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/connections/status": {
@@ -30324,7 +36417,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/connections/disconnect": {
@@ -30383,7 +36488,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/policies/": {
@@ -30435,7 +36552,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -30514,7 +36643,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/policies/{policy_id}": {
@@ -30568,7 +36709,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -30630,7 +36783,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -30675,7 +36840,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/tokens/mint": {
@@ -30728,7 +36905,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/tokens/leases/{lease_id}": {
@@ -30782,7 +36971,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -30827,7 +37028,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/tokens/connectors/{connector_id}/mint": {
@@ -30892,7 +37105,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/proxy/{provider}/{service}/{operation}/{resource_id}": {
@@ -30903,7 +37128,7 @@
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post_post",
+        "operationId": "oauth_proxy_with_resource_post",
         "parameters": [
           {
             "name": "provider",
@@ -30973,7 +37198,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
+                  "title": "Response Oauth Proxy With Resource Post"
                 }
               }
             }
@@ -30997,7 +37222,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -31006,7 +37243,7 @@
         ],
         "summary": "Proxy With Resource",
         "description": "Proxy request with a resource identifier (e.g., message_id, file_id).",
-        "operationId": "proxy_with_resource_oauth_broker_proxy__provider___service___operation___resource_id__post_get",
+        "operationId": "oauth_proxy_with_resource_get",
         "parameters": [
           {
             "name": "provider",
@@ -31076,7 +37313,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy With Resource Oauth Broker Proxy  Provider   Service   Operation   Resource Id  Post"
+                  "title": "Response Oauth Proxy With Resource Get"
                 }
               }
             }
@@ -31100,7 +37337,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/proxy/{provider}/{service}/{operation}": {
@@ -31111,7 +37360,7 @@
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post_post",
+        "operationId": "oauth_proxy_request_post",
         "parameters": [
           {
             "name": "provider",
@@ -31172,7 +37421,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
+                  "title": "Response Oauth Proxy Request Post"
                 }
               }
             }
@@ -31196,7 +37445,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -31205,7 +37466,7 @@
         ],
         "summary": "Proxy Request",
         "description": "Proxy request to an external API operation.",
-        "operationId": "proxy_request_oauth_broker_proxy__provider___service___operation__post_get",
+        "operationId": "oauth_proxy_request_get",
         "parameters": [
           {
             "name": "provider",
@@ -31266,7 +37527,7 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true,
-                  "title": "Response Proxy Request Oauth Broker Proxy  Provider   Service   Operation  Post"
+                  "title": "Response Oauth Proxy Request Get"
                 }
               }
             }
@@ -31290,7 +37551,19 @@
             "BearerAuth": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/connectors/{connector_id}/proxy": {
@@ -31355,7 +37628,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/oauth-broker/connectors/{connector_id}/identity-proxy": {
@@ -31420,7 +37705,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills/import": {
@@ -31471,7 +37768,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills": {
@@ -31610,7 +37919,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills/{skill_id}": {
@@ -31663,7 +37984,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "put": {
         "tags": [
@@ -31726,7 +38059,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -31770,7 +38115,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills/{skill_id}/export": {
@@ -31821,7 +38178,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills/{skill_id}/package": {
@@ -31872,7 +38241,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/skills/export": {
@@ -31921,7 +38302,2245 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/profile/start-preference": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Get Start Preference",
+        "operationId": "get_start_preference_profile_start_preference_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/StartPreference"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Start Preference Profile Start Preference Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "put": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Set Start Preference",
+        "operationId": "set_start_preference_profile_start_preference_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartPreferenceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartPreference"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/platform/users/invitations": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Invite Platform Users",
+        "description": "Persist bounded invitations for resolution at the invitee's first visit.",
+        "operationId": "invite_platform_users_platform_users_invitations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformInvitationCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformInvitationList"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/surface-constraints": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "List Surface Constraints",
+        "operationId": "list_surface_constraints_admin_surface_constraints_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SurfaceConstraint"
+                  },
+                  "type": "array",
+                  "title": "Response List Surface Constraints Admin Surface Constraints Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "post": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Create Surface Constraint",
+        "operationId": "create_surface_constraint_admin_surface_constraints_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SurfaceConstraintCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SurfaceConstraint"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/surface-constraints/{constraint_id}": {
+      "put": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Update Surface Constraint",
+        "operationId": "update_surface_constraint_admin_surface_constraints__constraint_id__put",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "constraint_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Constraint Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SurfaceConstraintCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SurfaceConstraint"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "delete": {
+        "tags": [
+          "platform-console",
+          "platform-surfaces"
+        ],
+        "summary": "Delete Surface Constraint",
+        "operationId": "delete_surface_constraint_admin_surface_constraints__constraint_id__delete",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "constraint_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Constraint Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/rooms/settings": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Get Room Settings",
+        "operationId": "get_room_settings_admin_rooms_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomOrgSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "put": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Update Room Settings",
+        "operationId": "update_room_settings_admin_rooms_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoomOrgSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomOrgSettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/rooms/decommission/inventory": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Get Room Inventory",
+        "operationId": "get_room_inventory_admin_rooms_decommission_inventory_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomInventory"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/rooms/decommission/plans": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Create Room Decommission Plan",
+        "operationId": "create_room_decommission_plan_admin_rooms_decommission_plans_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoomDecommissionPlanCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomDecommissionPlan"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/admin/rooms/decommission/plans/{plan_id}/confirm": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Confirm Room Decommission Plan",
+        "operationId": "confirm_room_decommission_plan_admin_rooms_decommission_plans__plan_id__confirm_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Plan Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoomDecommissionConfirm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomDecommissionPlan"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/rooms/tombstones/{workroom_id}": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "room-governance"
+        ],
+        "summary": "Get Room Tombstone",
+        "operationId": "get_room_tombstone_rooms_tombstones__workroom_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workroom_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workroom Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoomTombstone"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/operations/tray": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Get Operation Tray",
+        "operationId": "get_operation_tray_operations_tray_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrayProjection"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/operations": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "List Operations",
+        "operationId": "list_operations_operations_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "include_dismissed",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Dismissed"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OperationView"
+                  },
+                  "title": "Response List Operations Operations Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/operations/{operation_id}": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Get Operation",
+        "operationId": "get_operation_operations__operation_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "operation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Operation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/operations/{operation_id}/seen": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Mark Operation Seen",
+        "operationId": "mark_operation_seen_operations__operation_id__seen_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "operation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Operation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateChanged"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/operations/{operation_id}/dismiss": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Dismiss Operation",
+        "operationId": "dismiss_operation_operations__operation_id__dismiss_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "operation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Operation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateChanged"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "List Notifications",
+        "operationId": "list_notifications_notifications_get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "include_dismissed",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Dismissed"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationView"
+                  },
+                  "title": "Response List Notifications Notifications Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/notifications/{notification_id}": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Get Notification",
+        "operationId": "get_notification_notifications__notification_id__get",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/notifications/{notification_id}/seen": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Mark Notification Seen",
+        "operationId": "mark_notification_seen_notifications__notification_id__seen_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateChanged"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/notifications/{notification_id}/dismiss": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "operations"
+        ],
+        "summary": "Dismiss Notification",
+        "operationId": "dismiss_notification_notifications__notification_id__dismiss_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateChanged"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/remediations": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "remediations"
+        ],
+        "summary": "List Remediations",
+        "operationId": "list_remediations_remediations_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RemediationDescriptor"
+                  },
+                  "type": "array",
+                  "title": "Response List Remediations Remediations Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/remediations/{remediation_id}/preview": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "remediations"
+        ],
+        "summary": "Preview Remediation",
+        "operationId": "preview_remediation_remediations__remediation_id__preview_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "remediation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Remediation Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemediationTarget"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemediationPreview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/remediations/{remediation_id}/execute": {
+      "post": {
+        "tags": [
+          "platform-console",
+          "remediations"
+        ],
+        "summary": "Execute Remediation",
+        "operationId": "execute_remediation_remediations__remediation_id__execute_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "remediation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Remediation Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemediationExecute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationAccepted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/profile/notification-preferences": {
+      "get": {
+        "tags": [
+          "platform-console",
+          "notification-preferences"
+        ],
+        "summary": "Get Notification Preference",
+        "operationId": "get_notification_preference_profile_notification_preferences_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreference"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "put": {
+        "tags": [
+          "platform-console",
+          "notification-preferences"
+        ],
+        "summary": "Set Notification Preference",
+        "operationId": "set_notification_preference_profile_notification_preferences_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationPreferenceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreference"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/platform/readiness": {
+      "get": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Inspect Platform Readiness",
+        "description": "Return one best-effort snapshot without masking section failures.",
+        "operationId": "inspect_platform_readiness_platform_readiness_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformReadiness"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/credentials/intake": {
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Intake Credential",
+        "description": "Exchange plaintext received on a trusted call for a short-lived reference.",
+        "operationId": "intake_credential_credentials_intake_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialIntakeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialIntakeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/model-providers/connections": {
+      "get": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "List Provider Connections",
+        "operationId": "list_provider_connections_model_providers_connections_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderConnection"
+                  },
+                  "type": "array",
+                  "title": "Response List Provider Connections Model Providers Connections Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      },
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Create Provider Connection",
+        "description": "Consume a credential reference and persist an encrypted provider connection.",
+        "operationId": "create_provider_connection_model_providers_connections_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderConnectionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderConnection"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/orchestrations/connect-and-index": {
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Connect And Index",
+        "description": "Create one Context import and its durable operation record.",
+        "operationId": "connect_and_index_orchestrations_connect_and_index_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectAndIndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationAccepted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/access-requests": {
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Request Access",
+        "description": "Persist an access request and notify every concrete user grantor.",
+        "operationId": "request_access_access_requests_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessRequestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationAccepted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/access-requests/{access_request_id}/resolve": {
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Resolve Access Request",
+        "description": "Approve or deny an access request as a current resource grantor.",
+        "operationId": "resolve_access_request_access_requests__access_request_id__resolve_post",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "access_request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Access Request Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessRequestResolve"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationAccepted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/artifacts": {
+      "post": {
+        "tags": [
+          "platform-console"
+        ],
+        "summary": "Create Artifact",
+        "description": "Create a durable artifact and completed operation in one transaction.",
+        "operationId": "create_artifact_artifacts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtifactCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationAccepted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2Login": []
+          }
+        ],
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/": {
@@ -31973,7 +40592,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "get": {
         "tags": [
@@ -32027,7 +40658,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/manager/path": {
@@ -32069,7 +40712,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}": {
@@ -32123,7 +40778,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "patch": {
         "tags": [
@@ -32185,7 +40852,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -32237,7 +40916,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/members": {
@@ -32303,7 +40994,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -32365,7 +41068,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/events": {
@@ -32431,7 +41146,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/events/stream": {
@@ -32515,7 +41242,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads": {
@@ -32569,7 +41308,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -32631,7 +41382,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/messages": {
@@ -32708,7 +41471,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -32781,7 +41556,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/handoff": {
@@ -32856,7 +41643,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/claims": {
@@ -32931,7 +41730,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -32994,7 +41805,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/turns": {
@@ -33071,7 +41894,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -33144,7 +41979,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/turns/{turn_id}/complete": {
@@ -33229,7 +42076,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/threads/{thread_key}/credentials/resolve": {
@@ -33305,7 +42164,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/credentials/registrations": {
@@ -33359,7 +42230,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -33421,7 +42304,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/credentials/registrations/{registration_id}": {
@@ -33478,7 +42373,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/credentials/consents": {
@@ -33532,7 +42439,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "post": {
         "tags": [
@@ -33594,7 +42513,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/credentials/consents/{consent_id}": {
@@ -33651,7 +42582,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/role-history": {
@@ -33717,7 +42660,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/members/lookup": {
@@ -33782,7 +42737,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/members/{member_user_id}": {
@@ -33855,7 +42822,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       },
       "delete": {
         "tags": [
@@ -33928,7 +42907,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/ownership/transfer": {
@@ -33992,7 +42983,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/lifecycle/summary": {
@@ -34046,7 +43049,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/delete-preview": {
@@ -34100,7 +43115,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/archive": {
@@ -34154,7 +43181,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/restore": {
@@ -34208,7 +43247,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/export/manifest": {
@@ -34262,7 +43313,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/export": {
@@ -34314,7 +43377,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/ingestion/summary": {
@@ -34368,7 +43443,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/runtime/bootstrap": {
@@ -34422,7 +43509,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/runtime/context": {
@@ -34476,7 +43575,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/presence/stream": {
@@ -34528,7 +43639,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/sessions/heartbeat": {
@@ -34599,7 +43722,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/{workroom_id}/enter": {
@@ -34653,7 +43788,19 @@
             }
           }
         },
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/workrooms/leave": {
@@ -34712,7 +43859,19 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/admin/workrooms/": {
@@ -34795,7 +43954,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/admin/workrooms/{workroom_id}": {
@@ -34849,7 +44020,19 @@
             }
           }
         },
-        "x-auth-role": "admin"
+        "x-auth-role": "admin",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
       }
     },
     "/node/node_status": {
@@ -34915,12 +44098,293 @@
             "OAuth2Login": []
           }
         ],
-        "x-auth-role": "authenticated"
+        "x-auth-role": "authenticated",
+        "x-auth-rejected-token-indicators": {
+          "issuerPrefixes": [
+            "urn:kamiwaza:delegated-workloads:v1"
+          ],
+          "joseTypes": [
+            "kz-run-cap+jwt",
+            "kz-effect-cap+jwt"
+          ],
+          "kidPrefixes": [
+            "kz-delegated-"
+          ]
+        }
+      }
+    },
+    "/v1/delegated-workloads/capabilities": {
+      "get": {
+        "tags": [
+          "delegated-workloads"
+        ],
+        "summary": " Held Capabilities",
+        "operationId": "_held_capabilities_v1_delegated_workloads_capabilities_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/delegated-workloads/registrations/workloads/{deployment_uid}": {
+      "put": {
+        "tags": [
+          "delegated-workloads"
+        ],
+        "summary": "Partial",
+        "description": "partial(func, *args, **keywords) - new function with partial application\nof the given arguments and keywords.",
+        "operationId": "partial_v1_delegated_workloads_registrations_workloads__deployment_uid__put",
+        "parameters": [
+          {
+            "name": "deployment_uid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Deployment Uid"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrationReconcileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkloadRegistrationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v1/delegated-workloads/registrations/resources/{resource_type}/revisions/{descriptor_version}": {
+      "put": {
+        "tags": [
+          "delegated-workloads"
+        ],
+        "summary": "Partial",
+        "description": "partial(func, *args, **keywords) - new function with partial application\nof the given arguments and keywords.",
+        "operationId": "partial_v1_delegated_workloads_registrations_resources__resource_type__revisions__descriptor_version__put",
+        "parameters": [
+          {
+            "name": "resource_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Resource Type"
+            }
+          },
+          {
+            "name": "descriptor_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Descriptor Version"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceRegistrationRequestSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceRegistrationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/v1/delegated-workloads/.well-known/jwks.json": {
+      "get": {
+        "summary": "Delegated Capability Jwks",
+        "operationId": "delegated_capability_jwks_v1_delegated_workloads__well_known_jwks_json_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
       }
     }
   },
   "components": {
     "schemas": {
+      "AccessRequestCreate": {
+        "properties": {
+          "resource_kind": {
+            "type": "string",
+            "enum": [
+              "dataset",
+              "model",
+              "workroom"
+            ],
+            "title": "Resource Kind"
+          },
+          "resource_id": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Resource Id"
+          },
+          "capability": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capability"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 300
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "idempotency_key": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Idempotency Key"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "resource_kind",
+          "resource_id",
+          "idempotency_key"
+        ],
+        "title": "AccessRequestCreate"
+      },
+      "AccessRequestResolve": {
+        "properties": {
+          "decision": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "denied"
+            ],
+            "title": "Decision"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "decision"
+        ],
+        "title": "AccessRequestResolve"
+      },
       "AccessSubjectRow": {
         "properties": {
           "subject": {
@@ -35046,6 +44510,63 @@
         "type": "object",
         "title": "AcquireWorkroomThreadClaimRequest",
         "description": "Acquire serialized interaction control for a thread."
+      },
+      "ActionDescriptor": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "effect": {
+            "type": "string",
+            "enum": [
+              "read",
+              "write",
+              "destructive"
+            ],
+            "title": "Effect"
+          },
+          "capability": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capability"
+          },
+          "input_schema": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Input Schema"
+          },
+          "executable": {
+            "type": "boolean",
+            "title": "Executable"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "description",
+          "effect",
+          "capability",
+          "input_schema",
+          "executable"
+        ],
+        "title": "ActionDescriptor"
       },
       "ActiveIngestRequest": {
         "properties": {
@@ -35376,6 +44897,38 @@
             "title": "Attested",
             "description": "Caller confirmed the share attestation step",
             "default": false
+          },
+          "surface_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "use",
+                  "analyze",
+                  "build",
+                  "operate"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Id"
+          },
+          "landing_target": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Landing Target",
+            "description": "Invitation landing target such as a room, app, or analysis handle"
           }
         },
         "type": "object",
@@ -36569,7 +46122,7 @@
           "is_primary": {
             "type": "boolean",
             "title": "Is Primary",
-            "description": "Whether this is the primary port for Traefik routing",
+            "description": "Whether this is the primary port for gateway routing",
             "default": false
           },
           "created_at": {
@@ -36747,6 +46300,19 @@
               }
             ],
             "description": "Extension type: app, tool, or service. Auto-resolved from name if not set."
+          },
+          "workload_identity": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workload Identity",
+            "description": "Delegated workload identity declared by the extension manifest: contract versions, required capability families, roles, and ordered acceptable attestation profiles. Persisted so every later reconcile of the deployed resource projects the same declaration; the deployed resource is a projection of this record, never its source."
           },
           "display_name": {
             "anyOf": [
@@ -36947,7 +46513,7 @@
               }
             ],
             "title": "Strip Path Prefix",
-            "description": "Whether Traefik should strip the path prefix before forwarding. Defaults to True for tools, False for apps and services."
+            "description": "Whether the routing provider should strip the path prefix before forwarding. Defaults to True for tools, False for apps and services."
           },
           "id": {
             "type": "string",
@@ -36997,6 +46563,69 @@
           "source_type": "kamiwaza",
           "template_type": "app"
         }
+      },
+      "ArtifactCreate": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "summary",
+              "report",
+              "briefing"
+            ],
+            "title": "Kind"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title"
+          },
+          "source_result_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "minItems": 1,
+            "title": "Source Result Refs"
+          },
+          "room_scope": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NoWorkroomScope"
+              },
+              {
+                "$ref": "#/components/schemas/WorkroomScope"
+              }
+            ],
+            "title": "Room Scope",
+            "discriminator": {
+              "propertyName": "kind",
+              "mapping": {
+                "no_workroom": "#/components/schemas/NoWorkroomScope",
+                "workroom": "#/components/schemas/WorkroomScope"
+              }
+            }
+          },
+          "idempotency_key": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Idempotency Key"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind",
+          "title",
+          "source_result_refs",
+          "room_scope",
+          "idempotency_key"
+        ],
+        "title": "ArtifactCreate"
       },
       "AttributeGateBindingRequest": {
         "properties": {
@@ -38008,7 +47637,7 @@
               }
             ],
             "title": "Strip Path Prefix",
-            "description": "Whether Traefik strips the path prefix"
+            "description": "Whether the routing provider strips the path prefix"
           },
           "preferred_model_type": {
             "anyOf": [
@@ -38986,6 +48615,94 @@
         "type": "object",
         "title": "CompleteWorkroomQueuedTurnRequest",
         "description": "Complete the active queued turn and optionally append a system note."
+      },
+      "ConnectAndIndexRequest": {
+        "properties": {
+          "connector_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Connector Id"
+          },
+          "source_spec": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UploadSource"
+              },
+              {
+                "$ref": "#/components/schemas/ConnectorSource"
+              }
+            ],
+            "title": "Source Spec",
+            "discriminator": {
+              "propertyName": "kind",
+              "mapping": {
+                "connector": "#/components/schemas/ConnectorSource",
+                "upload": "#/components/schemas/UploadSource"
+              }
+            }
+          },
+          "dataset_name": {
+            "type": "string",
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Dataset Name"
+          },
+          "indexing_profile": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Indexing Profile"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "new",
+              "reindex"
+            ],
+            "title": "Mode"
+          },
+          "room_scope": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NoWorkroomScope"
+              },
+              {
+                "$ref": "#/components/schemas/WorkroomScope"
+              }
+            ],
+            "title": "Room Scope",
+            "discriminator": {
+              "propertyName": "kind",
+              "mapping": {
+                "no_workroom": "#/components/schemas/NoWorkroomScope",
+                "workroom": "#/components/schemas/WorkroomScope"
+              }
+            }
+          },
+          "idempotency_key": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Idempotency Key"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "connector_id",
+          "source_spec",
+          "dataset_name",
+          "mode",
+          "room_scope",
+          "idempotency_key"
+        ],
+        "title": "ConnectAndIndexRequest"
       },
       "ConnectionResponse": {
         "properties": {
@@ -40115,6 +49832,31 @@
         "title": "ConnectorRoutingMetadata",
         "description": "Routing hints for generic connector consumers."
       },
+      "ConnectorSource": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "connector",
+            "title": "Kind"
+          },
+          "selection_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "minItems": 1,
+            "title": "Selection Ids"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind",
+          "selection_ids"
+        ],
+        "title": "ConnectorSource"
+      },
       "ConnectorSourceRef": {
         "properties": {
           "provider": {
@@ -41100,6 +50842,19 @@
             ],
             "description": "Extension type: app, tool, or service. Auto-resolved from name if not set."
           },
+          "workload_identity": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workload Identity",
+            "description": "Delegated workload identity declared by the extension manifest: contract versions, required capability families, roles, and ordered acceptable attestation profiles. Persisted so every later reconcile of the deployed resource projects the same declaration; the deployed resource is a projection of this record, never its source."
+          },
           "display_name": {
             "anyOf": [
               {
@@ -41312,7 +51067,7 @@
               }
             ],
             "title": "Strip Path Prefix",
-            "description": "Whether Traefik should strip the path prefix before forwarding. Defaults to True for tools, False for apps and services."
+            "description": "Whether the routing provider should strip the path prefix before forwarding. Defaults to True for tools, False for apps and services."
           }
         },
         "type": "object",
@@ -41723,6 +51478,19 @@
             ],
             "title": "Annotations",
             "description": "Optional client-supplied CR annotations. Only keys in the kamiwaza.ai/* namespace are accepted; the kamiwaza.io/* namespace is reserved for server-trusted annotations such as owner-user-id and workroom-id."
+          },
+          "workload_identity": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workload Identity",
+            "description": "Validated delegated-workload declaration projected to spec.workloadIdentity for operator reconciliation."
           }
         },
         "type": "object",
@@ -43168,6 +52936,44 @@
         "title": "CreateWorkroomThreadRequest",
         "description": "Create a shared collaborative thread."
       },
+      "CredentialIntakeRequest": {
+        "properties": {
+          "credential": {
+            "type": "string",
+            "maxLength": 16384,
+            "minLength": 1,
+            "format": "password",
+            "title": "Credential",
+            "writeOnly": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "credential"
+        ],
+        "title": "CredentialIntakeRequest"
+      },
+      "CredentialIntakeResponse": {
+        "properties": {
+          "credential_ref": {
+            "type": "string",
+            "title": "Credential Ref"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "credential_ref",
+          "expires_at"
+        ],
+        "title": "CredentialIntakeResponse"
+      },
       "Dataset": {
         "properties": {
           "name": {
@@ -43537,6 +53343,36 @@
         ],
         "title": "DatasetCreate",
         "description": "Schema for creating a new dataset - only includes fields that users provide"
+      },
+      "DatasetDelegatedAccess": {
+        "properties": {
+          "urn": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Urn"
+          },
+          "operations": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "discover",
+                "read",
+                "retrieve"
+              ]
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Operations"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "urn",
+          "operations"
+        ],
+        "title": "DatasetDelegatedAccess",
+        "description": "Exact receiver dataset and its read-only operations."
       },
       "DatasetDescriptor": {
         "properties": {
@@ -44311,6 +54147,61 @@
           "has_more"
         ],
         "title": "DecisionExportResponse"
+      },
+      "DelegatedAccess": {
+        "properties": {
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetDelegatedAccess"
+            },
+            "type": "array",
+            "maxItems": 64,
+            "title": "Datasets",
+            "default": []
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/ModelDelegatedAccess"
+            },
+            "type": "array",
+            "maxItems": 64,
+            "title": "Models",
+            "default": []
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "DelegatedAccess",
+        "description": "Closed resource vocabulary for a receiver-executed job."
+      },
+      "DelegatedErrorCode": {
+        "type": "string",
+        "enum": [
+          "invalid_request",
+          "readiness_unavailable",
+          "incompatible_contract",
+          "registration_rejected",
+          "resource_registration_rejected",
+          "attestation_rejected",
+          "grant_inactive",
+          "revision_mismatch",
+          "current_authority_denied",
+          "capability_expired",
+          "proof_mismatch",
+          "dpop_nonce_required",
+          "replay_rejected",
+          "claim_conflict",
+          "fenced_claim",
+          "occurrence_digest_conflict",
+          "effect_digest_conflict",
+          "unknown_resource_contract",
+          "protected_resource_rejected",
+          "approval_required",
+          "credential_binding_unavailable",
+          "provider_transient_failure",
+          "ambiguous_effect_outcome"
+        ],
+        "title": "DelegatedErrorCode"
       },
       "DeleteGroupResult": {
         "properties": {
@@ -45369,6 +55260,52 @@
         "title": "EpisodesResult",
         "description": "Result of getting episodes."
       },
+      "ErrorBody": {
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/DelegatedErrorCode"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "retry_classification": {
+            "$ref": "#/components/schemas/RetryClassification"
+          },
+          "correlation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Correlation Id"
+          },
+          "safe_details": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Safe Details"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "retry_classification",
+          "correlation_id"
+        ],
+        "title": "ErrorBody"
+      },
+      "ErrorEnvelope": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorBody"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "title": "ErrorEnvelope"
+      },
       "EvaluateImportOptionsRequest": {
         "properties": {
           "sources": {
@@ -45423,6 +55360,40 @@
         "type": "object",
         "title": "EvaluatedImportOptionsResponse",
         "description": "Import options plus Context validation for selected sources."
+      },
+      "EvidenceRef": {
+        "properties": {
+          "result_ref": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Result Ref"
+          },
+          "locator": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Label"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "result_ref",
+          "label"
+        ],
+        "title": "EvidenceRef"
       },
       "ExecutionGateBindingRequest": {
         "properties": {
@@ -45910,7 +55881,52 @@
               }
             ],
             "title": "Healthcheck",
-            "description": "Health check configuration for readiness/liveness/startup probes"
+            "description": "Health check configuration for readiness/liveness/startup probes. When both are positive, startPeriod must be at least periodSeconds."
+          },
+          "persistence": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Persistence",
+            "description": "Validated PVC request for this service (enabled/size/mountPath)"
+          },
+          "volumes": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Volumes",
+            "description": "Validated pod volumes for this service (ephemeral sources only)"
+          },
+          "volumeMounts": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Volumemounts",
+            "description": "Validated container volume mounts for this service"
           }
         },
         "type": "object",
@@ -46436,7 +56452,7 @@
               }
             ],
             "title": "Admin User Id",
-            "description": "Admin user who initiated pairing (for ReBAC seeding on target)"
+            "description": "Admin user who initiated pairing (used to stage receiver-local brokered authority for supported peer-KC compatibility flows)"
           },
           "local_ca_cert": {
             "anyOf": [
@@ -48567,6 +58583,17 @@
             ],
             "title": "Metadata",
             "description": "Arbitrary key-value metadata attached to the job record."
+          },
+          "delegated_access": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DelegatedAccess"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Exact receiver resources made available through the job agent."
           }
         },
         "type": "object",
@@ -48712,6 +58739,17 @@
             ],
             "title": "Metadata",
             "description": "Arbitrary key-value metadata attached to the job record."
+          },
+          "delegated_access": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DelegatedAccess"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Exact receiver resources made available through the job agent."
           }
         },
         "type": "object",
@@ -48842,6 +58880,35 @@
         ],
         "title": "KnowledgeSearchResult",
         "description": "Result of searching the knowledge graph.\n\nExtended in T3.1 with the optional ``sources`` field carrying per-fact\nsource attribution from the C9 OntologySourceAttribution join. Empty\nlist (default) signals the lazy-fallback mode or facts with no\ncontributing sources per INF-G4."
+      },
+      "LandingTarget": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Kind"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "title": "LandingTarget"
       },
       "LeaseStatusResponse": {
         "properties": {
@@ -50235,6 +60302,35 @@
         ],
         "title": "ModelConfig"
       },
+      "ModelDelegatedAccess": {
+        "properties": {
+          "deployment_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Deployment Id"
+          },
+          "operations": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "discover",
+                "chat"
+              ]
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Operations"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "deployment_id",
+          "operations"
+        ],
+        "title": "ModelDelegatedAccess",
+        "description": "Exact receiver model deployment and its read-only operations."
+      },
       "ModelDownloadCancelResponse": {
         "properties": {
           "result": {
@@ -51527,7 +61623,7 @@
           "ingress_enabled": {
             "type": "boolean",
             "title": "Ingress Enabled",
-            "description": "Enable Traefik ingress",
+            "description": "Enable platform ingress",
             "default": true
           },
           "path_prefix": {
@@ -51740,6 +61836,21 @@
         ],
         "title": "NewsResponse",
         "description": "Complete news response structure."
+      },
+      "NoWorkroomScope": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "no_workroom",
+            "title": "Kind"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "title": "NoWorkroomScope"
       },
       "Node": {
         "properties": {
@@ -52051,6 +62162,123 @@
         ],
         "title": "NodeStatus",
         "description": "NodeStatus: Pydantic model for Node Status"
+      },
+      "NotificationPreference": {
+        "properties": {
+          "severity_routes": {
+            "$ref": "#/components/schemas/SeverityRoutes"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "severity_routes",
+          "user_id"
+        ],
+        "title": "NotificationPreference"
+      },
+      "NotificationPreferenceUpdate": {
+        "properties": {
+          "severity_routes": {
+            "$ref": "#/components/schemas/SeverityRoutes"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "severity_routes"
+        ],
+        "title": "NotificationPreferenceUpdate"
+      },
+      "NotificationView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
+          "resource_ref": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Resource Ref"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "info",
+              "warning",
+              "critical"
+            ],
+            "title": "Severity"
+          },
+          "requires_attention": {
+            "type": "boolean",
+            "title": "Requires Attention"
+          },
+          "seen": {
+            "type": "boolean",
+            "title": "Seen"
+          },
+          "dismissed": {
+            "type": "boolean",
+            "title": "Dismissed"
+          },
+          "dismissible": {
+            "type": "boolean",
+            "title": "Dismissible"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "title",
+          "body",
+          "resource_ref",
+          "severity",
+          "requires_attention",
+          "seen",
+          "dismissed",
+          "dismissible",
+          "created_at"
+        ],
+        "title": "NotificationView"
       },
       "OCRConfig": {
         "properties": {
@@ -52502,6 +62730,238 @@
         "title": "OntologyStatus",
         "description": "Ontology instance lifecycle status."
       },
+      "OntologyUpstreamErrorDetail": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "ontology_upstream_error",
+            "title": "Code",
+            "description": "Stable machine-readable ontology upstream error code"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Stable caller-facing operation failure message"
+          },
+          "upstream_status": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Status",
+            "description": "HTTP status returned by the ontology backend, when available"
+          },
+          "upstream_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upstream Message",
+            "description": "Sanitized request-correction detail for approved upstream client errors; omitted for substrate failures"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "upstream_status",
+          "upstream_message"
+        ],
+        "title": "OntologyUpstreamErrorDetail",
+        "description": "Sanitized details for a failed ontology backend request."
+      },
+      "OntologyUpstreamErrorResponse": {
+        "properties": {
+          "detail": {
+            "$ref": "#/components/schemas/OntologyUpstreamErrorDetail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "OntologyUpstreamErrorResponse",
+        "description": "FastAPI error wrapper for an ontology backend failure."
+      },
+      "OperationAccepted": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "retrying",
+              "waiting_for_user",
+              "succeeded",
+              "failed"
+            ],
+            "title": "Status"
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "steps": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Steps"
+          },
+          "resource_refs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Resource Refs"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "status",
+          "origin",
+          "title",
+          "steps",
+          "resource_refs",
+          "created_at"
+        ],
+        "title": "OperationAccepted"
+      },
+      "OperationView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "retrying",
+              "waiting_for_user",
+              "pending_write",
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
+            "title": "Status"
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "steps": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Steps"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "resource_refs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Resource Refs"
+          },
+          "seen": {
+            "type": "boolean",
+            "title": "Seen"
+          },
+          "dismissed": {
+            "type": "boolean",
+            "title": "Dismissed"
+          },
+          "dismissible": {
+            "type": "boolean",
+            "title": "Dismissible"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "kind",
+          "status",
+          "origin",
+          "title",
+          "steps",
+          "resource_refs",
+          "seen",
+          "dismissed",
+          "dismissible",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "OperationView"
+      },
       "PAT": {
         "properties": {
           "id": {
@@ -52855,6 +63315,19 @@
             ],
             "title": "Annotations",
             "description": "Optional client-supplied CR annotations to merge into existing metadata. Only keys in the kamiwaza.ai/* namespace are accepted."
+          },
+          "workload_identity": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workload Identity",
+            "description": "Delegated-workload declaration replacement. Omit to preserve the current declaration; send null to clear it."
           }
         },
         "type": "object",
@@ -52862,7 +63335,7 @@
           "services"
         ],
         "title": "PatchExtension",
-        "description": "Partial extension update. Only service-level fields supported in v1."
+        "description": "Partial extension update."
       },
       "PatchServiceSpec": {
         "properties": {
@@ -52910,14 +63383,177 @@
             ],
             "title": "Replicas",
             "description": "Desired replica count override for the service"
+          },
+          "automountServiceAccountToken": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Automountserviceaccounttoken",
+            "description": "Service account token automount override for this service"
+          },
+          "containerSecurityContext": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Containersecuritycontext",
+            "description": "Validated container security context replacement for this service"
+          },
+          "healthCheck": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Healthcheck",
+            "description": "Validated health check replacement for this service. Omit to preserve the current probe; send null to clear it. When both are positive, startPeriod must be at least periodSeconds."
+          },
+          "persistence": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Persistence",
+            "description": "Validated PVC request override for this service"
+          },
+          "volumes": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Volumes",
+            "description": "Validated pod volumes; an empty list clears existing volumes"
+          },
+          "volumeMounts": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Volumemounts",
+            "description": "Validated container mounts; an empty list clears existing mounts"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "name"
         ],
         "title": "PatchServiceSpec",
         "description": "Partial service update -- only name is required (for matching)."
+      },
+      "PendingQuestion": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Question"
+          },
+          "options": {
+            "items": {
+              "$ref": "#/components/schemas/QuestionOption"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 2,
+            "title": "Options"
+          },
+          "context_result_ref": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context Result Ref"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "question",
+          "options"
+        ],
+        "title": "PendingQuestion"
+      },
+      "PendingWrite": {
+        "properties": {
+          "action_id": {
+            "type": "string",
+            "title": "Action Id"
+          },
+          "confirmation_token": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Confirmation Token"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "effect": {
+            "type": "string",
+            "enum": [
+              "write",
+              "destructive"
+            ],
+            "title": "Effect"
+          },
+          "arguments": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Arguments"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "action_id",
+          "confirmation_token",
+          "title",
+          "effect",
+          "arguments"
+        ],
+        "title": "PendingWrite"
       },
       "PipelineConfig-Input": {
         "properties": {
@@ -53662,6 +64298,196 @@
         "title": "PipelineRequestSource",
         "description": "Durable replay snapshot for one provider-neutral source descriptor."
       },
+      "PlatformInvitation": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "invitee": {
+            "type": "string",
+            "title": "Invitee"
+          },
+          "groups": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Groups"
+          },
+          "surface_id": {
+            "type": "string",
+            "enum": [
+              "use",
+              "analyze",
+              "build",
+              "operate"
+            ],
+            "title": "Surface Id"
+          },
+          "landing_target": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Landing Target"
+          },
+          "room_scope": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Room Scope"
+          },
+          "invited_by": {
+            "type": "string",
+            "title": "Invited By"
+          },
+          "status": {
+            "type": "string",
+            "const": "active",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "invitee",
+          "groups",
+          "surface_id",
+          "landing_target",
+          "room_scope",
+          "invited_by",
+          "status",
+          "created_at"
+        ],
+        "title": "PlatformInvitation"
+      },
+      "PlatformInvitationCreate": {
+        "properties": {
+          "invitees": {
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "minItems": 1,
+            "title": "Invitees"
+          },
+          "groups": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "title": "Groups"
+          },
+          "surface_id": {
+            "type": "string",
+            "enum": [
+              "use",
+              "analyze",
+              "build",
+              "operate"
+            ],
+            "title": "Surface Id"
+          },
+          "landing_target": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LandingTarget"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "room_scope": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NoWorkroomScope"
+              },
+              {
+                "$ref": "#/components/schemas/WorkroomScope"
+              }
+            ],
+            "title": "Room Scope",
+            "discriminator": {
+              "propertyName": "kind",
+              "mapping": {
+                "no_workroom": "#/components/schemas/NoWorkroomScope",
+                "workroom": "#/components/schemas/WorkroomScope"
+              }
+            }
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "invitees",
+          "surface_id",
+          "room_scope"
+        ],
+        "title": "PlatformInvitationCreate"
+      },
+      "PlatformInvitationList": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformInvitation"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "PlatformInvitationList"
+      },
+      "PlatformReadiness": {
+        "properties": {
+          "completeness": {
+            "type": "string",
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "title": "Completeness"
+          },
+          "sections": {
+            "items": {
+              "$ref": "#/components/schemas/ReadinessSection"
+            },
+            "type": "array",
+            "title": "Sections"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "completeness",
+          "sections"
+        ],
+        "title": "PlatformReadiness",
+        "description": "Best-effort readiness snapshot with explicit partial-result state."
+      },
       "PodInfo": {
         "properties": {
           "name": {
@@ -53730,7 +64556,7 @@
           "is_primary": {
             "type": "boolean",
             "title": "Is Primary",
-            "description": "Whether this is the primary port for Traefik routing",
+            "description": "Whether this is the primary port for gateway routing",
             "default": false
           }
         },
@@ -54023,6 +64849,223 @@
         "title": "Provider",
         "description": "Supported OAuth providers."
       },
+      "ProviderConnection": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "bedrock",
+              "azure_ai",
+              "google_vertex",
+              "openai_compatible",
+              "openrouter"
+            ],
+            "title": "Provider"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "endpoint_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint Url"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Region"
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "deployment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deployment"
+          },
+          "status": {
+            "type": "string",
+            "const": "configured",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "provider",
+          "name",
+          "endpoint_url",
+          "model",
+          "region",
+          "project",
+          "location",
+          "deployment",
+          "status",
+          "created_at"
+        ],
+        "title": "ProviderConnection"
+      },
+      "ProviderConnectionCreate": {
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": [
+              "bedrock",
+              "azure_ai",
+              "google_vertex",
+              "openai_compatible",
+              "openrouter"
+            ],
+            "title": "Provider"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "credential_ref": {
+            "type": "string",
+            "pattern": "^cred_[A-Za-z0-9_-]+$",
+            "title": "Credential Ref"
+          },
+          "endpoint_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint Url"
+          },
+          "model": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Model"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Region"
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "deployment": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deployment"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "provider",
+          "name",
+          "credential_ref",
+          "model"
+        ],
+        "title": "ProviderConnectionCreate",
+        "description": "Closed provider configuration; the credential itself is reference-only."
+      },
       "Quadrant": {
         "properties": {
           "title": {
@@ -54050,6 +65093,57 @@
           "position"
         ],
         "title": "Quadrant"
+      },
+      "QuestionAnswer": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Value"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "title": "QuestionAnswer"
+      },
+      "QuestionOption": {
+        "properties": {
+          "label": {
+            "type": "string",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Label"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Value"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 300
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "label",
+          "value"
+        ],
+        "title": "QuestionOption"
       },
       "RawFileCreateRequest": {
         "properties": {
@@ -54452,6 +65546,71 @@
         "title": "RawFileListResponse",
         "description": "Paginated list of raw file records."
       },
+      "ReadinessSection": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "enum": [
+              "compute",
+              "providers",
+              "models",
+              "data_sources",
+              "apps"
+            ],
+            "title": "Key"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ready",
+              "missing",
+              "error"
+            ],
+            "title": "Status"
+          },
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count"
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          },
+          "error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "key",
+          "label",
+          "status",
+          "detail"
+        ],
+        "title": "ReadinessSection",
+        "description": "One independently evaluated platform-readiness section."
+      },
       "RegisterIdPRequest": {
         "properties": {
           "provider": {
@@ -54490,6 +65649,92 @@
           "provider"
         ],
         "title": "RegisterIdPRequest"
+      },
+      "RegistrationReconcileRequest": {
+        "properties": {
+          "client_key": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Client Key"
+          },
+          "client_kind": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Client Kind"
+          },
+          "registrar_revision": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Registrar Revision"
+          },
+          "display_name": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "artifact_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Artifact Digest"
+          },
+          "configuration_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Configuration Digest"
+          },
+          "authority_manifest_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Authority Manifest Digest"
+          },
+          "deployment_locator": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Deployment Locator"
+          },
+          "contract_versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Contract Versions"
+          },
+          "desired_client_status": {
+            "$ref": "#/components/schemas/WorkloadClientStatus"
+          },
+          "desired_revision_status": {
+            "$ref": "#/components/schemas/WorkloadRevisionStatus"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/WorkloadRoleRegistration"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Roles"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "client_key",
+          "client_kind",
+          "registrar_revision",
+          "display_name",
+          "artifact_digest",
+          "configuration_digest",
+          "authority_manifest_digest",
+          "contract_versions",
+          "desired_client_status",
+          "desired_revision_status",
+          "roles"
+        ],
+        "title": "RegistrationReconcileRequest"
       },
       "RejectedDocument": {
         "properties": {
@@ -54612,6 +65857,116 @@
           "object"
         ],
         "title": "RelationshipTupleDelete"
+      },
+      "RemediationDescriptor": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "const": "retry_connect_and_index",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "destructive": {
+            "type": "boolean",
+            "const": false,
+            "title": "Destructive",
+            "default": false
+          },
+          "capability": {
+            "type": "string",
+            "title": "Capability"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "description",
+          "capability"
+        ],
+        "title": "RemediationDescriptor"
+      },
+      "RemediationExecute": {
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Operation Id"
+          },
+          "confirmed": {
+            "type": "boolean",
+            "const": true,
+            "title": "Confirmed"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "operation_id",
+          "confirmed"
+        ],
+        "title": "RemediationExecute"
+      },
+      "RemediationPreview": {
+        "properties": {
+          "remediation": {
+            "$ref": "#/components/schemas/RemediationDescriptor"
+          },
+          "operation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Operation Id"
+          },
+          "impact": {
+            "type": "string",
+            "title": "Impact"
+          },
+          "changes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Changes"
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "const": true,
+            "title": "Requires Confirmation",
+            "default": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "remediation",
+          "operation_id",
+          "impact",
+          "changes"
+        ],
+        "title": "RemediationPreview"
+      },
+      "RemediationTarget": {
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Operation Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "operation_id"
+        ],
+        "title": "RemediationTarget"
       },
       "RemoteSourceRef": {
         "properties": {
@@ -54788,6 +66143,57 @@
         "title": "ReplayPipelineJobRequest",
         "description": "Controls Context-side retry/rerun behavior from recorded snapshots."
       },
+      "RequestValidationErrorItem": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Loc"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "RequestValidationErrorItem",
+        "description": "One FastAPI request-validation error."
+      },
+      "RequestValidationErrorResponse": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/RequestValidationErrorItem"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "RequestValidationErrorResponse",
+        "description": "FastAPI's standard request-validation error wrapper."
+      },
       "RerunPipelineItemsRequest": {
         "properties": {
           "item_keys": {
@@ -54845,6 +66251,178 @@
         "title": "RerunPipelineItemsRequest",
         "description": "Replay selected inventory items from Context-owned source snapshots."
       },
+      "ResourceActionDescriptor": {
+        "properties": {
+          "effect_class": {
+            "type": "string",
+            "enum": [
+              "read",
+              "mutation"
+            ],
+            "title": "Effect Class"
+          },
+          "approval_class": {
+            "type": "string",
+            "enum": [
+              "none",
+              "exact_it_approval"
+            ],
+            "title": "Approval Class"
+          },
+          "methods": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Methods"
+          },
+          "quota_dimensions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Quota Dimensions",
+            "default": []
+          },
+          "broker_operation_types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Broker Operation Types",
+            "default": []
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "effect_class",
+          "approval_class",
+          "methods"
+        ],
+        "title": "ResourceActionDescriptor"
+      },
+      "ResourceRegistrationRequestSchema": {
+        "properties": {
+          "descriptor_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Descriptor Digest"
+          },
+          "audiences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Audiences"
+          },
+          "resource_id_schema": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Resource Id Schema"
+          },
+          "actions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ResourceActionDescriptor"
+            },
+            "type": "object",
+            "minProperties": 1,
+            "title": "Actions"
+          },
+          "request_digest_profile": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Request Digest Profile"
+          },
+          "policy_adapter_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Policy Adapter Id"
+          },
+          "quota_adapter_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Quota Adapter Id"
+          },
+          "guard_contract_version": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Guard Contract Version"
+          },
+          "compatibility": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Compatibility"
+          },
+          "desired_status": {
+            "$ref": "#/components/schemas/ResourceRegistrationStatus"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "descriptor_digest",
+          "audiences",
+          "resource_id_schema",
+          "actions",
+          "request_digest_profile",
+          "policy_adapter_id",
+          "quota_adapter_id",
+          "guard_contract_version",
+          "desired_status"
+        ],
+        "title": "ResourceRegistrationRequestSchema"
+      },
+      "ResourceRegistrationResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "resource_type": {
+            "type": "string",
+            "title": "Resource Type"
+          },
+          "descriptor_version": {
+            "type": "string",
+            "title": "Descriptor Version"
+          },
+          "descriptor": {
+            "$ref": "#/components/schemas/ResourceRegistrationRequestSchema"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceRegistrationStatus"
+          },
+          "created": {
+            "type": "boolean",
+            "title": "Created"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "resource_type",
+          "descriptor_version",
+          "descriptor",
+          "status",
+          "created"
+        ],
+        "title": "ResourceRegistrationResponse"
+      },
+      "ResourceRegistrationStatus": {
+        "type": "string",
+        "enum": [
+          "staged",
+          "active",
+          "retired",
+          "revoked"
+        ],
+        "title": "ResourceRegistrationStatus"
+      },
       "ResourceSpec": {
         "properties": {
           "requests": {
@@ -54881,6 +66459,59 @@
         "type": "object",
         "title": "ResourceSpec",
         "description": "K8s resource requests and limits."
+      },
+      "ResultHandleView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "locator": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locator"
+          },
+          "data": {
+            "title": "Data"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "run_id",
+          "kind",
+          "label",
+          "locator",
+          "data",
+          "created_at"
+        ],
+        "title": "ResultHandleView"
       },
       "RetrievalJob": {
         "properties": {
@@ -55238,6 +66869,17 @@
         "title": "RetrieveResponse",
         "description": "Response for RAG context retrieval."
       },
+      "RetryClassification": {
+        "type": "string",
+        "enum": [
+          "never",
+          "after_reauthentication",
+          "nonce_required",
+          "bounded_backoff",
+          "idempotent_read_only"
+        ],
+        "title": "RetryClassification"
+      },
       "RiskTier": {
         "type": "integer",
         "enum": [
@@ -55298,6 +66940,359 @@
         ],
         "title": "RolloutOutcomeOut",
         "description": "Wire shape for :class:`RolloutOutcome` from the K8s patch adapter."
+      },
+      "RoomDecommissionConfirm": {
+        "properties": {
+          "confirm": {
+            "type": "boolean",
+            "const": true,
+            "title": "Confirm"
+          },
+          "org_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Org Name"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "confirm",
+          "org_name"
+        ],
+        "title": "RoomDecommissionConfirm"
+      },
+      "RoomDecommissionPlan": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "org_id": {
+            "type": "string",
+            "title": "Org Id"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy"
+          },
+          "cutoff_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Cutoff At"
+          },
+          "retention_contact": {
+            "type": "string",
+            "title": "Retention Contact"
+          },
+          "inventory": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inventory"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "completed"
+            ],
+            "title": "Status"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "confirmed_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmed By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "confirmed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmed At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "org_id",
+          "strategy",
+          "cutoff_at",
+          "retention_contact",
+          "inventory",
+          "status",
+          "created_by",
+          "confirmed_by",
+          "created_at",
+          "confirmed_at"
+        ],
+        "title": "RoomDecommissionPlan"
+      },
+      "RoomDecommissionPlanCreate": {
+        "properties": {
+          "strategy": {
+            "type": "string",
+            "enum": [
+              "retain_then_delete",
+              "delete"
+            ],
+            "title": "Strategy"
+          },
+          "cutoff_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Cutoff At"
+          },
+          "retention_contact": {
+            "type": "string",
+            "maxLength": 320,
+            "minLength": 3,
+            "title": "Retention Contact"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "strategy",
+          "cutoff_at",
+          "retention_contact"
+        ],
+        "title": "RoomDecommissionPlanCreate"
+      },
+      "RoomInventory": {
+        "properties": {
+          "captured_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Captured At"
+          },
+          "rooms": {
+            "items": {
+              "$ref": "#/components/schemas/RoomInventoryItem"
+            },
+            "type": "array",
+            "title": "Rooms"
+          },
+          "hold_source": {
+            "type": "string",
+            "const": "unavailable",
+            "title": "Hold Source",
+            "default": "unavailable"
+          },
+          "export_planning_supported": {
+            "type": "boolean",
+            "title": "Export Planning Supported",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "captured_at",
+          "rooms"
+        ],
+        "title": "RoomInventory"
+      },
+      "RoomInventoryItem": {
+        "properties": {
+          "workroom_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Workroom Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "owner_user_id": {
+            "type": "string",
+            "title": "Owner User Id"
+          },
+          "owner_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Email"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "hold_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hold Count"
+          },
+          "export_available": {
+            "type": "boolean",
+            "title": "Export Available",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "workroom_id",
+          "name",
+          "owner_user_id",
+          "status"
+        ],
+        "title": "RoomInventoryItem"
+      },
+      "RoomOrgSettings": {
+        "properties": {
+          "org_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Org Name"
+          },
+          "foreground_rooms": {
+            "type": "boolean",
+            "title": "Foreground Rooms"
+          },
+          "creation_policy": {
+            "type": "string",
+            "enum": [
+              "anyone",
+              "admins",
+              "off"
+            ],
+            "title": "Creation Policy"
+          },
+          "org_id": {
+            "type": "string",
+            "title": "Org Id"
+          },
+          "decommission_state": {
+            "type": "string",
+            "enum": [
+              "none",
+              "active",
+              "completed"
+            ],
+            "title": "Decommission State"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "org_name",
+          "foreground_rooms",
+          "creation_policy",
+          "org_id",
+          "decommission_state",
+          "updated_at"
+        ],
+        "title": "RoomOrgSettings"
+      },
+      "RoomOrgSettingsUpdate": {
+        "properties": {
+          "org_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Org Name"
+          },
+          "foreground_rooms": {
+            "type": "boolean",
+            "title": "Foreground Rooms"
+          },
+          "creation_policy": {
+            "type": "string",
+            "enum": [
+              "anyone",
+              "admins",
+              "off"
+            ],
+            "title": "Creation Policy"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "org_name",
+          "foreground_rooms",
+          "creation_policy"
+        ],
+        "title": "RoomOrgSettingsUpdate"
+      },
+      "RoomTombstone": {
+        "properties": {
+          "workroom_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Workroom Id"
+          },
+          "room_name": {
+            "type": "string",
+            "title": "Room Name"
+          },
+          "cutoff_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Cutoff At"
+          },
+          "retention_contact": {
+            "type": "string",
+            "title": "Retention Contact"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "read_only",
+              "tombstone"
+            ],
+            "title": "State"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "workroom_id",
+          "room_name",
+          "cutoff_at",
+          "retention_contact",
+          "state"
+        ],
+        "title": "RoomTombstone"
       },
       "RouteAuthMode": {
         "type": "string",
@@ -55404,6 +67399,213 @@
         "type": "object",
         "title": "RoutingConfigUpdate",
         "description": "Partial update for routing configuration fields."
+      },
+      "RunAnswer": {
+        "properties": {
+          "answer": {
+            "type": "string",
+            "maxLength": 4000,
+            "minLength": 1,
+            "title": "Answer"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceRef"
+            },
+            "type": "array",
+            "maxItems": 10,
+            "title": "Evidence"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "answer"
+        ],
+        "title": "RunAnswer"
+      },
+      "RunBudgets": {
+        "properties": {
+          "turns": {
+            "type": "integer",
+            "title": "Turns"
+          },
+          "max_turns": {
+            "type": "integer",
+            "const": 8,
+            "title": "Max Turns",
+            "default": 8
+          },
+          "tool_calls": {
+            "type": "integer",
+            "title": "Tool Calls"
+          },
+          "max_tool_calls": {
+            "type": "integer",
+            "const": 12,
+            "title": "Max Tool Calls",
+            "default": 12
+          },
+          "questions": {
+            "type": "integer",
+            "title": "Questions"
+          },
+          "max_questions": {
+            "type": "integer",
+            "const": 3,
+            "title": "Max Questions",
+            "default": 3
+          },
+          "elapsed_ms": {
+            "type": "integer",
+            "title": "Elapsed Ms"
+          },
+          "max_elapsed_ms": {
+            "type": "integer",
+            "const": 45000,
+            "title": "Max Elapsed Ms",
+            "default": 45000
+          }
+        },
+        "type": "object",
+        "required": [
+          "turns",
+          "tool_calls",
+          "questions",
+          "elapsed_ms"
+        ],
+        "title": "RunBudgets"
+      },
+      "RunCreate": {
+        "properties": {
+          "thread_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Thread Id"
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 4000,
+            "minLength": 1,
+            "title": "Query"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "thread_id",
+          "query"
+        ],
+        "title": "RunCreate"
+      },
+      "RunView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "thread_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Thread Id"
+          },
+          "operation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Operation Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "waiting_for_user",
+              "pending_write",
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
+            "title": "Status"
+          },
+          "question": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PendingQuestion"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pending_write": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PendingWrite"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "answer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RunAnswer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "result_refs": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Result Refs"
+          },
+          "budgets": {
+            "$ref": "#/components/schemas/RunBudgets"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "thread_id",
+          "operation_id",
+          "status",
+          "result_refs",
+          "budgets",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "RunView"
       },
       "RuntimeLaunchExchangeRequest": {
         "properties": {
@@ -56426,7 +68628,99 @@
           "banner_enabled"
         ],
         "title": "SecurityConfigResponse",
-        "description": "Public security configuration returned to frontend.\n\nThis is the response schema for GET /api/security/public/config.\nContains all settings needed by the UI to render consent gate\nand classification banners."
+        "description": "Security display configuration returned to frontend.\n\nThe public endpoint redacts values for disabled features. The authenticated\nadmin endpoint returns the complete stored values for safe editing."
+      },
+      "SecurityConfigUpdate": {
+        "properties": {
+          "consent_enabled": {
+            "type": "boolean",
+            "title": "Consent Enabled"
+          },
+          "consent_content": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 10000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consent Content"
+          },
+          "consent_button_label": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consent Button Label"
+          },
+          "banner_enabled": {
+            "type": "boolean",
+            "title": "Banner Enabled"
+          },
+          "banner_top_text": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Top Text"
+          },
+          "banner_top_color": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^#[0-9A-Fa-f]{6}$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Top Color"
+          },
+          "banner_bottom_text": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Bottom Text"
+          },
+          "banner_bottom_color": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^#[0-9A-Fa-f]{6}$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Banner Bottom Color"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "consent_enabled",
+          "banner_enabled"
+        ],
+        "title": "SecurityConfigUpdate",
+        "description": "Complete admin-owned consent and banner configuration."
       },
       "SecuritySpec": {
         "properties": {
@@ -56673,6 +68967,46 @@
         ],
         "title": "SetEmbeddingModelRequest",
         "description": "Body for ``PUT /api/v1/context/embedding-model``."
+      },
+      "SeverityRoutes": {
+        "properties": {
+          "info": {
+            "type": "string",
+            "enum": [
+              "tray",
+              "email",
+              "both",
+              "off"
+            ],
+            "title": "Info",
+            "default": "tray"
+          },
+          "warning": {
+            "type": "string",
+            "enum": [
+              "tray",
+              "email",
+              "both",
+              "off"
+            ],
+            "title": "Warning",
+            "default": "tray"
+          },
+          "critical": {
+            "type": "string",
+            "enum": [
+              "tray",
+              "email",
+              "both",
+              "off"
+            ],
+            "title": "Critical",
+            "default": "tray"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "SeverityRoutes"
       },
       "SkillLibraryDetailResponse": {
         "properties": {
@@ -57186,6 +69520,95 @@
         "title": "SourceType",
         "description": "Provider-neutral source types surfaced to Kaizen."
       },
+      "StartPreference": {
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "enum": [
+              "use",
+              "analyze",
+              "build",
+              "operate"
+            ],
+            "title": "Surface Id"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LandingTarget"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "surface_id",
+          "user_id",
+          "updated_at"
+        ],
+        "title": "StartPreference"
+      },
+      "StartPreferenceUpdate": {
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "enum": [
+              "use",
+              "analyze",
+              "build",
+              "operate"
+            ],
+            "title": "Surface Id"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LandingTarget"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "surface_id"
+        ],
+        "title": "StartPreferenceUpdate"
+      },
+      "StateChanged": {
+        "properties": {
+          "seen": {
+            "type": "boolean",
+            "title": "Seen"
+          },
+          "dismissed": {
+            "type": "boolean",
+            "title": "Dismissed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "seen",
+          "dismissed"
+        ],
+        "title": "StateChanged"
+      },
       "StorageType": {
         "type": "string",
         "enum": [
@@ -57292,6 +69715,107 @@
         ],
         "title": "SubjectUpsertRequest",
         "description": "PUT body for ``/api/authz/subjects/{id_or_username}`` (v0.3.5 OQ-11).\n\nIdempotent upsert: caller supplies the subject identifier in the URL,\nthe body specifies ``attributes`` and an optional initial ``password``\nfor create-time bootstrap."
+      },
+      "SurfaceConstraint": {
+        "properties": {
+          "directory_source": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Directory Source"
+          },
+          "group_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Group Name"
+          },
+          "allowed_surfaces": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "use",
+                "analyze",
+                "build",
+                "operate"
+              ]
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 1,
+            "title": "Allowed Surfaces"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "directory_source",
+          "group_name",
+          "allowed_surfaces",
+          "id",
+          "created_by",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SurfaceConstraint"
+      },
+      "SurfaceConstraintCreate": {
+        "properties": {
+          "directory_source": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Directory Source"
+          },
+          "group_name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Group Name"
+          },
+          "allowed_surfaces": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "use",
+                "analyze",
+                "build",
+                "operate"
+              ]
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 1,
+            "title": "Allowed Surfaces"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "directory_source",
+          "group_name",
+          "allowed_surfaces"
+        ],
+        "title": "SurfaceConstraintCreate"
       },
       "TemplateShadow": {
         "properties": {
@@ -57429,6 +69953,54 @@
         ],
         "title": "TemplateVisibility",
         "description": "Access visibility level for an app template."
+      },
+      "ThreadCreate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Title"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ThreadCreate"
+      },
+      "ThreadView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ThreadView"
       },
       "ToggleIdPRequest": {
         "properties": {
@@ -58120,6 +70692,169 @@
         ],
         "title": "TransportType",
         "description": "Transport strategies supported by the retrieval service."
+      },
+      "TrayItem": {
+        "properties": {
+          "record_type": {
+            "type": "string",
+            "enum": [
+              "operation",
+              "notification"
+            ],
+            "title": "Record Type"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Origin"
+          },
+          "resource_refs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Resource Refs"
+          },
+          "steps": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Steps"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "seen": {
+            "type": "boolean",
+            "title": "Seen"
+          },
+          "dismissible": {
+            "type": "boolean",
+            "title": "Dismissible"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "record_type",
+          "id",
+          "kind",
+          "title",
+          "resource_refs",
+          "seen",
+          "dismissible",
+          "created_at"
+        ],
+        "title": "TrayItem"
+      },
+      "TrayProjection": {
+        "properties": {
+          "needs_attention": {
+            "items": {
+              "$ref": "#/components/schemas/TrayItem"
+            },
+            "type": "array",
+            "title": "Needs Attention"
+          },
+          "running": {
+            "items": {
+              "$ref": "#/components/schemas/TrayItem"
+            },
+            "type": "array",
+            "title": "Running"
+          },
+          "updates": {
+            "items": {
+              "$ref": "#/components/schemas/TrayItem"
+            },
+            "type": "array",
+            "title": "Updates"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "needs_attention",
+          "running",
+          "updates",
+          "has_more"
+        ],
+        "title": "TrayProjection"
       },
       "TriggerResponse": {
         "properties": {
@@ -59844,7 +72579,7 @@
               }
             ],
             "title": "Strip Path Prefix",
-            "description": "Whether Traefik should strip the path prefix before forwarding"
+            "description": "Whether the routing provider should strip the path prefix before forwarding"
           }
         },
         "type": "object",
@@ -60174,6 +72909,31 @@
         "title": "UpgradeAllResult",
         "description": "Per-extension outcome of an Upgrade All operation."
       },
+      "UploadSource": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "upload",
+            "title": "Kind"
+          },
+          "file_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "minItems": 1,
+            "title": "File Refs"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind",
+          "file_refs"
+        ],
+        "title": "UploadSource"
+      },
       "UserInfo": {
         "properties": {
           "username": {
@@ -60405,7 +73165,7 @@
           "flush": {
             "type": "boolean",
             "title": "Flush",
-            "description": "Force a synchronous Milvus flush after this insert. Off by default so bulk ingestion is not gated by a per-insert flush; inserted vectors are searchable immediately and Milvus auto-flushes segments by size. Set true when immediate on-disk durability is required (e.g. a single end-of-batch flush).",
+            "description": "Force a synchronous Milvus flush after this insert. Off by default so bulk ingestion is not gated by a per-insert flush; inserted vectors are searchable immediately and Milvus auto-flushes segments by size. Set true when immediate on-disk durability is required (e.g. a single end-of-batch flush). Note the durability contract: with flush off the response confirms only that Milvus accepted the rows, so a full object store cannot be reported on this call — the auto-flush that stalls against it happens after the response. Set true to have that surface as HTTP 507.",
             "default": false
           }
         },
@@ -60687,6 +73447,168 @@
           "rows"
         ],
         "title": "WhoCanAccessResponse"
+      },
+      "WorkloadClientStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "active",
+          "suspended",
+          "deregistered"
+        ],
+        "title": "WorkloadClientStatus"
+      },
+      "WorkloadRegistrationResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "deployment_uid": {
+            "type": "string",
+            "title": "Deployment Uid"
+          },
+          "client_key": {
+            "type": "string",
+            "title": "Client Key"
+          },
+          "client_kind": {
+            "type": "string",
+            "title": "Client Kind"
+          },
+          "registrar_revision": {
+            "type": "string",
+            "title": "Registrar Revision"
+          },
+          "workload_revision_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Workload Revision Id"
+          },
+          "activation_epoch": {
+            "type": "integer",
+            "minimum": 1,
+            "title": "Activation Epoch"
+          },
+          "authority_manifest_digest": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Authority Manifest Digest"
+          },
+          "client_status": {
+            "$ref": "#/components/schemas/WorkloadClientStatus"
+          },
+          "revision_status": {
+            "$ref": "#/components/schemas/WorkloadRevisionStatus"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/WorkloadRoleRegistration"
+            },
+            "type": "array",
+            "title": "Roles"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "id",
+          "deployment_uid",
+          "client_key",
+          "client_kind",
+          "registrar_revision",
+          "workload_revision_id",
+          "activation_epoch",
+          "authority_manifest_digest",
+          "client_status",
+          "revision_status",
+          "roles"
+        ],
+        "title": "WorkloadRegistrationResponse"
+      },
+      "WorkloadRevisionStatus": {
+        "type": "string",
+        "enum": [
+          "staged",
+          "active",
+          "draining",
+          "retired",
+          "revoked"
+        ],
+        "title": "WorkloadRevisionStatus"
+      },
+      "WorkloadRoleRegistration": {
+        "properties": {
+          "role_key": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Role Key"
+          },
+          "role_type": {
+            "$ref": "#/components/schemas/WorkloadRoleType"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkloadRoleStatus"
+          },
+          "deployment_role_locator": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Deployment Role Locator"
+          },
+          "allowed_platform_operations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true,
+            "title": "Allowed Platform Operations"
+          },
+          "acceptable_attestation_profiles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Acceptable Attestation Profiles"
+          },
+          "attestation_selector": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attestation Selector"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "role_key",
+          "role_type",
+          "status",
+          "deployment_role_locator",
+          "allowed_platform_operations",
+          "acceptable_attestation_profiles",
+          "attestation_selector"
+        ],
+        "title": "WorkloadRoleRegistration"
+      },
+      "WorkloadRoleStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "suspended",
+          "revoked"
+        ],
+        "title": "WorkloadRoleStatus"
+      },
+      "WorkloadRoleType": {
+        "type": "string",
+        "enum": [
+          "control_plane",
+          "executor",
+          "resource_server"
+        ],
+        "title": "WorkloadRoleType"
       },
       "WorkroomBootstrapResponse": {
         "properties": {
@@ -61673,6 +74595,37 @@
             "type": "boolean",
             "title": "Is Primary Owner",
             "default": false
+          },
+          "surface_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "use",
+                  "analyze",
+                  "build",
+                  "operate"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Id"
+          },
+          "landing_target": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Landing Target"
           }
         },
         "type": "object",
@@ -62707,6 +75660,27 @@
         "title": "WorkroomRuntimeThreadResponse",
         "description": "Shared thread summary for workroom collaboration runtime."
       },
+      "WorkroomScope": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "workroom",
+            "title": "Kind"
+          },
+          "workroom_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Workroom Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "kind",
+          "workroom_id"
+        ],
+        "title": "WorkroomScope"
+      },
       "WorkroomScopeAuditFinding": {
         "properties": {
           "deployment_id": {
@@ -63200,6 +76174,28 @@
         ],
         "title": "WorkroomType",
         "description": "Workroom type determines lifecycle behavior.\n\n- ephemeral: purges on session end (logout/timeout)\n- persistent: requires explicit delete"
+      },
+      "WriteConfirmation": {
+        "properties": {
+          "confirmed": {
+            "type": "boolean",
+            "const": true,
+            "title": "Confirmed"
+          },
+          "confirmation_token": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Confirmation Token"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "confirmed",
+          "confirmation_token"
+        ],
+        "title": "WriteConfirmation"
       },
       "_GrantBody": {
         "properties": {

--- a/scripts/sync-openapi.test.ts
+++ b/scripts/sync-openapi.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
+import { sanitizeRemoteUrl } from "./sync-openapi";
+
 const syncScript = fs.readFileSync(
 	path.resolve(__dirname, "sync-openapi.ts"),
 	"utf-8",
@@ -36,4 +38,17 @@ test("published OpenAPI metadata uses a portable GitHub source URL", () => {
 		publishedMetadata.sourceRemote,
 		"https://github.com/kamiwaza-internal/kamiwaza",
 	);
+});
+
+test("GitHub source remotes normalize to one portable HTTPS URL", () => {
+	const expected = "https://github.com/kamiwaza-internal/kamiwaza";
+	for (const remote of [
+		"git@github.com:kamiwaza-internal/kamiwaza.git",
+		"git@github.com:kamiwaza-internal/kamiwaza.git/",
+		"ssh://git@github.com/kamiwaza-internal/kamiwaza.git",
+		"https://github.com/kamiwaza-internal/kamiwaza.git",
+		"https://token@github.com/kamiwaza-internal/kamiwaza/",
+	]) {
+		assert.equal(sanitizeRemoteUrl(remote), expected);
+	}
 });

--- a/scripts/sync-openapi.test.ts
+++ b/scripts/sync-openapi.test.ts
@@ -11,6 +11,12 @@ const publishedSpec = fs.readFileSync(
 	path.resolve(__dirname, "../docs/api/openapi.json"),
 	"utf-8",
 );
+const publishedMetadata = JSON.parse(
+	fs.readFileSync(
+		path.resolve(__dirname, "../docs/api/openapi-metadata.json"),
+		"utf-8",
+	),
+);
 
 test("local OpenAPI generation uses the selected core project environment", () => {
 	assert.match(
@@ -23,4 +29,11 @@ test("local OpenAPI generation uses the selected core project environment", () =
 
 test("published OpenAPI surface does not name the retired Traefik provider", () => {
 	assert.doesNotMatch(publishedSpec, /traefik/i);
+});
+
+test("published OpenAPI metadata uses a portable GitHub source URL", () => {
+	assert.equal(
+		publishedMetadata.sourceRemote,
+		"https://github.com/kamiwaza-internal/kamiwaza",
+	);
 });

--- a/scripts/sync-openapi.test.ts
+++ b/scripts/sync-openapi.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const syncScript = fs.readFileSync(
+	path.resolve(__dirname, "sync-openapi.ts"),
+	"utf-8",
+);
+const publishedSpec = fs.readFileSync(
+	path.resolve(__dirname, "../docs/api/openapi.json"),
+	"utf-8",
+);
+
+test("local OpenAPI generation uses the selected core project environment", () => {
+	assert.match(
+		syncScript,
+		/execFileSync\(\s*"uv",\s*\["--project", repoPath, "run", "python", "-c", pythonScript\]/,
+	);
+	assert.doesNotMatch(syncScript, /execFileSync\("\.\/scripts\/kw_py"/);
+	assert.match(syncScript, /maxBuffer:\s*16 \* 1024 \* 1024/);
+});
+
+test("published OpenAPI surface does not name the retired Traefik provider", () => {
+	assert.doesNotMatch(publishedSpec, /traefik/i);
+});

--- a/scripts/sync-openapi.ts
+++ b/scripts/sync-openapi.ts
@@ -202,36 +202,43 @@ print(json.dumps(app.openapi()))
 `.trim();
 
 	try {
-		return execFileSync("./scripts/kw_py", ["-c", pythonScript], {
-			cwd: repoPath,
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-			env: {
-				...process.env,
-				KAMIWAZA_ENV: process.env.KAMIWAZA_ENV || "dev",
-				KAMIWAZA_LITE: process.env.KAMIWAZA_LITE || "true",
-				KAMIWAZA_ROOT: process.env.KAMIWAZA_ROOT || tempRoot,
-				// create_app() -> init_auth() requires the RBAC policy file; its
-				// default derives from KAMIWAZA_ROOT (<root>/runtime/auth_gateway_policy.yaml),
-				// which the ephemeral tempRoot does not have. Point at the policy
-				// shipped in the kamiwaza repo so from-source generation is
-				// self-contained (no running platform, no manual staging).
-				AUTH_GATEWAY_POLICY_FILE:
-					process.env.AUTH_GATEWAY_POLICY_FILE ||
-					path.join(repoPath, "config", "auth_gateway_policy.yaml"),
-				DATABASE_URL:
-					process.env.DATABASE_URL || `sqlite:///${path.join(tempDir, "main.db")}`,
-				CLUSTER_DATABASE_URL:
-					process.env.CLUSTER_DATABASE_URL ||
-					`sqlite:///${path.join(tempDir, "cluster.db")}`,
-				AUTH_DATABASE_URL:
-					process.env.AUTH_DATABASE_URL || `sqlite:///${path.join(tempDir, "auth.db")}`,
-				// Ephemeral per-invocation secret so no literal is committed.
-				AUTH_FORWARD_HEADER_SECRET:
-					process.env.AUTH_FORWARD_HEADER_SECRET ||
-					crypto.randomBytes(32).toString("hex"),
+		return execFileSync(
+			"uv",
+			["--project", repoPath, "run", "python", "-c", pythonScript],
+			{
+				cwd: repoPath,
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+				maxBuffer: 16 * 1024 * 1024,
+				env: {
+					...process.env,
+					KAMIWAZA_ENV: process.env.KAMIWAZA_ENV || "dev",
+					KAMIWAZA_LITE: process.env.KAMIWAZA_LITE || "true",
+					KAMIWAZA_ROOT: process.env.KAMIWAZA_ROOT || tempRoot,
+					// create_app() -> init_auth() requires the RBAC policy file; its
+					// default derives from KAMIWAZA_ROOT (<root>/runtime/auth_gateway_policy.yaml),
+					// which the ephemeral tempRoot does not have. Point at the policy
+					// shipped in the kamiwaza repo so from-source generation is
+					// self-contained (no running platform, no manual staging).
+					AUTH_GATEWAY_POLICY_FILE:
+						process.env.AUTH_GATEWAY_POLICY_FILE ||
+						path.join(repoPath, "config", "auth_gateway_policy.yaml"),
+					DATABASE_URL:
+						process.env.DATABASE_URL ||
+						`sqlite:///${path.join(tempDir, "main.db")}`,
+					CLUSTER_DATABASE_URL:
+						process.env.CLUSTER_DATABASE_URL ||
+						`sqlite:///${path.join(tempDir, "cluster.db")}`,
+					AUTH_DATABASE_URL:
+						process.env.AUTH_DATABASE_URL ||
+						`sqlite:///${path.join(tempDir, "auth.db")}`,
+					// Ephemeral per-invocation secret so no literal is committed.
+					AUTH_FORWARD_HEADER_SECRET:
+						process.env.AUTH_FORWARD_HEADER_SECRET ||
+						crypto.randomBytes(32).toString("hex"),
+				},
 			},
-		});
+		);
 	} catch (error: any) {
 		const stderr =
 			typeof error?.stderr === "string" && error.stderr.trim()

--- a/scripts/sync-openapi.ts
+++ b/scripts/sync-openapi.ts
@@ -99,20 +99,29 @@ function getCurrentCommit(repoPath: string): string {
  * different leak. Normalize GitHub SSH remotes to portable HTTPS metadata so
  * the generated artifact does not vary with the checkout transport.
  */
-function sanitizeRemoteUrl(raw: string): string {
+function canonicalGitHubRemote(repositoryPath: string): string {
+	const repository = repositoryPath
+		.replace(/^\/+|\/+$/g, "")
+		.replace(/\.git$/i, "");
+	return `https://github.com/${repository}`;
+}
+
+export function sanitizeRemoteUrl(raw: string): string {
 	if (!raw) {
 		return raw;
 	}
-	const githubSshRemote = raw.match(/^git@github\.com:(.+)$/);
+	const githubSshRemote = raw.trim().match(/^git@github\.com:(.+)$/);
 	if (githubSshRemote) {
-		const repository = githubSshRemote[1].replace(/\.git$/, "");
-		return `https://github.com/${repository}`;
+		return canonicalGitHubRemote(githubSshRemote[1]);
 	}
 	if (/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(raw)) {
 		try {
 			const parsed = new URL(raw);
 			parsed.username = "";
 			parsed.password = "";
+			if (parsed.hostname.toLowerCase() === "github.com") {
+				return canonicalGitHubRemote(parsed.pathname);
+			}
 			return parsed.toString();
 		} catch {
 			// Fall through and return the raw value if URL parsing failed —
@@ -426,7 +435,9 @@ async function main() {
 	console.log("  2. Review changes at /sdk/api-reference");
 }
 
-main().catch((err) => {
-	console.error("\nError:", err.message);
-	process.exit(1);
-});
+if (require.main === module) {
+	main().catch((err) => {
+		console.error("\nError:", err.message);
+		process.exit(1);
+	});
+}

--- a/scripts/sync-openapi.ts
+++ b/scripts/sync-openapi.ts
@@ -96,12 +96,17 @@ function getCurrentCommit(repoPath: string): string {
  * before persisting it to tracked metadata. Git lets users embed access
  * tokens directly in `remote.origin.url`, and a previous fix that swapped a
  * leaky absolute path for the remote URL would otherwise re-introduce a
- * different leak. SSH-style URLs (`git@github.com:org/repo.git`) don't
- * contain secrets and survive untouched.
+ * different leak. Normalize GitHub SSH remotes to portable HTTPS metadata so
+ * the generated artifact does not vary with the checkout transport.
  */
 function sanitizeRemoteUrl(raw: string): string {
 	if (!raw) {
 		return raw;
+	}
+	const githubSshRemote = raw.match(/^git@github\.com:(.+)$/);
+	if (githubSshRemote) {
+		const repository = githubSshRemote[1].replace(/\.git$/, "");
+		return `https://github.com/${repository}`;
 	}
 	if (/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(raw)) {
 		try {


### PR DESCRIPTION
## Summary
- regenerate the public OpenAPI artifact from current core develop (`32fbf6acb4965aaa7328926555469bfe3095e247`)
- remove seven stale active Traefik descriptions from the published API surface
- make local source generation use the selected core uv project and support schemas larger than the Node child-process default buffer
- canonicalize GitHub source remotes to portable credential-free HTTPS metadata
- add regression coverage for generator selection/buffering, remote normalization, and the Traefik-free published API contract

## Validation
- `npm test` (58 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `rg -ni traefik docs/api` (no matches)

Linear: ENG-10473