### PR TITLE
ENG-10327: cherry-pick the collector --output-dir docs to release/1.2.0

### DIFF
--- a/docs/docs/runbooks/core-database-upgrade-1.2.md
+++ b/docs/docs/runbooks/core-database-upgrade-1.2.md
@@ -1280,12 +1280,36 @@ namespace state and events, and Helm status/history. For a pod that never
 started, the pod description and events are authoritative; an empty container
 log alone is not evidence that migration code ran.
 
-`--namespace` and `--release` are also accepted as flags; the positional
-`DIR [NAMESPACE] [RELEASE]` form above is still supported. Every option also
-takes the `--option=value` form, which is how to pass a value that legitimately
-begins with `-`. Both binary options need a path to an executable regular file
-containing a `/`: a bare name would be re-resolved through `PATH` when the
-command runs, so the binary that executes need not be the one that was checked.
+`--output-dir`, `--namespace`, and `--release` are also accepted as flags; the
+positional `DIR [NAMESPACE] [RELEASE]` form above is still supported. Every
+option also takes the `--option=value` form, which is how to pass a value that
+legitimately begins with `-`.
+
+`--output-dir` **replaces** the positional evidence directory rather than
+supplementing it, so passing both is a usage error naming the two forms.
+Accepting both would make the first positional mean `DIR` in one invocation
+and `NAMESPACE` in another, and a mistyped flag would then write the bundle to
+a directory named for the namespace. Either of these is complete, and mixing
+them is not:
+
+```bash
+"${COLLECTOR_COMMAND}" "${COLLECTOR_DIR}" "${NAMESPACE}" "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+
+"${COLLECTOR_COMMAND}" --output-dir "${COLLECTOR_DIR}" \
+  --namespace "${NAMESPACE}" --release "${RELEASE}" \
+  --kubectl-bin "${KUBECTL_PATH}" --helm-bin "${HELM_PATH}"
+```
+
+Those two lines show argument shape only. Run the canonical block earlier in
+this section rather than either of them on its own — a bare collector line
+loses the `COLLECTOR_RC` capture and the ownership reclaim that block performs.
+That block uses the positional form; either form is fine there, but do not edit
+it into a mixture of the two.
+
+Both binary options need a path to an executable regular file containing a
+`/`: a bare name would be re-resolved through `PATH` when the command runs, so
+the binary that executes need not be the one that was checked.
 A *non-empty* value that fails either test is not a usage error — the tool is
 simply unresolvable, and the run ends at exit 1 with `result=not-collected`
 naming it. An *empty* value is rejected as a usage error, at exit 2, before the
@@ -1366,6 +1390,26 @@ resolved but had every one of its invocations fail — and `manifest.txt` names
 what is missing. `COLLECTOR_RC` of 2 is a usage error or an evidence path that
 is unsafe to write (an existing non-empty directory, a symbolic link, or a
 non-directory); correct the argument or choose a new `COLLECTOR_DIR` and re-run.
+Each of those *path* refusals names the offending path, so a first attempt
+that failed does not leave you deducing why the corrected one is also refused.
+
+Whether the refusal also prints a `rm -rf` depends on what is in the way, and
+the asymmetry is deliberate. When the directory holds an earlier run of this
+collector — identified by its own `manifest.txt` — the refusal prints the
+exact removal command, quoted so a path containing spaces pastes as-is. A
+non-empty directory the collector did **not** write is never offered for
+removal, however plainly it is in the way; point `COLLECTOR_DIR` at a new path
+instead. That case is the mistyped `--output-dir`, and the collector may be
+run under `sudo`, so it will not hand a root shell a deletion
+command for data it did not create — **and neither should you.** Move or
+remove such a directory yourself, deliberately and outside this runbook, or
+leave it alone.
+
+Even for a bundle the collector did write, removal is only right when you do
+not intend to keep it. If the first attempt collected anything worth
+preserving — in particular anything you hand-copied into the collector
+bundle's own `${COLLECTOR_DIR}/installer` — choose a new `COLLECTOR_DIR` rather than clearing the old one.
+
 Exit zero means both collectors produced evidence — it does **not** mean every
 command succeeded. A run where some commands failed (a Job that does not exist,
 an RBAC denial on one resource) still exits zero, prints


### PR DESCRIPTION
## Summary

Cherry-pick of [#205](https://github.com/kamiwaza-ai/kamiwaza-docs/pull/205)
(`0f1874d`) onto `release/1.2.0`, which ENG-10327 targets alongside `develop`.

Clean pick, no conflicts, no adaptation:
`docs/docs/runbooks/core-database-upgrade-1.2.md` was identical on the two
branches before #205 merged, and after this pick it is identical again —
`git diff origin/develop HEAD -- docs/docs/runbooks/core-database-upgrade-1.2.md`
is empty.

This matters for 1.2.0 specifically. The collector's code half is **already on
this branch** — deploy [#807](https://github.com/kamiwaza-internal/deploy/pull/807)
(`cbd4867d`) backported it to `release/1.2.0` on Aug 14 — so until this lands,
1.2.0 ships a collector that accepts `--output-dir` alongside a runbook that
documents only the positional form. That is exactly the first-attempt failure
ENG-10327 exists to remove, and it is the half an operator actually reads.

The change documents the flag form, states that `--output-dir` replaces rather
than supplements the positional evidence directory, and explains the asymmetric
retry message: an earlier run of this collector (identified by its own
`manifest.txt`) gets an exact `rm -rf` printed and shell-quoted, while a
non-empty directory the collector did not write is never offered for removal.

## Test plan

- `npm run build` in `docs/` passes on this branch: `[SUCCESS] Generated static
  files in "build"`. Run against the `release/1.2.0` base specifically, not
  reused from #205 — different base, own lockfiles.
- No Docusaurus warning names this page; grepping the full build output for
  `core-database-upgrade` and `runbook` returns zero matches.
- Content equivalence to the merged `develop` state confirmed by empty diff, so
  #205's verification carries over: every behavioral claim in the prose was
  checked against the shipped `scripts/collect-core-db-init-diagnostics.sh`
  rather than against the PR description, and the round-2 paragraph-break fix
  was confirmed in the built HTML.

Documentation only; no code paths change.

Refs ENG-10327

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: "0.13.1"
generated_at: "2026-08-18T18:59:35Z"
pr:
  repo: "kamiwaza-ai/kamiwaza-docs"
  number: 208
linear_issues: [ENG-10327]
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "3/3 green on this head (Docs tests and production build, Validate package locks, check-linear-issue). Gate re-verifies."
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "Retired in pr-verify 0.13.x (ENG-10304); confirmed only test references remain in the installed 0.13.1. Gate re-verifies against GitHub's clock."
  - kind: linear-issue-present
    required: true
    status: pass
    detail: "ENG-10327 in the branch name, every commit subject, and the PR body's Refs line."
  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff is one Markdown file. No console.log / debugger / pdb.set_trace / breakpoint added."
  - kind: pr-review-approved
    required: true
    status: pass
    detail: "/pr-review APPROVE (Risk Low, 0 Critical) posted SHA-pinned on head f383f942da87eaf05e11fcfab06ffe8cc14a7449."
  - kind: pr-evidence
    required: false
    status: skipped
    detail: "No cluster smoke applies: documentation-only change to a Docusaurus page, no runtime surface."
manual_steps:
  - id: ms-1
    description: "Confirm the cherry-pick is content-identical to the approved and merged develop state, not merely conflict-free."
    observation: "git diff origin/develop HEAD -- docs/docs/runbooks/core-database-upgrade-1.2.md is empty (exit 0). The pick applied with no conflict and no adaptation; the two branches were already identical on this file before #205 merged."
    status: pass
  - id: ms-2
    description: "Confirm the backport touches only the intended file."
    observation: "git diff --stat origin/release/1.2.0 HEAD reports exactly one file: docs/docs/runbooks/core-database-upgrade-1.2.md, 50 insertions(+), 6 deletions(-). Base 3dedb4b is a true ancestor of HEAD, so the merge-base diff is exactly the PR. release/1.2.0 has diverged from develop in many other files (1.0.2 versioned docs, OpenAPI sync) but none of that is in this diff."
    status: pass
  - id: ms-3
    description: "Confirm the code half the prose describes is actually present on THIS release line - the one way a docs backport like this could be wrong."
    observation: "scripts/collect-core-db-init-diagnostics.sh on deploy origin/release/1.2.0 is BYTE-IDENTICAL to origin/develop (diff -q reports no difference), so the picked prose applies verbatim. Directly confirmed on the release branch: 12 occurrences of --output-dir, is_prior_bundle() at line 246, the guarded printf rm -rf %q at 288, and the deliberate no-removal branch at 295. deploy #807 (cbd4867d) is what put it there."
    status: pass
  - id: ms-4
    description: "Build the docs site against the release/1.2.0 base specifically, not reusing the develop result."
    observation: "npm ci at repo root and docs/, then npm run build in docs/ on this worktree: exit 0, \"[SUCCESS] Generated static files in build.\" Grepping the full output for core-database-upgrade and runbook returns zero matches, so no warning names this page on this base. CI Docs tests and production build passed independently."
    status: pass
  - id: ms-5
    description: "Confirm cherry-pick provenance is auditable from git alone."
    observation: "f383f94 carries (cherry picked from commit 0f1874d5ee13ae881d48e73681efd8a9b03cd712) from the -x flag, plus Refs ENG-10327 and PR: #205 in the body."
    status: pass
verdict:
  decision: approve
  rationale: "Cherry-pick of the already-approved and merged #205 onto release/1.2.0, which ENG-10327 targets alongside develop. Verified as a no-op adaptation: empty diff against origin/develop on the changed file, single file, correct -x provenance, no dangling references, green build on this base. Critically, the collector the prose describes is byte-identical on deploy's develop and release/1.2.0, so the documentation is accurate for this release line rather than describing develop-only behavior. Content review was settled on #205 over two rounds. One residual Medium was raised and deliberately NOT applied: its proposed remedy would have retargeted the rm -rf warning at a directory that command cannot reach, which would be a regression rather than a fix. Scope limit: the collector was not executed against a live cluster from here."
gate:
  approval_submitted: false
```

</details>


<!-- pr-verify-end -->