### PR TITLE
ENG-10588: correct 1.2 inference install guidance

### DIFF
--- a/docs/docs/installation/installation_process.md
+++ b/docs/docs/installation/installation_process.md
@@ -30,7 +30,7 @@ Both methods install the same platform. The difference is only how the installer
 | RHEL-compatible 9.x | ✅ | ✅ |
 | macOS | ✅ | — |
 
-> All installs require a Kamiwaza Prod license key. GPU acceleration (NVIDIA CUDA, AMD ROCm, or NVIDIA vLLM) is optional and selected during installation — see [Online Installation](online_install.md#gpu-and-inference-images) and the [System Requirements](system_requirements.md).
+> All installs require a Kamiwaza Prod license key. GPU acceleration (NVIDIA CUDA, AMD ROCm, or NVIDIA vLLM) is optional. The default k0s runtime pulls inference images when needed; Kind installations can use an [optional raw image preload](online_install.md#optional-raw-image-preload). See [System Requirements](system_requirements.md) for supported host software.
 
 ## What Happens During Installation
 

--- a/docs/docs/installation/online_install.md
+++ b/docs/docs/installation/online_install.md
@@ -1,6 +1,6 @@
 # Online Installation
 
-The online installer is the recommended way to install Kamiwaza 1.0.2 on an internet-connected host. It is a single self-contained script that bundles the deploy payload, playbooks, and Helm chart dependencies. Host tools are installed from your OS package manager, and the Kamiwaza platform images are pulled from Keygen.
+The online installer is the recommended way to install Kamiwaza 1.2.0 on an internet-connected host. It is a single self-contained script that bundles the deploy payload, playbooks, and Helm chart dependencies. Host tools are installed from your OS package manager, and the Kamiwaza platform images are pulled from Keygen.
 
 **Supported hosts:**
 
@@ -64,7 +64,7 @@ The online installer is the recommended way to install Kamiwaza 1.0.2 on an inte
 Download the installer and its checksum, verify the checksum, then make the installer executable:
 
 ```bash
-base_url="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-online-installer/@kamiwaza-online-installer/1.0.2"
+base_url="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-online-installer/@kamiwaza-online-installer/1.2.0"
 
 for file in kamiwaza-online-install.sh kamiwaza-online-install.sh.sha256; do
   curl -fsSLO "${base_url}/${file}"
@@ -102,31 +102,36 @@ Before extracting its payload or installing any prerequisites, the installer val
 
 > Passing the license key through the `KEYGEN_LICENSE_KEY` environment variable keeps it out of the installer's command-line arguments, where it could otherwise be visible in `ps` output or logs. You can also use `KAMIWAZA_KEYGEN_LICENSE_KEY` or the `--keygen-license-key` option. If you also want to keep the key out of your interactive shell history, set the variable from somewhere other than the command line — for example a `.env` file you source, or your shell profile — following your environment's own conventions for handling secrets.
 
-## GPU and Inference Images
+## Optional raw image preload
 
-Large inference images are not all downloaded during installation. To enable GPU-accelerated inference, add the one image package that matches your hardware with `--keygen-raw-image-package`:
+The installer normally uses `k0s-podman`, and the charts pull inference images from the authenticated registry when a model is deployed. The `--keygen-raw-image-packages` option applies only to the legacy Kind runtime. It preloads a space- or comma-separated replacement list of raw image archives into the Kind nodes.
 
-| Hardware | Package |
+The default list is `kamiwaza-opensearch kamiwaza-vllm kamiwaza-kaizen-agent kamiwaza-kaizen-backend kamiwaza-omniparse`. A custom list replaces that default, so include every default package that the installation still needs.
+
+Kamiwaza 1.2.0 provides the following hardware-specific raw package basenames:
+
+| Hardware and engine | Package basename |
 | --- | --- |
-| NVIDIA with CUDA 12 | `kamiwaza-llamacpp-cuda12` |
-| NVIDIA with CUDA 13 | `kamiwaza-llamacpp-cuda13` |
-| AMD CDNA | `kamiwaza-llamacpp-rocm-cdna` |
-| AMD RDNA | `kamiwaza-llamacpp-rocm-rdna` |
-| AMD gfx1151 | `kamiwaza-llamacpp-rocm-gfx1151` |
-| NVIDIA vLLM (Ampere or newer) | `kamiwaza-vllm` |
+| NVIDIA with CUDA 12, llama.cpp | `kamiwaza-llamacpp-cuda12` |
+| NVIDIA with CUDA 13, llama.cpp | `kamiwaza-llamacpp-cuda13` |
+| NVIDIA amd64, vLLM | `kamiwaza-vllm` |
+| NVIDIA ARM64, including DGX Spark, vLLM | `kamiwaza-vllm-cuda-arm64` |
+| AMD CDNA, llama.cpp | `kamiwaza-llamacpp-rocm-cdna` |
+| AMD RDNA, including gfx1151, llama.cpp | `kamiwaza-llamacpp-rocm-rdna` |
 
-For example, to install on an NVIDIA CUDA 12 host:
+For example, this Kind installation replaces the default amd64 vLLM archive with the ARM64 vLLM archive while retaining the other default packages:
 
 ```bash
 KEYGEN_LICENSE_KEY="<kamiwaza-prod-license-key>" \
 ./kamiwaza-online-install.sh \
-  --keygen-raw-image-package kamiwaza-llamacpp-cuda12 \
+  --keygen-raw-image-packages "kamiwaza-opensearch kamiwaza-vllm-cuda-arm64 kamiwaza-kaizen-agent kamiwaza-kaizen-backend kamiwaza-omniparse" \
   --domain <domain> \
   --admin-password "<initial-admin-password>" \
-  -y
+  -y \
+  -e k8s_runtime=kind
 ```
 
-The same `-e storage_host_prep_virtual_block_size=80G` note above applies here. The installer always includes the required core and Kaizen agent images. If your NVIDIA host uses Secure Boot, also see [NVIDIA Secure Boot](nvidia-secure-boot.md).
+The same `-e storage_host_prep_virtual_block_size=80G` note above applies here. The core image follows the installer's required image path; retain the Kaizen packages in a custom raw list when installing Kaizen. If your NVIDIA host uses Secure Boot, also see [NVIDIA Secure Boot](nvidia-secure-boot.md).
 
 ## Common Options
 
@@ -143,7 +148,7 @@ Frequently used **install arguments**:
 Frequently used **installer options**:
 
 - `--keygen-license-key <key>`: Keygen license key used for image pulls. Prefer the `KEYGEN_LICENSE_KEY` environment variable so the key does not appear in the installer's command-line arguments.
-- `--keygen-raw-image-package <name>`: Preload one optional image package (see [GPU and Inference Images](#gpu-and-inference-images)). Repeat for each package you need.
+- `--keygen-raw-image-packages <list>`: Replace the raw image package preload list for a Kind installation. Supply a space- or comma-separated list; the option has no effect on the default `k0s-podman` runtime. See [Optional raw image preload](#optional-raw-image-preload).
 - `--keep-extract`: Preserve the extracted payload after the install.
 - `--phase1-only`: Stop after host prerequisites and cluster bootstrap.
 

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -1,5 +1,7 @@
 # System Requirements
 
+These requirements apply to Kamiwaza 1.2.0.
+
 ## Hardware Requirements
 
 ### CPU
@@ -130,18 +132,22 @@ The Kamiwaza installer provisions the container runtime, local Kubernetes cluste
 Install the appropriate driver for your GPU hardware:
 
 **NVIDIA GPUs:**
-| Component | Requirement | Installation Guide |
+| Component | Requirement | Installation guide |
 |-----------|-------------|-------------------|
-| NVIDIA Driver | 550-server or later | [NVIDIA Driver Downloads](https://www.nvidia.com/download/index.aspx) |
-| NVIDIA Container Toolkit | Required for GPU containers | [Container Toolkit Install](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) |
+| NVIDIA driver for CUDA 12 images | 550-server or later | [NVIDIA driver downloads](https://www.nvidia.com/download/index.aspx) |
+| NVIDIA driver for CUDA 13 images and DGX Spark | 580.65.06 or later | [CUDA 13 release notes](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/index.html) |
+| NVIDIA Container Toolkit | Required for GPU containers | [Container Toolkit installation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) |
+
+DGX Spark software releases include the matching R580 driver and CUDA 13 stack. See the [DGX Spark release notes](https://docs.nvidia.com/dgx/dgx-spark/release-notes.html) for the versions in each release.
 
 **AMD GPUs (ROCm):**
-| Component | Requirement | Installation Guide |
+| Component | Requirement | Installation guide |
 |-----------|-------------|-------------------|
-| ROCm | 7.1.1+ (see note for gfx1151) | [ROCm Installation](https://rocm.docs.amd.com/en/latest/deploy/linux/index.html) |
+| ROCm for Ryzen AI Max+ 395 (gfx1151) | ROCm 7.2.1 or later on Ubuntu 24.04 | [Ryzen native Linux compatibility](https://rocm.docs.amd.com/projects/radeon-ryzen/en/docs-7.2.1/docs/compatibility/compatibilityryz/native_linux/native_linux_compatibility.html) |
+| Other AMD GPUs | A ROCm release that lists the GPU and operating system as supported | [ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html) |
 | Container GPU access | `/dev/kfd` and `/dev/dri` exposed to the container runtime | [ROCm containers guide](https://rocm.docs.amd.com/en/latest/how-to/docker.html) |
 
-> **Note:** AMD Strix Halo (gfx1151) requires ROCm 7.10.0 preview or later. See [ROCm 7.10.0 Preview](https://rocm.docs.amd.com/en/7.10.0-preview/) - this is a preview release and not intended for production use.
+AMD lists the Radeon 8060S in Ryzen AI Max+ 395 systems as production-supported on the ROCm 7.2.x native Linux path. Follow the [Ryzen native Linux installation guide](https://rocm.docs.amd.com/projects/radeon-ryzen/en/docs-7.2/docs/install/installryz/native_linux/install-ryzen.html); the retired ROCm 7.10 preview path is not required.
 
 ### Auto-Installed by Kamiwaza
 
@@ -162,7 +168,8 @@ Use these commands to verify your system meets the requirements before installat
 ```bash
 # Check NVIDIA driver
 nvidia-smi
-# Expected: Driver version 550 or later
+# Expected for CUDA 12 images: Driver version 550 or later
+# Expected for CUDA 13 images and DGX Spark: Driver version 580.65.06 or later
 # Should display GPU name, driver version, and CUDA version
 
 # Check NVIDIA Container Toolkit
@@ -181,7 +188,7 @@ rocm-smi
 
 # Check ROCm version
 cat /opt/rocm/.info/version
-# Expected: 7.1.1 or later (7.10.0+ for Strix Halo gfx1151)
+# Expected for Ryzen AI Max+ 395 (gfx1151): 7.2.1 or later
 
 # Verify GPU device access
 ls -la /dev/kfd /dev/dri
@@ -549,7 +556,7 @@ AMD's Strix Halo platform provides powerful AI inference in a compact form facto
 
 ## Version Compatibility
 
-- NVIDIA Driver: 550-server or later
+- NVIDIA driver: 550-server or later for CUDA 12 images; 580.65.06 or later for CUDA 13 images and DGX Spark
 - ETCD: 3.5 or later
 
 ---


### PR DESCRIPTION
## Summary

- document the release/1.2 raw-image package names and replacement-list installer option
- distinguish default k0s registry pulls from Kind-only raw-image preloads
- align NVIDIA ARM64, CUDA 13, and AMD Strix Halo requirements with official vendor guidance

## Release gate

This PR intentionally remains draft until the Kamiwaza 1.2.0 Keygen installer URL exists and the public documentation package version advances from 1.0.2.

## Validation

- npm run typecheck
- npm run build:docs
- changed-file documentation style check: zero errors
- git diff --check

Linear: https://linear.app/kamiwaza/issue/ENG-10588