### PR TITLE
docs(federation): clarify cluster-name and selector behavior (ENG-10633)

### DIFF
--- a/docs/docs/federation/api-reference.md
+++ b/docs/docs/federation/api-reference.md
@@ -99,10 +99,21 @@ The mesh proxy forwards requests to remote federated clusters. Every request is 
 ### Proxy Path Pattern
 
 ```
-{METHOD} /api/mesh/{federation_name}/{remote_path}
+{METHOD} /api/mesh/{federation_selector}/{remote_path}
 ```
 
-The `{federation_name}` is the `remote_cluster_name` from the federation record. The `{remote_path}` is the path on the remote cluster (without the `/api` prefix — it's re-added by the proxy).
+`{federation_selector}` accepts an exact federation UUID, an exact remote cluster
+UUID, or the federation record's `remote_cluster_name` as an exact or prefix
+match. Use the federation UUID for automation. A name or prefix that matches
+multiple paired rows returns `409 mesh_target_ambiguous` instead of choosing a
+peer.
+
+`remote_cluster_name` is the peer label stored when the federation is created
+or paired. Ping does not refresh it after a peer rename. The cached old name
+and federation UUID continue to work; re-pairing adopts the new display name.
+
+`{remote_path}` is the path on the remote cluster. The proxy adds `/api` when
+the path does not already begin with `/api` or `/runtime`.
 
 **Authorization:** Mesh egress is **authenticated-only** — any authenticated local
 user may call `/api/mesh/{fed}/*`. There is **no** `federation:operator` gate on the

--- a/docs/docs/federation/operations.md
+++ b/docs/docs/federation/operations.md
@@ -41,6 +41,30 @@ curl --fail --silent --show-error \
 
 ## 2. Mesh Proxy Troubleshooting
 
+### Duplicate or stale cluster names
+
+**Symptoms:** Federation cards show the same peer label, a renamed peer still
+shows its old label, a new name returns `404 mesh_target_not_found`, or a shared
+name or prefix returns `409 mesh_target_ambiguous`.
+
+**Diagnosis:** Read the stored selector and UUID for every active federation:
+
+```bash
+curl --fail --silent --show-error \
+  --header "Authorization: Bearer $LOCAL_TOKEN" \
+  "$LOCAL_API/cluster/federations?status=PAIRED" | jq \
+  '.[] | {id, remote_cluster_id, remote_cluster_name, status}'
+```
+
+`remote_cluster_name` is stored when the federation is created or paired.
+Renaming the peer changes its local cluster row, but ping does not refresh the
+cached federation row.
+
+**Resolution:** Use the exact federation UUID for automation. Assign a distinct
+`core.initialClusterName` on every cluster, then re-pair existing federations to
+adopt renamed peer labels. Until re-pairing, the cached old name and federation
+UUID continue to select the existing pair.
+
 ### HMAC Signature Failures (403)
 
 **Symptoms:** 403 response on mesh proxy requests. No `rebac_denied` detail in the response body -- the request is rejected before reaching the endpoint.

--- a/docs/docs/federation/setup.md
+++ b/docs/docs/federation/setup.md
@@ -26,6 +26,31 @@ explicitly enables `ALLOW_UNTRUSTED_FEDERATION`.
   clusters.
 - A native-realm cluster administrator on each cluster.
 
+### Set display names before pairing
+
+Supported Helmfile installations derive the cluster display name from the first
+label of a custom DNS domain. Default or non-DNS domains fall back to the short
+install hostname. Raw Helm installations retain the `Default Cluster` chart
+value.
+
+Set an explicit name in the persistent site overlay when the derived name is not
+suitable:
+
+```yaml
+# deploy/cluster/values/overrides.yaml
+core:
+  initialClusterName: "fed-a"
+```
+
+Use a distinct value on each cluster and apply the normal Helmfile sync before
+pairing. A later change renames the local cluster after the scheduler restarts,
+but paired peers retain their cached old name. Ping does not refresh that name;
+re-pair the federation to refresh peer labels and name-based selectors.
+
+The cluster display name is separate from the hostname in `remote_ips`. The
+display name labels and selects a federation, while the hostname controls the
+HTTP Host header and TLS SNI.
+
 For an IP-based connection, provide both the connect address and the hostname:
 
 ```json


### PR DESCRIPTION
## Summary

Document how federation cluster display names are derived, overridden, cached, and resolved by the mesh proxy.

## Changes

- Add setup guidance for distinct cluster names before pairing.
- Add operations guidance for duplicate and stale names, including the exact-UUID workaround and 409 ambiguity behavior.
- Correct the mesh selector reference: federation UUID, remote-cluster UUID, and exact/prefix name selection.
- Clarify that peer-name snapshots require re-pairing after a rename.

## Validation

- `npm run build:docs`: pass (existing archived-link/anchor warnings only).
- Documentation style validation: 0 errors (existing warnings only).
- `git diff --check`: pass.

## Scope boundary

This PR fixes ENG-10633 name and selector semantics. The broader release/1.2.0 federation API-reference reconciliation is tracked separately in ENG-10665.

## Tracking

- ENG-10633
- ENG-10665
- Related deploy fix: https://github.com/kamiwaza-internal/deploy/pull/843

