### PR TITLE
ENG-10771: document offline install prerequisites and image contract

### DIFF
--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -487,6 +487,17 @@ sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
 The release/1.2.0 RPM overlay accepts `--yes` for noninteractive bootstrap.
 Do not pipe repeated `yes` or press Enter to drive a long unattended install.
 
+On Red Hat 9, if the bootstrap exits nonzero reporting a bundled command
+missing, expose the bundled tools on sudo's path and re-run it unchanged:
+
+```bash
+for tool in helm helmfile k0s kind kubectl; do
+  sudo ln -sfn "/usr/local/bin/${tool}" "/usr/bin/${tool}"
+done
+```
+
+The second run reports `==> Bootstrap complete`.
+
 The install runs as root, so verify tools using root's actual environment:
 
 ```bash
@@ -682,6 +693,15 @@ contract names another runtime, stop and use that runtime's runbook.
 `KAMIWAZA_OFFLINE_EXTRA_IMAGES` is a Kajiya wrap-build input, not an installer
 environment variable; record it in build provenance when it is nonempty, but do
 not add it to this runtime contract.
+
+Take `KAMIWAZA_IMAGE_TAG` and `KAMIWAZA_IMAGE_OVERRIDES` from the same run; the
+bulk tag also moves infrastructure images that carry their own pinned versions.
+For 1.2.0 those two values are:
+
+```json
+  "KAMIWAZA_IMAGE_TAG": "release-1.2.0",
+  "KAMIWAZA_IMAGE_OVERRIDES": "postgres:v18.4,keycloak:release-1.2.0,etcd:v3.6.10"
+```
 
 > **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
 > [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -57,6 +57,10 @@ Storage requirements are the same across all platforms.
 - **Recommended**: 200GB+ free disk space
 - Additional space for `/opt/kamiwaza` persistence
 
+> **Linux:** additionally size `/var/lib` for the Ceph OSD backing image —
+> 700GiB by default, plus a 1GiB margin. Set `KAMIWAZA_ROOK_OSD_IMAGE_SIZE`
+> before installing to use a smaller image.
+
 #### Capacity Planning
 
 | Component | Minimum | Recommended | Notes |
@@ -204,6 +208,10 @@ nproc
 # Check available disk space
 df -h /
 # Expected: At least 100GB free (200GB+ recommended)
+
+# Linux: check /var/lib separately for the Ceph OSD image
+df -h /var/lib
+# Expected: OSD image size + 1GiB (about 701GiB at the default)
 ```
 
 ---

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -487,6 +487,17 @@ sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
 The release/1.2.0 RPM overlay accepts `--yes` for noninteractive bootstrap.
 Do not pipe repeated `yes` or press Enter to drive a long unattended install.
 
+On Red Hat 9, if the bootstrap exits nonzero reporting a bundled command
+missing, expose the bundled tools on sudo's path and re-run it unchanged:
+
+```bash
+for tool in helm helmfile k0s kind kubectl; do
+  sudo ln -sfn "/usr/local/bin/${tool}" "/usr/bin/${tool}"
+done
+```
+
+The second run reports `==> Bootstrap complete`.
+
 The install runs as root, so verify tools using root's actual environment:
 
 ```bash
@@ -682,6 +693,15 @@ contract names another runtime, stop and use that runtime's runbook.
 `KAMIWAZA_OFFLINE_EXTRA_IMAGES` is a Kajiya wrap-build input, not an installer
 environment variable; record it in build provenance when it is nonempty, but do
 not add it to this runtime contract.
+
+Take `KAMIWAZA_IMAGE_TAG` and `KAMIWAZA_IMAGE_OVERRIDES` from the same run; the
+bulk tag also moves infrastructure images that carry their own pinned versions.
+For 1.2.0 those two values are:
+
+```json
+  "KAMIWAZA_IMAGE_TAG": "release-1.2.0",
+  "KAMIWAZA_IMAGE_OVERRIDES": "postgres:v18.4,keycloak:release-1.2.0,etcd:v3.6.10"
+```
 
 > **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
 > [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)

--- a/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
+++ b/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
@@ -57,6 +57,10 @@ Storage requirements are the same across all platforms.
 - **Recommended**: 200GB+ free disk space
 - Additional space for `/opt/kamiwaza` persistence
 
+> **Linux:** additionally size `/var/lib` for the Ceph OSD backing image —
+> 700GiB by default, plus a 1GiB margin. Set `KAMIWAZA_ROOK_OSD_IMAGE_SIZE`
+> before installing to use a smaller image.
+
 #### Capacity Planning
 
 | Component | Minimum | Recommended | Notes |
@@ -204,6 +208,10 @@ nproc
 # Check available disk space
 df -h /
 # Expected: At least 100GB free (200GB+ recommended)
+
+# Linux: check /var/lib separately for the Ceph OSD image
+df -h /var/lib
+# Expected: OSD image size + 1GiB (about 701GiB at the default)
 ```
 
 ---


### PR DESCRIPTION
Findings from validating the 1.2.0 offline install end to end on clean RHEL 9 hosts during a customer escalation (ENG-10771).

## Changes

**`offline_install.md` section 3** — on Red Hat 9 the prerequisite bootstrap exits nonzero reporting a bundled command missing even though every tool installed correctly, because it installs into `/usr/local/bin` which sudo's `secure_path` omits. It names one tool at a time, so repairing only the named tool moves the failure to the next. Added the symlink loop for the whole bundled set plus a re-run.

**`offline_install.md` section 5** — the runtime contract carried `<exact comma-separated map>` as a placeholder with no values anywhere in the document. Recorded the 1.2.0 bulk tag and override map. This is the gap that produced the escalation: the published bundle ships `postgres:v18.4` and `keycloak:release-1.2.0`, while an install without the map requests `v18.4-kz.1` and `v26.6.4` and stalls in `ImagePullBackOff`. `etcd:v3.6.10` is required because the bulk tag otherwise moves etcd off its pinned version.

**`system_requirements.md`** — host preparation fails unless the filesystem backing `/var/lib` has the Ceph OSD image size plus a 1GiB margin free (about 701GiB at the default), which the stated 100GB/200GB figures do not cover. Added the note and a separate `df -h /var/lib` check.

## Why `versioned_docs/` is edited here

Normally only `docs/docs/` is edited. 1.2.0 is the published version these pages serve, so a current-docs-only change would not reach the readers actually hitting this. The two copies were byte-identical beforehand and both carry the same edit.

Regenerating the snapshot through the documented versioning path was not used: nine unrelated files have since drifted between the current and versioned trees, so a regeneration would pull that drift into the published 1.2.0 version. Reconciling those is worth doing separately.

## Validation

The documented sequence was executed on clean RHEL 9.8 hosts (m5.4xlarge, 16 vCPU / 61GB / 1TB). With the recorded map the platform installs green — core, auth, extension and placement operators all Running, umbrella Helm release deployed, authenticated API returning 200, and the App Garden catalog loading with deployable applications.

## Notes for review

- The extension phase needed no change: section 8 already runs the helper from `BUNDLE_ROOT` with `--bundle-root` alone, which is correct.
- Related: ENG-9591 covers the storage floor understatement more broadly; ENG-10652 covers the wrap-versus-install tag mismatch.
- The offline runbook rewrite (ENG-10370) landed on `main` and `release/1.2.0` but was never back-merged to `develop`, which still carries the 273-line 1.0.2-era page. Instructions circulated to the customer derived from that stale page. Worth reconciling separately, or edits authored on `develop` will regress the published 1.2.0 page.