### PR TITLE
ENG-10579: guard current public docs against retired routing guidance

### DIFF
--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -45,9 +45,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kamiwaza-ai/kamiwaza-sdk
-          ref: develop
+          # Reviewed source for the generated SDK surface. Bump this SHA when
+          # synchronizing SDK documentation so CI remains reproducible.
+          ref: 06398a7905eee36861436ba8d3a6847f84de4eb1
           path: kamiwaza-sdk
           persist-credentials: false
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -77,10 +77,17 @@ jobs:
           KW_SDK_DOCS: ${{ github.workspace }}/kamiwaza-sdk
 
       - name: Verify generated SDK documentation
-        run: >-
-          find docs/sdk/current/services -type f
-          \( -name '*.md' -o -name '*.mdx' \)
-          -size +0c -print -quit | grep -q .
+        run: |
+          generated_page=$(find docs/sdk/current/services -type f \
+            \( -name '*.md' -o -name '*.mdx' \) -print -quit)
+          test -n "${generated_page}"
+
+          empty_page=$(find docs/sdk/current/services -type f \
+            \( -name '*.md' -o -name '*.mdx' \) -size 0c -print -quit)
+          if [[ -n "${empty_page}" ]]; then
+            echo "Generated SDK page is empty: ${empty_page}" >&2
+            exit 1
+          fi
 
       - name: Run scripts unit tests
         run: npm test

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -14,6 +14,7 @@ on:
       - "docs/extensions/**"
       - "docs/sdk/**"
       - "docs/api/**"
+      - "docs/research/**"
       - "docs/versioned_docs/**"
       - "docs/versioned_sidebars/**"
       - "docs/docusaurus.config.ts"
@@ -74,6 +75,12 @@ jobs:
         run: npm run sync-sdk
         env:
           KW_SDK_DOCS: ${{ github.workspace }}/kamiwaza-sdk
+
+      - name: Verify generated SDK documentation
+        run: >-
+          find docs/sdk/current/services -type f
+          \( -name '*.md' -o -name '*.mdx' \)
+          -print -quit | grep -q .
 
       - name: Run scripts unit tests
         run: npm test

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -11,6 +11,9 @@ on:
       - "docs/scripts/**"
       - "docs/sidebars.ts"
       - "docs/docs/**"
+      - "docs/extensions/**"
+      - "docs/sdk/**"
+      - "docs/api/**"
       - "docs/versioned_docs/**"
       - "docs/versioned_sidebars/**"
       - "docs/docusaurus.config.ts"
@@ -38,6 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout SDK documentation source
+        uses: actions/checkout@v4
+        with:
+          repository: kamiwaza-ai/kamiwaza-sdk
+          ref: develop
+          path: kamiwaza-sdk
+          persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -55,6 +66,11 @@ jobs:
 
       - name: Install docs dependencies
         run: npm ci --ignore-scripts --prefix docs
+
+      - name: Materialize generated SDK documentation
+        run: npm run sync-sdk
+        env:
+          KW_SDK_DOCS: ${{ github.workspace }}/kamiwaza-sdk
 
       - name: Run scripts unit tests
         run: npm test

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -80,7 +80,7 @@ jobs:
         run: >-
           find docs/sdk/current/services -type f
           \( -name '*.md' -o -name '*.mdx' \)
-          -print -quit | grep -q .
+          -size +0c -print -quit | grep -q .
 
       - name: Run scripts unit tests
         run: npm test

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -6,25 +6,29 @@ import test from "node:test";
 const root = path.resolve(__dirname, "..");
 const retiredProvider = "trae" + "fik";
 
-const intentionalHistory: Record<string, RegExp[]> = {
+const providerTitle = `${retiredProvider[0].toUpperCase()}${retiredProvider.slice(1)}`;
+
+const intentionalHistory: Record<string, string[]> = {
   "docs/docs/installation/offline_install.md": [
-    new RegExp(
-      `KAMIWAZA_IMAGE_OVERRIDES=.*${retiredProvider}=v3\\.6\\.20-kz\\.1`,
-      "i",
-    ),
+    `export KAMIWAZA_IMAGE_OVERRIDES="keycloak=\${CONTAINERS_TAG},postgres=v18.4,etcd=v3.6.10,kubectl=v1.35.5-dev,chainguard-base=\${CONTAINERS_TAG},${retiredProvider}=v3.6.20-kz.1,kafka-iamguarded=v4.3.0,neo4j=v5.26.25-kz.1,datahub-gms=\${CONTAINERS_TAG},datahub-frontend=\${CONTAINERS_TAG},datahub-upgrade=\${CONTAINERS_TAG},datahub-postgres-setup=\${CONTAINERS_TAG},vram-plugin=\${APP_TAG},opensearch=v2.19.5,extension-operator=\${EXTENSION_OPERATOR_TAG}"`,
   ],
   "docs/docs/routing-modes.md": [
-    new RegExp(`Migrating from ${retiredProvider}`, "i"),
-    new RegExp(`${retiredProvider} routing support was removed`, "i"),
-    new RegExp(`KAMIWAZA_ROUTING_PROVIDER=${retiredProvider}`, "i"),
-    new RegExp("Remove the `" + retiredProvider + "` provider override", "i"),
-    new RegExp(
-      "custom " + retiredProvider + " `IngressRoute` and `Middleware`",
-      "i",
-    ),
-    new RegExp(`${retiredProvider} ForwardAuth headers`, "i"),
+    `## Migrating from ${providerTitle}`,
+    `${providerTitle} routing support was removed after the platform moved to Istio and`,
+    `\`KAMIWAZA_ROUTING_PROVIDER=${retiredProvider}\` now fails during startup with migration`,
+    `1. Remove the \`${retiredProvider}\` provider override and any \`network.${retiredProvider}\` values.`,
+    `3. Replace custom ${providerTitle} \`IngressRoute\` and \`Middleware\` resources with the`,
+    `Do not translate ${providerTitle} ForwardAuth headers into application configuration.`,
   ],
 };
+
+function consumeIntentionalHistory(allowed: string[], line: string): boolean {
+  const trimmed = line.trim();
+  const index = allowed.indexOf(trimmed);
+  if (index === -1) return false;
+  allowed.splice(index, 1);
+  return true;
+}
 
 function markdownFiles(directory: string): string[] {
   if (!fs.existsSync(directory)) return [];
@@ -56,11 +60,8 @@ test("current public, SDK, and API docs do not restore retired-provider guidance
       .filter((line) => line.toLowerCase().includes(retiredProvider));
 
     for (const line of matchingLines) {
-      const index = allowed.findIndex((pattern) => pattern.test(line));
-      if (index === -1) {
+      if (!consumeIntentionalHistory(allowed, line)) {
         offenders.push(`${relative}: ${line.trim()}`);
-      } else {
-        allowed.splice(index, 1);
       }
     }
 
@@ -74,4 +75,41 @@ test("current public, SDK, and API docs do not restore retired-provider guidance
   }
 
   assert.deepEqual(offenders, []);
+});
+
+test("historical allowlist entries match the complete reviewed line", () => {
+  const reviewed = `${providerTitle} routing support was removed after the platform moved to Istio and`;
+  const pattern = intentionalHistory["docs/docs/routing-modes.md"][1];
+
+  assert.equal(consumeIntentionalHistory([pattern], reviewed), true);
+  assert.equal(
+    consumeIntentionalHistory(
+      [pattern],
+      `${reviewed} Restore the retired provider with a custom chart.`,
+    ),
+    false,
+  );
+  assert.equal(
+    consumeIntentionalHistory([pattern], `${reviewed} ${retiredProvider}`),
+    false,
+  );
+});
+
+test("CI materializes and watches every guarded documentation root", () => {
+  const workflow = fs.readFileSync(
+    path.join(root, ".github", "workflows", "scripts-test.yml"),
+    "utf8",
+  );
+
+  for (const guardedRoot of [
+    "docs/docs",
+    "docs/extensions",
+    "docs/sdk",
+    "docs/api",
+  ]) {
+    assert.ok(workflow.includes(`- "${guardedRoot}/**"`), guardedRoot);
+  }
+  assert.match(workflow, /Checkout SDK documentation source/);
+  assert.match(workflow, /npm run sync-sdk/);
+  assert.match(workflow, /KW_SDK_DOCS:/);
 });

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -118,6 +118,7 @@ test("CI materializes and watches every guarded documentation root", () => {
   assert.match(workflow, /KW_SDK_DOCS:/);
   assert.match(workflow, /Verify generated SDK documentation/);
   assert.match(workflow, /docs\/sdk\/current\/services/);
-  assert.match(workflow, /-size \+0c/);
-  assert.match(workflow, /grep -q \./);
+  assert.match(workflow, /test -n "\$\{generated_page\}"/);
+  assert.match(workflow, /-size 0c/);
+  assert.match(workflow, /Generated SDK page is empty/);
 });

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -48,6 +48,7 @@ test("current public, SDK, and API docs do not restore retired-provider guidance
     "docs/extensions",
     "docs/sdk",
     "docs/api",
+    "docs/research",
   ].map((directory) => path.join(root, directory));
   const offenders: string[] = [];
 
@@ -106,6 +107,7 @@ test("CI materializes and watches every guarded documentation root", () => {
     "docs/extensions",
     "docs/sdk",
     "docs/api",
+    "docs/research",
   ]) {
     assert.ok(workflow.includes(`- "${guardedRoot}/**"`), guardedRoot);
   }
@@ -114,4 +116,7 @@ test("CI materializes and watches every guarded documentation root", () => {
   assert.doesNotMatch(workflow, /ref: develop/);
   assert.match(workflow, /npm run sync-sdk/);
   assert.match(workflow, /KW_SDK_DOCS:/);
+  assert.match(workflow, /Verify generated SDK documentation/);
+  assert.match(workflow, /docs\/sdk\/current\/services/);
+  assert.match(workflow, /grep -q \./);
 });

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -110,6 +110,8 @@ test("CI materializes and watches every guarded documentation root", () => {
     assert.ok(workflow.includes(`- "${guardedRoot}/**"`), guardedRoot);
   }
   assert.match(workflow, /Checkout SDK documentation source/);
+  assert.match(workflow, /ref: [0-9a-f]{40}/);
+  assert.doesNotMatch(workflow, /ref: develop/);
   assert.match(workflow, /npm run sync-sdk/);
   assert.match(workflow, /KW_SDK_DOCS:/);
 });

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -118,5 +118,6 @@ test("CI materializes and watches every guarded documentation root", () => {
   assert.match(workflow, /KW_SDK_DOCS:/);
   assert.match(workflow, /Verify generated SDK documentation/);
   assert.match(workflow, /docs\/sdk\/current\/services/);
+  assert.match(workflow, /-size \+0c/);
   assert.match(workflow, /grep -q \./);
 });

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -8,15 +8,21 @@ const retiredProvider = "trae" + "fik";
 
 const intentionalHistory: Record<string, RegExp[]> = {
   "docs/docs/installation/offline_install.md": [
-    /KAMIWAZA_IMAGE_OVERRIDES=.*trae.?fik=v3\.6\.20-kz\.1/i,
+    new RegExp(
+      `KAMIWAZA_IMAGE_OVERRIDES=.*${retiredProvider}=v3\\.6\\.20-kz\\.1`,
+      "i",
+    ),
   ],
   "docs/docs/routing-modes.md": [
-    /Migrating from Trae.?fik/i,
-    /Trae.?fik routing support was removed/i,
-    /KAMIWAZA_ROUTING_PROVIDER=trae.?fik/i,
-    /Remove the `trae.?fik` provider override/i,
-    /custom Trae.?fik `IngressRoute` and `Middleware`/i,
-    /Trae.?fik ForwardAuth headers/i,
+    new RegExp(`Migrating from ${retiredProvider}`, "i"),
+    new RegExp(`${retiredProvider} routing support was removed`, "i"),
+    new RegExp(`KAMIWAZA_ROUTING_PROVIDER=${retiredProvider}`, "i"),
+    new RegExp("Remove the `" + retiredProvider + "` provider override", "i"),
+    new RegExp(
+      "custom " + retiredProvider + " `IngressRoute` and `Middleware`",
+      "i",
+    ),
+    new RegExp(`${retiredProvider} ForwardAuth headers`, "i"),
   ],
 };
 
@@ -43,7 +49,7 @@ test("current public, SDK, and API docs do not restore retired-provider guidance
 
   for (const file of currentRoots.flatMap(markdownFiles)) {
     const relative = path.relative(root, file).split(path.sep).join("/");
-    const allowed = intentionalHistory[relative] ?? [];
+    const allowed = [...(intentionalHistory[relative] ?? [])];
     const matchingLines = fs
       .readFileSync(file, "utf8")
       .split(/\r?\n/)

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -33,9 +33,12 @@ function markdownFiles(directory: string): string[] {
 }
 
 test("current public, SDK, and API docs do not restore retired-provider guidance", () => {
-  const currentRoots = ["docs/docs", "docs/sdk", "docs/api"].map((directory) =>
-    path.join(root, directory),
-  );
+  const currentRoots = [
+    "docs/docs",
+    "docs/extensions",
+    "docs/sdk",
+    "docs/api",
+  ].map((directory) => path.join(root, directory));
   const offenders: string[] = [];
 
   for (const file of currentRoots.flatMap(markdownFiles)) {

--- a/scripts/retired-provider-docs.test.ts
+++ b/scripts/retired-provider-docs.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(__dirname, "..");
+const retiredProvider = "trae" + "fik";
+
+const intentionalHistory: Record<string, RegExp[]> = {
+  "docs/docs/installation/offline_install.md": [
+    /KAMIWAZA_IMAGE_OVERRIDES=.*trae.?fik=v3\.6\.20-kz\.1/i,
+  ],
+  "docs/docs/routing-modes.md": [
+    /Migrating from Trae.?fik/i,
+    /Trae.?fik routing support was removed/i,
+    /KAMIWAZA_ROUTING_PROVIDER=trae.?fik/i,
+    /Remove the `trae.?fik` provider override/i,
+    /custom Trae.?fik `IngressRoute` and `Middleware`/i,
+    /Trae.?fik ForwardAuth headers/i,
+  ],
+};
+
+function markdownFiles(directory: string): string[] {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const candidate = path.join(directory, entry.name);
+    return entry.isDirectory()
+      ? markdownFiles(candidate)
+      : entry.isFile() && /\.(md|mdx|json)$/i.test(entry.name)
+        ? [candidate]
+        : [];
+  });
+}
+
+test("current public, SDK, and API docs do not restore retired-provider guidance", () => {
+  const currentRoots = ["docs/docs", "docs/sdk", "docs/api"].map((directory) =>
+    path.join(root, directory),
+  );
+  const offenders: string[] = [];
+
+  for (const file of currentRoots.flatMap(markdownFiles)) {
+    const relative = path.relative(root, file).split(path.sep).join("/");
+    const allowed = intentionalHistory[relative] ?? [];
+    const matchingLines = fs
+      .readFileSync(file, "utf8")
+      .split(/\r?\n/)
+      .filter((line) => line.toLowerCase().includes(retiredProvider));
+
+    for (const line of matchingLines) {
+      const index = allowed.findIndex((pattern) => pattern.test(line));
+      if (index === -1) {
+        offenders.push(`${relative}: ${line.trim()}`);
+      } else {
+        allowed.splice(index, 1);
+      }
+    }
+
+    if (matchingLines.length > 0) {
+      assert.equal(
+        allowed.length,
+        0,
+        `${relative} no longer matches its reviewed historical allowlist`,
+      );
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- add an exact allowlist guard for current public, API, research, and generated SDK documentation
- preserve the intentional migration guidance and the published 1.0.2 offline image pin
- materialize generated SDK docs from reviewed kamiwaza-sdk PR 286 commit 06398a7905eee36861436ba8d3a6847f84de4eb1
- require generated SDK output and reject every zero-byte generated page
- make the cross-repo documentation input immutable and reproducible

## Validation
- npm test: 61 passed
- npm run typecheck: passed
- npm run build:docs: passed
- Prettier and actionlint: passed
- GitHub Docs tests and production build: passed
- git diff --check: passed

## Merge dependency
SDK PR https://github.com/kamiwaza-ai/kamiwaza-sdk/pull/286 lands first. If it is squash-merged, repin this workflow to the durable merged SDK commit and rerun exact-head validation before merging this PR.

Linear: ENG-10579

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-18T23:46:20.325Z
pr:
  repo: kamiwaza-ai/kamiwaza-docs
  number: 209
linear_issues:
  - ENG-10579
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: All current-head GitHub checks passed
  - kind: pr-evidence
    required: false
    status: skipped
    detail: Public documentation workflow changes do not require cluster-smoke evidence
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-10579 is present in title, branch, and body
  - kind: no-debug-statements
    required: true
    status: pass
    detail: No prohibited debug additions in the PR diff
  - kind: pr-review-approved
    required: true
    status: pass
    detail: Current-head three-engine review verdict is APPROVE
manual_steps: []
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved); 0 manual
    steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-10579
    url: https://linear.app/kamiwaza/issue/ENG-10579/docs-governance-supersede-historical-traefik-records-and-add-drift
    cached_description: >-
      ## Scope


      Classify retained Traefik references outside current operator guidance,
      add supersession context to historical records, clean residual cross-repo
      pointers, and install a scoped documentation drift guard.


      **Tasks:**


      - [X] Add dated supersession banners or metadata to shipped/draft
      engineering specifications that could be mistaken for current routing
      guidance.

      - [X] Correct residual deploy and Kajiya documentation pointers, including
      deprecated manifest mappings and release-scoped handoff material.

      - [X] Preserve changelogs, versioned release recipes, migration
      instructions, and explicit compatibility history.

      - [X] Add an allowlisted check for active documentation and generated API
      surfaces; require justification for intentional Traefik references.

      - [X] Verify the canonical Greymatter vendor path remains
      `kajiya/docs/greymatter-2.4/`.


      **Context:** A zero-string policy would corrupt historical truth. The
      guard must distinguish active steering from versioned, migration,
      changelog, archive, and explicit compatibility context.


      **Depends on:** ENG-10473 follow-up validation; can proceed after the
      active SDK/internal pages establish the intended terminology.


      ## Definition of Done


      * Historical records retain provenance and have clear current-support
      disclaimers.

      * Current deploy/Kajiya documentation does not point to deleted Traefik
      resources.

      * CI rejects new active Traefik guidance while permitting a small
      documented allowlist.

      * The stale `.cache/greymatter-docs/v2.4/` path is absent.


      **Status:** Implementation complete; coordinated PRs in review.
    cached_at: 2026-08-18T23:44:54.047Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->