### PR TITLE
ENG-10771: publish the validated 1.2.0 install documentation

### DIFF
--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -27,7 +27,7 @@ findmnt -T /var/lib
 lsblk -f
 ```
 
-The host's static hostname must be **55 characters or fewer**. Longer names
+The host's static hostname must be **54 characters or fewer**. Longer names
 overflow the certificate subject fields the cluster generates:
 
 ```bash
@@ -58,9 +58,17 @@ The extension-bundle filename is likewise release-specific. The value below matc
 
 ```bash
 export KEYGEN_TOKEN="<license-key>"
-export RELEASE="1.2.0"
-export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
-export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
+
+# The whole block runs fail-fast in a subshell: any failed download, checksum, or
+# reassembly stops it immediately rather than leaving partial artifacts to be
+# transferred or installed. The trap removes the credential file on every exit
+# path, including failure.
+(
+set -euo pipefail
+
+RELEASE="1.2.0"
+EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
+BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 
 sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
 cd /opt/kamiwaza/prereqs
@@ -71,6 +79,7 @@ cd /opt/kamiwaza/prereqs
 # that directory is transferred to the target host.
 KEYGEN_HEADER="$(mktemp)"
 chmod 600 "${KEYGEN_HEADER}"
+trap 'rm -f "${KEYGEN_HEADER}"' EXIT
 printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" > "${KEYGEN_HEADER}"
 
 for file in \
@@ -128,8 +137,7 @@ sha256sum -c "${EXT_BUNDLE}.sha256"
 grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
   | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
 sha256sum -c kamiwaza-prod.sha256
-
-rm -f "${KEYGEN_HEADER}"
+)
 ```
 
 The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
@@ -228,7 +236,7 @@ Stage the extension bundle before installing the platform:
 ```bash
 cd /opt/kamiwaza/prereqs
 
-EXT_BUNDLE="${EXT_BUNDLE:-$(ls -1 kamiwaza-extensions-bundle-*.tar.gz | tail -1)}"
+EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 rm -rf /tmp/kamiwaza-ext-extract
 mkdir -p /tmp/kamiwaza-ext-extract
 tar -xzf "$EXT_BUNDLE" -C /tmp/kamiwaza-ext-extract

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -114,9 +114,15 @@ cat "${EXT_BUNDLE}".part-{000..004} > "${EXT_BUNDLE}"
 ln -sf kamiwaza-helm.00.tar kamiwaza-helm.tar
 sha256sum -c kamiwaza-helm.sha256
 sha256sum -c "${EXT_BUNDLE}.sha256"
+
+# Verify the prerequisites RPM against the hash recorded in release_origination.md.
+# Step 2 installs it as root, so establish its integrity first.
+grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
+  | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
+sha256sum -c kamiwaza-prod.sha256
 ```
 
-The `release_origination.md` artifact records the build provenance and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
+The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
 
 > If a download stalls, rerun the block — `curl --continue-at -` resumes partial files. If you downloaded on a separate connected machine, transfer the entire `/opt/kamiwaza/prereqs` directory to the same path on the target host before continuing.
 

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -1,1446 +1,348 @@
 # Offline Installation
 
-This guide installs Kamiwaza on a standalone RHEL 9 x86_64 host from a
-previously published offline bundle. The target does not pull product images
-during the install. Whether the **host bootstrap** can also run without any
-network access depends on the selected bundle: do not call an installation
-fully air-gapped unless that exact build was tested with disconnected RHEL
-package sources.
+The offline installer is for **air-gapped or restricted RHEL 9 environments** with no outbound internet access on the target host. You download the Kamiwaza bundle on a connected machine, transfer it to the target host, and install without pulling anything from the internet during installation.
 
-> This is an advanced, operator-driven path. If the target has normal internet
-> access, use [Online Installation](online_install.md). This page describes the
-> standalone `k0s-podman` topology; an EKS recipe is not an alternative source
-> of truth for this installation.
+**Supported host:** RHEL-compatible 9.x (x86_64).
 
-An offline deployment has three separate completion levels:
+> This is an advanced, operator-driven path. If your host has internet access, use the simpler [Online Installation](online_install.md) instead.
 
-1. **Core installed:** the platform is healthy and login works.
-2. **Bundle installed:** bundled extension images are loaded and the live
-   catalog is imported.
-3. **Release parity (publisher qualification):** one bundled extension is
-   deployed, verified, and removed through the supported catalog/API path, plus
-   any additional gates recorded by the selected release run.
+## Prerequisites
 
-Do not report level 2 or 3 after only pre-staging the extension catalog.
-Level 3 requires the private, hash-recorded Kajiya gate inputs from the selected
-run and is performed by Kamiwaza release engineers; it is not a customer
-installation requirement. A customer handoff without those internal inputs can
-complete and report levels 1 and 2.
+- A **Kamiwaza Prod license key**, used to download the bundle artifacts from Keygen.
+- A RHEL-compatible 9.x host (x86_64) that meets the [System Requirements](system_requirements.md).
+- **Free disk space, on the right filesystems.** The offline flow stages large artifacts and provisions cluster storage under `/`, `/tmp`, and `/var/lib`. Confirm each path has room on the **volume that actually backs it** — on hosts with LVM or separate partitions (most cloud RHEL images ship this way), a large total disk does **not** help if `/var` is a small separate volume. Recommended free space:
+  - **`/var/lib` ≥ 350 GB**, assuming `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G` is set in [Step 5](#step-5-install-kamiwaza). Without that export the OSD image defaults to 700 GB and you need **1.1 TB** instead. The OSD image is preallocated at install time and also holds all stateful data, so size it for the data you expect to keep, not just to complete the install.
+  - **`/tmp` ≥ 25 GB** — bundle extraction and install scratch space.
+  - **`/` ≥ 50 GB** — the downloaded bundle and its recombined tarballs under `/opt/kamiwaza/prereqs` (~25 GB), plus installed tooling under `/opt` and `/usr/local`.
 
-## Before you begin
+  A small default `/tmp` or `/var` is the most common cause of install failure. It surfaces in one of three ways, none of which mentions disk space directly: the preflight aborts at `storage_host_prep` with an `fs-virtual-block free space` error; an image import fails with `no space left on device`; or the helmfile sync fails roughly ten minutes in with `Progress deadline exceeded` on the `cert-manager` deployments and `FailedScheduling: 1 node(s) had untolerated taint(s)` on their pods — that last one is the kubelet disk-pressure taint, not a cert-manager fault. Grow the backing LV or partition (or mount adequate storage at `/var/lib`) **before** you begin.
+- A machine with internet access to download the bundle, and a way to transfer files to the target host.
 
-You need:
-
-- A supported RHEL-compatible 9.x x86_64 host that meets the
-  [System Requirements](system_requirements.md).
-- A host name no longer than 54 characters.
-- A Kamiwaza license and access to one **immutable** release or Kajiya run.
-- A connected staging machine if the target cannot download the artifacts.
-- Root access on the target. For a remote private host, Session Manager (SSM)
-  or an equivalent managed shell is preferred over SSH.
-- Bash 4.4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
-  `tar` on every machine that runs the snippets. They use GNU options and do not
-  run in stock macOS Bash; use a trusted Linux staging host or container when
-  the connected workstation is a Mac. If the target has no reachable RHEL
-  repositories, those tools and all OS packages required by the selected
-  prerequisite bootstrap must already be available through a trusted local
-  repository or the verified handoff.
-
-### Check the actual filesystems
-
-The bundle, extracted extensions, container images, and the Rook/Ceph OSD can
-live on different filesystems. A large virtual disk is not proof that
-`/var/lib` or `/tmp` has room; cloud RHEL images commonly put `/var` on a small
-logical volume.
-
-Before transfer, calculate the compressed bundle total, the extracted
-extension size, installer scratch, image-store growth, the configured OSD image
-size, and operational headroom. Then check the backing filesystems:
+Confirm which filesystem actually backs each path before you transfer anything — a
+large total disk tells you nothing if `/var` is a separate logical volume:
 
 ```bash
 df -hT / /tmp /var/tmp /var/lib /opt
-findmnt -T /tmp
-findmnt -T /var/tmp
 findmnt -T /var/lib
-findmnt -T /opt
 lsblk -f
 ```
 
-There is no release-independent free-space floor for this path. The verified
-staging copy, `/opt/kamiwaza/prereqs` copy, logical-wrap scratch space under
-`/var/tmp`, extracted extension tree, image store, and configured OSD can
-coexist. Calculate their peak sizes from the selected handoff and budget each
-copy on its actual backing filesystem. Grow the correct PV/LV/filesystem before
-installation and run `df` again afterward.
-
-Also confirm that no package manager, previous installer, Kubernetes bootstrap,
-or local-registry import is running. Understand any existing `/opt/kamiwaza`,
-`/var/lib/k0s`, Podman, or cluster state before rerunning an installer.
-
-Verify the host before transferring large artifacts:
+The host's static hostname must be **55 characters or fewer**. Longer names
+overflow the certificate subject fields the cluster generates:
 
 ```bash
-(
-set -euo pipefail
-test "$(uname -m)" = x86_64
-grep -E 'release 9([. ]|$)' /etc/redhat-release
-test "$(hostnamectl --static | wc -c)" -le 55
-((BASH_VERSINFO[0] > 4 ||
-  (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)))
-for command_name in \
-  awk curl find findmnt gpg jq lsblk rpm sha256sum sort stat sudo systemctl \
-  systemd-run tar; do
-  command -v "${command_name}" >/dev/null
-done
-)
+hostnamectl --static | wc -c
 ```
 
-If the host is reached through SSM, validate all four access paths before the
-install window: the instance is `Online`, a harmless Run Command succeeds, an
-interactive Session Manager shell opens, and local port forwarding starts.
-Resolve any configured Session Manager RunAs user mismatch first; do not enable
-SSH as an ad hoc fallback.
+Throughout this guide, replace the placeholders:
+
+- `<license-key>` — your Kamiwaza Prod license key.
+- `<domain>` — the base domain to serve Kamiwaza from (for example `kamiwaza.example.com`).
+- `<admin-password>` — the initial admin password.
+
+## Step 1: Download the Bundle Artifacts
+
+The 1.2.0 offline bundle is published to Keygen as a set of split, checksummed artifacts. You download them (on a connected machine or on the host if it has temporary access), verify the checksums, and recombine the split parts.
+
+`RELEASE` must name the bundle exactly as it is published on Keygen. At the time of
+writing the published 1.2.0 bundle is `1.2.0-rc.3`; once a plain `1.2.0` bundle is
+published, use that instead. Check the artifact listing for your release rather than
+assuming — a `RELEASE` value that does not exist fails at the first download.
+
+The extension-bundle filename is likewise release-specific. The value below matches the published 1.2.0 bundle. If you are installing a different build, take the filename from the artifact listing for that release.
 
 ```bash
-aws ssm describe-instance-information \
-  --filters Key=InstanceIds,Values=<instance-id> \
-  --region <region> --profile <profile>
+export KEYGEN_TOKEN="<license-key>"
+export RELEASE="1.2.0-rc.3"
+export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
+export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 
-COMMAND_ID="$(aws ssm send-command \
-  --instance-ids <instance-id> \
-  --document-name AWS-RunShellScript \
-  --parameters 'commands=["id","true"]' \
-  --query 'Command.CommandId' --output text \
-  --region <region> --profile <profile>)"
-aws ssm wait command-executed \
-  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
-  --region <region> --profile <profile>
-aws ssm get-command-invocation \
-  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
-  --query '{Status:Status,ResponseCode:ResponseCode}' \
-  --region <region> --profile <profile>
+sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
+cd /opt/kamiwaza/prereqs
 
-aws ssm start-session \
-  --target <instance-id> \
-  --region <region> --profile <profile>
-
-aws ssm start-session \
-  --target <instance-id> \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}' \
-  --region <region> --profile <profile>
-```
-
-## 1. Select and record the exact bundle
-
-Never copy artifact names, tags, or image overrides from another release. Start
-with the Keygen release or exact Kajiya workflow run selected for this install
-and record:
-
-- release/run identifier, attempt, source prefix, and publication inventory;
-- immutable Kajiya, Deploy, Core, Containers, and extension source commits;
-- every object name and SHA-256, plus sizes where the publisher exposes them;
-- runtime, resource profile, OSD size, and compatibility flags;
-- every product tag and the complete `KAMIWAZA_IMAGE_OVERRIDES` map;
-- extension helper names and hashes; and
-- the release's required verification gates.
-
-Download `release_origination.md` first. Its `## Artifacts` section is the
-authoritative hash list for source artifacts and its repository section records
-provenance. It is **not** by itself the full launcher contract: settings such as
-the complete image-override map can come from the exact Kajiya run. If the
-publisher cannot supply both provenance and the complete install contract, stop
-instead of guessing from a previous release.
-
-Modern bundle roles normally include:
-
-- `release_origination.md`;
-- one `kamiwaza-prod-*.el9.x86_64.rpm`;
-- one or more `kamiwaza-helm.<number>.tar` wrap chunks;
-- `kamiwaza-helm.sha256`, `kamiwaza-helm.asc`, and the signing public key;
-- optionally, one extension bundle plus its `.sha256`; and
-- for files split by the distribution service, `.part-NNN` files, per-part
-  sidecars, and a `.parts.json` assembly manifest.
-
-The number and names are release-specific. The publisher must supply a complete
-post-distribution `artifacts.tsv` with tab-separated filename and SHA-256
-columns, including any generated part manifests, parts, and part sidecars. The
-customer-reachable `release_origination.md` authenticates source-artifact
-hashes, but does not enumerate every distribution-added object or provide a
-byte count for every artifact. If the publisher does not supply the complete
-post-distribution inventory, stop. Keep it with the installation record.
-
-## 2. Download, transfer, and verify artifacts
-
-On the connected staging machine, use the selected package URL and the exact
-inventory. The example below is deliberately parameterized; `<release>` is the
-immutable selected release or run tag, not a version copied from this page.
-
-```bash
-export RELEASE="<release>"
-export PACKAGE_KEY="<exact-package-key-from-the-selected-release>"
-export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@${PACKAGE_KEY}/${RELEASE}"
-export ARTIFACT_DIR="${PWD}/kamiwaza-offline-${RELEASE}"
-export INVENTORY_SOURCE="<secure-path-to-artifacts.tsv>"
-
-(
-set -euo pipefail
-[[ "${RELEASE}" =~ ^[A-Za-z0-9._-]+$ ]]
-[[ "${INVENTORY_SOURCE}" != *'<'* ]]
-test -f "${INVENTORY_SOURCE}"
-
-read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
-
-AUTH_HEADER="$(mktemp)"
-chmod 0600 "${AUTH_HEADER}"
-trap 'rm -f "${AUTH_HEADER}"' EXIT
-printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" >"${AUTH_HEADER}"
-unset KEYGEN_TOKEN
-
-install -d -m 0755 "${ARTIFACT_DIR}"
-cp "${INVENTORY_SOURCE}" "${ARTIFACT_DIR}/artifacts.tsv"
-cd "${ARTIFACT_DIR}"
-
-artifact_count=0
-while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
-  [[ -n "${file}" && "${file}" != \#* ]] || continue
-  [[ -z "${extra:-}" ]]
-  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  ((artifact_count += 1))
-
-  if [[ -f "${file}" ]] &&
-     printf '%s  %s\n' "${expected_sha}" "${file}" | sha256sum -c - >/dev/null; then
-    printf 'already verified: %s\n' "${file}"
-    continue
-  fi
-  rm -f "${file}"
-
-  if [[ -f "${file}.partial" ]] &&
-     printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c - >/dev/null; then
-    mv "${file}.partial" "${file}"
-    continue
-  fi
-
-  curl_rc=0
+for file in \
+  release_origination.md \
+  kamiwaza-tools-rpm.pub.gpg \
+  kamiwaza-helm.sha256 \
+  kamiwaza-helm.asc \
+  kamiwaza-helm.00.tar.part-000 \
+  kamiwaza-helm.00.tar.part-000.sha256 \
+  kamiwaza-helm.00.tar.part-001 \
+  kamiwaza-helm.00.tar.part-001.sha256 \
+  kamiwaza-helm.00.tar.part-002 \
+  kamiwaza-helm.00.tar.part-002.sha256 \
+  kamiwaza-helm.00.tar.parts.json \
+  kamiwaza-prod-1.2.0-1.el9.x86_64.rpm \
+  "${EXT_BUNDLE}.sha256" \
+  "${EXT_BUNDLE}.part-000" \
+  "${EXT_BUNDLE}.part-000.sha256" \
+  "${EXT_BUNDLE}.part-001" \
+  "${EXT_BUNDLE}.part-001.sha256" \
+  "${EXT_BUNDLE}.part-002" \
+  "${EXT_BUNDLE}.part-002.sha256" \
+  "${EXT_BUNDLE}.part-003" \
+  "${EXT_BUNDLE}.part-003.sha256" \
+  "${EXT_BUNDLE}.part-004" \
+  "${EXT_BUNDLE}.part-004.sha256" \
+  "${EXT_BUNDLE}.parts.json"
+do
+  # Always attempt a resume: curl --continue-at - fetches a fresh file or
+  # resumes a partial one, so rerunning the block after an interruption
+  # repairs truncated downloads instead of skipping them.
   curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
-    --header "@${AUTH_HEADER}" \
-    -o "${file}.partial" \
-    "${BASE}/${file}" || curl_rc=$?
-  if ((curl_rc != 0)); then
-    # A rejected/invalid range cannot become resumable without discarding it.
-    # Preserve partial bytes for ordinary transport timeouts.
-    case "${curl_rc}" in
-      22|33|36) rm -f "${file}.partial" ;;
-    esac
-    exit "${curl_rc}"
-  fi
-
-  if ! printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c -; then
-    rm -f "${file}.partial"
-    printf 'download verification failed: %s\n' "${file}" >&2
-    exit 1
-  fi
-  mv "${file}.partial" "${file}"
-done < artifacts.tsv
-((artifact_count > 0)) || {
-  printf 'artifacts.tsv contained no artifact records\n' >&2
-  exit 1
-}
-)
-```
-
-Do not put license tokens in command logs, shell history, or the installation
-record. A cloud-to-cloud relay may be faster than a local upload, but use a
-managed identity or short-lived prefix-scoped credential and verify again on
-the final target. S3 ETags are not SHA-256 integrity checks.
-
-### Reassemble distribution parts
-
-Each `.parts.json` records the original filename/hash and the ordered part
-inventory. Reassemble from that manifest instead of hardcoding part counts:
-
-Skip this block when the inventory contains no `.parts.json` files.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-shopt -s nullglob
-manifests=( *.parts.json )
-((${#manifests[@]} > 0)) || {
-  printf 'no part manifests found\n' >&2
-  exit 1
-}
-
-for manifest in "${manifests[@]}"; do
-  output="$(jq -er '.source.filename' "${manifest}")"
-  expected_size="$(jq -er '.source.size' "${manifest}")"
-  expected_sha="$(jq -er '.source.sha256' "${manifest}")"
-  [[ "${output}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_size}" =~ ^[0-9]+$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  jq -e '.parts | type == "array" and length > 0' "${manifest}" >/dev/null
-
-  : > "${output}.assembling"
-  part_count=0
-  while IFS=$'\t' read -r part part_sha; do
-    [[ "${part}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-    [[ "${part_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-    printf '%s  %s\n' "${part_sha}" "${part}" | sha256sum -c -
-    cat "${part}" >> "${output}.assembling"
-    ((part_count += 1))
-  done < <(jq -r '.parts[] | [.filename, .sha256] | @tsv' "${manifest}")
-
-  ((part_count > 0))
-  test "$(stat -c %s "${output}.assembling")" = "${expected_size}"
-  printf '%s  %s\n' "${expected_sha}" "${output}.assembling" | sha256sum -c -
-  mv "${output}.assembling" "${output}"
-done
-)
-```
-
-### Verify source artifacts and the logical wrap
-
-Verify every artifact recorded in `release_origination.md`:
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-artifact_count=0
-while read -r file expected; do
-  test -f "${file}"
-  printf '%s  %s\n' "${expected}" "${file}" | sha256sum -c -
-  ((artifact_count += 1))
-done < <(
-  awk '
-    $0 == "## Artifacts" { in_artifacts=1; next }
-    in_artifacts && /^## / { exit }
-    in_artifacts && /^- / {
-      name=$2; sub(/:$/, "", name); print name, $3
-    }
-  ' release_origination.md
-)
-((artifact_count > 0)) || {
-  printf 'release_origination.md contained no artifact records\n' >&2
-  exit 1
-}
-)
-```
-
-`kamiwaza-helm.sha256` names the **logical concatenated wrap**, which might not
-exist as a physical file. Hash the bytewise concatenation of all numbered wrap
-chunks in natural numeric order. Creating a similarly named symlink does not
-verify this contract.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-mapfile -d '' WRAP_CHUNKS < <(
-  find . -maxdepth 1 -type f -regextype posix-extended \
-    -regex './kamiwaza-helm\.[0-9]+\.tar' -print0 | sort -z -V
-)
-((${#WRAP_CHUNKS[@]} > 0))
-
-expected="$(awk 'NR==1 {print $1}' kamiwaza-helm.sha256)"
-actual="$(cat "${WRAP_CHUNKS[@]}" | sha256sum | awk '{print $1}')"
-test "${actual}" = "${expected}"
-printf 'logical wrap checksum: OK (%s chunks)\n' "${#WRAP_CHUNKS[@]}"
-)
-```
-
-Verify the detached signature over the checksum file. Confirm the signer
-fingerprint through an independent trusted channel; a key delivered in the same
-directory proves bundle consistency, not independently anchored provenance.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-export GNUPGHOME="$(mktemp -d)"
-chmod 0700 "${GNUPGHOME}"
-trap 'rm -rf "${GNUPGHOME}"' EXIT
-gpg --batch --import ./kamiwaza-tools-rpm.pub.gpg
-gpg --batch --verify ./kamiwaza-helm.asc ./kamiwaza-helm.sha256
-gpg --batch --with-colons --fingerprint
-)
-```
-
-Transfer the entire verified directory to
-`/var/tmp/kamiwaza-offline/<release-or-run>` on the target, then repeat the
-hash, logical-wrap, and signature checks there. Perform the rest of this guide
-only from that final target copy.
-
-## 3. Install and verify embedded prerequisites
-
-Move the verified artifacts into the fixed prerequisite path, install the exact
-RPM, and run its packaged bootstrap noninteractively:
-
-```bash
-export ARTIFACT_DIR="/var/tmp/kamiwaza-offline/<release-or-run>"
-
-(
-set -euo pipefail
-
-mapfile -t RPM_FILES < <(
-  find "${ARTIFACT_DIR}" -maxdepth 1 -type f \
-    -name 'kamiwaza-prod-*.el9.x86_64.rpm' -print
-)
-mapfile -t WRAP_FILES < <(
-  find "${ARTIFACT_DIR}" -maxdepth 1 -type f -regextype posix-extended \
-    -regex '.*/kamiwaza-helm\.[0-9]+\.tar' -print | sort -V
-)
-test "${#RPM_FILES[@]}" -eq 1
-((${#WRAP_FILES[@]} > 0))
-
-sudo install -d -m 0755 /opt/kamiwaza/prereqs
-existing_bundle_file="$({
-  sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
-    \( -name 'kamiwaza-prod-*.el9.x86_64.rpm' \
-       -o -name 'kamiwaza-helm.*.tar' \
-       -o -name 'kamiwaza-helm.sha256' \
-       -o -name 'kamiwaza-helm.asc' \
-       -o -name 'kamiwaza-tools-rpm.pub.gpg' \
-       -o -name '*.parts.json' \
-       -o -name 'artifacts.tsv' \) \
-    -print -quit
-})"
-if [[ -n "${existing_bundle_file}" ]]; then
-  printf 'existing staged bundle artifact: %s\n' "${existing_bundle_file}" >&2
-  printf 'verify and archive or remove the complete staged set before retrying, even for the same release\n' >&2
-  exit 1
-fi
-
-sudo install -o root -g root -m 0600 "${ARTIFACT_DIR}/artifacts.tsv" \
-  /opt/kamiwaza/prereqs/artifacts.tsv
-
-declare -A INVENTORY=()
-while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
-  [[ -n "${file}" && "${file}" != \#* ]] || continue
-  [[ -z "${extra:-}" ]]
-  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  [[ ! -v "INVENTORY[${file}]" ]]
-  INVENTORY["${file}"]="${expected_sha}"
-done < <(sudo cat /opt/kamiwaza/prereqs/artifacts.tsv)
-((${#INVENTORY[@]} > 0))
-
-# A split source is reconstructed locally and therefore is not itself a row in
-# the post-distribution inventory. Root-stage each authenticated manifest and
-# add its source hash to the accepted source map.
-declare -A SOURCE_INVENTORY=()
-shopt -s nullglob
-PART_MANIFESTS=("${ARTIFACT_DIR}"/*.parts.json)
-for manifest in "${PART_MANIFESTS[@]}"; do
-  manifest_name="$(basename "${manifest}")"
-  [[ -v "INVENTORY[${manifest_name}]" ]]
-  sudo cp "${manifest}" /opt/kamiwaza/prereqs/
-  printf '%s  %s\n' "${INVENTORY[${manifest_name}]}" \
-    "/opt/kamiwaza/prereqs/${manifest_name}" | sudo sha256sum -c -
-  source_name="$(sudo jq -er '.source.filename' \
-    "/opt/kamiwaza/prereqs/${manifest_name}")"
-  source_sha="$(sudo jq -er '.source.sha256' \
-    "/opt/kamiwaza/prereqs/${manifest_name}")"
-  [[ "${source_name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${source_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  [[ ! -v "SOURCE_INVENTORY[${source_name}]" ]]
-  SOURCE_INVENTORY["${source_name}"]="${source_sha}"
+    -H "Authorization: License ${KEYGEN_TOKEN}" \
+    -o "$file" \
+    "${BASE}/${file}"
 done
 
-sudo cp "${RPM_FILES[@]}" \
-  "${WRAP_FILES[@]}" \
-  "${ARTIFACT_DIR}"/kamiwaza-helm.sha256 \
-  "${ARTIFACT_DIR}"/kamiwaza-helm.asc \
-  "${ARTIFACT_DIR}"/kamiwaza-tools-rpm.pub.gpg \
-  /opt/kamiwaza/prereqs/
-
-STAGED_FILES=(
-  "${RPM_FILES[@]}"
-  "${WRAP_FILES[@]}"
-  "${ARTIFACT_DIR}/kamiwaza-helm.sha256"
-  "${ARTIFACT_DIR}/kamiwaza-helm.asc"
-  "${ARTIFACT_DIR}/kamiwaza-tools-rpm.pub.gpg"
-)
-for source in "${STAGED_FILES[@]}"; do
-  name="$(basename "${source}")"
-  if [[ -v "INVENTORY[${name}]" ]]; then
-    expected_sha="${INVENTORY[${name}]}"
-  else
-    [[ -v "SOURCE_INVENTORY[${name}]" ]]
-    expected_sha="${SOURCE_INVENTORY[${name}]}"
-  fi
-  printf '%s  %s\n' "${expected_sha}" \
-    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
+# Verify part checksums
+for checksum in \
+  kamiwaza-helm.00.tar.part-*.sha256 \
+  "${EXT_BUNDLE}".part-*.sha256
+do
+  sha256sum -c "${checksum}"
 done
 
-RPM_NAME="$(basename "${RPM_FILES[0]}")"
-sudo rpm -Uvh --replacepkgs "/opt/kamiwaza/prereqs/${RPM_NAME}"
+# Recombine split parts and verify the full-artifact checksums
+cat kamiwaza-helm.00.tar.part-{000..002} > kamiwaza-helm.00.tar
+cat "${EXT_BUNDLE}".part-{000..004} > "${EXT_BUNDLE}"
+ln -sf kamiwaza-helm.00.tar kamiwaza-helm.tar
+sha256sum -c kamiwaza-helm.sha256
+sha256sum -c "${EXT_BUNDLE}.sha256"
+```
+
+The `release_origination.md` artifact records the build provenance and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
+
+> If a download stalls, rerun the block — `curl --continue-at -` resumes partial files. If you downloaded on a separate connected machine, transfer the entire `/opt/kamiwaza/prereqs` directory to the same path on the target host before continuing.
+
+## Step 2: Install Prerequisites
+
+Install the prerequisites RPM and run the bootstrap script, which installs the container runtime, cluster tooling, and Ansible from the embedded artifacts:
+
+```bash
+cd /opt/kamiwaza/prereqs
+
+sudo rpm -Uvh --replacepkgs ./kamiwaza-prod-*.x86_64.rpm
+
 sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
-  --yes \
   --embedded-root /opt/kamiwaza/prereqs \
   --os rhel
-)
-```
 
-The release/1.2.0 RPM overlay accepts `--yes` for noninteractive bootstrap.
-Do not pipe repeated `yes` or press Enter to drive a long unattended install.
-
-The install runs as root, so verify tools using root's actual environment:
-
-```bash
-(
-set -euo pipefail
-sudo env \
-  HOME=/root \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  bash -euo pipefail -c '
-    ansible-playbook --version | head -n1
-    podman --version
-    kubectl version --client
-    helm version --short
-    helmfile --version
-    helm dt version
-  '
-)
-```
-
-Do not repair a missing embedded tool by silently installing an arbitrary
-internet version. Reconcile the selected RPM/bootstrap contract first.
-
-## 4. Pre-stage the extension bundle (optional)
-
-Skip this section when the selected bundle has no extension archive. Pre-stage
-loads the bundled catalog files and writes offline catalog values needed by the
-core install. It does **not** load all images or import the live catalog.
-
-Copy the verified extension archive and sidecar into `/opt/kamiwaza/prereqs`.
-Derive and validate its single top-level directory, then record the exact final
-bundle root. Do not rediscover it later with `find | head`; stale extractions
-can coexist after a retry.
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_BUNDLE="<exact-extension-filename-from-inventory>"
-export EXTRACT_DIR="/var/lib/kajiya-reports/extensions-${RUN_ID}"
-export ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${EXT_BUNDLE}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-HELPER_DIR="$(sudo mktemp -d -p /var/tmp \
-  "kamiwaza-extension-helper-${RUN_ID}.XXXXXX")"
-trap 'sudo rm -rf -- "${HELPER_DIR}"' EXIT
-
-sudo cp "${ARTIFACT_DIR}/${EXT_BUNDLE}" \
-  "${ARTIFACT_DIR}/${EXT_BUNDLE}.sha256" \
-  /opt/kamiwaza/prereqs/
-
-for name in "${EXT_BUNDLE}" "${EXT_BUNDLE}.sha256"; do
-  mapfile -t expected_rows < <(
-    sudo awk -F '\t' -v name="${name}" '$1 == name {print $2}' \
-      /opt/kamiwaza/prereqs/artifacts.tsv
-  )
-  if ((${#expected_rows[@]} == 0)); then
-    mapfile -t root_manifests < <(
-      sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
-        -name '*.parts.json' -print
-    )
-    for manifest in "${root_manifests[@]}"; do
-      if [[ "$(sudo jq -er '.source.filename' "${manifest}")" = "${name}" ]]; then
-        expected_rows+=("$(sudo jq -er '.source.sha256' "${manifest}")")
-      fi
-    done
+# Put the bundled tools on sudo's PATH. Later steps call `sudo kubectl`, and the
+# bootstrap's own verification cannot see them either, so re-run it afterwards —
+# the second run reports "Bootstrap complete".
+for tool in helm helmfile k0s kind kubectl; do
+  if [[ -x "/usr/local/bin/${tool}" ]]; then
+    sudo ln -sfn "/usr/local/bin/${tool}" "/usr/bin/${tool}"
   fi
-  test "${#expected_rows[@]}" -eq 1
-  [[ "${expected_rows[0]}" =~ ^[0-9a-fA-F]{64}$ ]]
-  printf '%s  %s\n' "${expected_rows[0]}" \
-    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
 done
 
-mapfile -t BUNDLE_TOP_LEVELS < <(
-  sudo tar -tzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" |
-    awk -F/ 'NF {print $1}' | sort -u
-)
-test "${#BUNDLE_TOP_LEVELS[@]}" -eq 1
-export BUNDLE_DIR_NAME="${BUNDLE_TOP_LEVELS[0]}"
-[[ "${BUNDLE_DIR_NAME}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
+  --embedded-root /opt/kamiwaza/prereqs \
+  --os rhel
+```
 
-sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}" -- \
-  "${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
-sudo test -x \
-  "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
-sudo bash "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh" \
+The first bootstrap run commonly exits nonzero on RHEL 9 with `ERROR: required
+bundled command missing after install: helm`, even though every tool installed
+correctly: the bootstrap installs into `/usr/local/bin`, which sudo's
+`secure_path` omits, so its own verification cannot see them. The symlink loop
+and second run in the block above resolve it.
+
+Verify the tools are present:
+
+```bash
+export HELM_PLUGINS="/usr/local/share/helm/plugins"
+
+checks=(
+  "ansible::ansible-playbook --version | head -n1"
+  "podman::podman --version"
+  "kubectl::kubectl version --client"
+  "helm::helm version --short"
+  "helmfile::helmfile --version"
+  "helm dt::helm dt version"
+)
+
+for check in "${checks[@]}"; do
+  label="${check%%::*}"; command="${check#*::}"
+  if output="$(bash -o pipefail -c "${command}" 2>&1)"; then
+    result=GOOD
+  else
+    result=BAD
+  fi
+  output="$(printf '%s' "${output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  printf '[%-4s] %s: %s\n' "${result}" "${label}" "${output:-no output}"
+done
+```
+
+Every tool above ships in the bundle, so a failure here means the bootstrap did
+not complete rather than that something is missing from the host. Re-run the
+bootstrap and re-verify before considering other sources.
+
+On a host that still has repository access you can install a missing tool
+directly, but this reaches the OS package repositories and is not available on
+an air-gapped host:
+
+```bash
+sudo dnf install -y ansible-core podman kubectl
+```
+
+## Step 3: Create the Overrides File
+
+Create the cluster overrides file with your domain. This is also where you add optional deployment customizations.
+
+```bash
+sudo install -d -m 0755 /opt/kamiwaza/cluster/values
+sudo tee /opt/kamiwaza/cluster/values/overrides.yaml > /dev/null <<'EOF'
+global:
+  domain: <domain>
+EOF
+```
+
+> Advanced deployments (for example, external S3-backed workroom storage or a classification banner) add further keys under `global:` and `core:` in this file. Those are optional and not required for a standard install.
+
+## Step 4: Pre-Extract the Extension Bundle
+
+Stage the extension bundle before installing the platform:
+
+```bash
+cd /opt/kamiwaza/prereqs
+
+EXT_BUNDLE="${EXT_BUNDLE:-$(ls -1 kamiwaza-extensions-bundle-*.tar.gz | tail -1)}"
+rm -rf /tmp/kamiwaza-ext-extract
+mkdir -p /tmp/kamiwaza-ext-extract
+tar -xzf "$EXT_BUNDLE" -C /tmp/kamiwaza-ext-extract
+
+sudo /tmp/kamiwaza-ext-extract/kamiwaza-extensions-bundle-*/scripts/install-extensions-bundle.sh \
   --bundle "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" \
   --sha256-file "/opt/kamiwaza/prereqs/${EXT_BUNDLE}.sha256" \
-  --extract-dir "${EXTRACT_DIR}" \
+  --extract-dir /var/lib/kajiya-reports/extensions-bundle-preinstall \
   --skip-images \
   --skip-catalog
 
-export BUNDLE_ROOT="${EXTRACT_DIR}/${BUNDLE_DIR_NAME}"
-sudo test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
-sudo install -d -m 0700 "$(dirname "${ROOT_RECORD}")"
-printf '%s\n' "${BUNDLE_ROOT}" | sudo tee "${ROOT_RECORD}" >/dev/null
-sudo chmod 0600 "${ROOT_RECORD}"
-)
+# The /tmp copy only supplies the helper script. The install itself runs from
+# the --extract-dir copy, so reclaim the scratch space before installing.
+rm -rf /tmp/kamiwaza-ext-extract
 ```
 
-When helpers are supplied separately from the archive, use only the exact
-Kajiya commit recorded by the selected run and verify each helper SHA-256 before
-execution.
+This stages the bundle under `/var/lib/kajiya-reports/extensions-bundle-preinstall`
+(about 24 GB); [Step 6](#step-6-finish-extension-installation) installs from
+there.
 
-## 5. Prepare a durable core launcher
-
-The selected immutable run must supply a complete, non-secret install contract.
-Record it as JSON so values containing spaces cannot become shell syntax. Fill
-every value from the selected run, including the complete infrastructure and
-inference image map:
-
-```json
-{
-  "KAMIWAZA_VERSION": "<exact>",
-  "KAMIWAZA_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_K8S_RUNTIME": "k0s-podman",
-  "KAMIWAZA_ROOK_OSD_IMAGE_SIZE": "<exact>",
-  "KAMIWAZA_RESOURCE_PROFILE": "<exact>",
-  "HELMFILE_EXTRA_SET": "<exact, including spaces>",
-  "KAMIWAZA_OFFLINE_APP_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CORE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_DATAHUB_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_FRONTEND_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG": "<exact>",
-  "KAMIWAZA_IMAGE_OVERRIDES": "<exact comma-separated map>"
-}
-```
-
-Validate that the document contains only the expected string keys, then install
-it root-owned:
-
-```bash
-(
-set -euo pipefail
-CONTRACT_SOURCE='<secure-path-to-kamiwaza-install-contract.json>'
-[[ "${CONTRACT_SOURCE}" != *'<'* ]]
-test -f "${CONTRACT_SOURCE}"
-if ! jq -e '
-  type == "object" and
-  (keys | sort) == ([
-    "HELMFILE_EXTRA_SET",
-    "KAMIWAZA_IMAGE_OVERRIDES",
-    "KAMIWAZA_IMAGE_TAG",
-    "KAMIWAZA_K8S_RUNTIME",
-    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
-    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CORE_TAG",
-    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
-    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
-    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
-    "KAMIWAZA_RESOURCE_PROFILE",
-    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
-    "KAMIWAZA_VERSION"
-  ] | sort) and
-  all(.[]; type == "string") and
-  all(.[]; (contains("<") or contains(">")) | not) and
-  .KAMIWAZA_K8S_RUNTIME == "k0s-podman" and
-  (. as $contract | all([
-    "KAMIWAZA_IMAGE_OVERRIDES",
-    "KAMIWAZA_IMAGE_TAG",
-    "KAMIWAZA_K8S_RUNTIME",
-    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
-    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CORE_TAG",
-    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
-    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
-    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
-    "KAMIWAZA_RESOURCE_PROFILE",
-    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
-    "KAMIWAZA_VERSION"
-  ][]; ($contract[.] | length > 0)))
-' "${CONTRACT_SOURCE}" >/dev/null; then
-  printf 'install contract has missing, extra, empty, placeholder, or topology-invalid values\n' >&2
-  exit 1
-fi
-sudo install -o root -g root -m 0600 \
-  "${CONTRACT_SOURCE}" /run/kamiwaza-install-contract.json
-)
-```
-
-Use the exact release contract even when several values happen to share a tag.
-Do not synthesize missing values from the release number.
-`KAMIWAZA_K8S_RUNTIME` must be `k0s-podman` for this guide. If the selected
-contract names another runtime, stop and use that runtime's runbook.
-`KAMIWAZA_OFFLINE_EXTRA_IMAGES` is a Kajiya wrap-build input, not an installer
-environment variable; record it in build provenance when it is nonempty, but do
-not add it to this runtime contract.
+## Step 5: Install Kamiwaza
 
 > **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
 > [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)
-> before invoking `install-prod.sh`. It requires the exact 1.2.0 candidate, a
-> pre-mutation backup, schema gates, stop rules, and recovery evidence.
+> before invoking `install-prod.sh`. The runbook requires the exact 1.2.0
+> candidate and its `release_origination.md`; the fresh-install values below
+> are not upgrade inputs.
 
-### Password handling
+Set the image tags for the bundle and run the offline installer. The values below match the published 1.2.0 build. If you are installing a different build, obtain its image override map from the publisher — `release_origination.md` records the app, containers, and frontend tags only.
 
-The packaged release/1.2.0 RPM passes unknown arguments through to Ansible. The
-launcher below writes `admin_password` to a root-only, attempt-bound JSON
-extra-vars file under `/run` and passes only that file's path. The password is
-not placed in the installer or child-process arguments or environment. Root can
-still read the temporary file while the phase is running; the launcher's exit
-trap removes it.
+Both `KAMIWAZA_IMAGE_TAG` and `KAMIWAZA_IMAGE_OVERRIDES` are required, and they correct each other:
 
-Read the password without echoing it and create a transient root-only file:
+- `KAMIWAZA_IMAGE_TAG` moves the platform images to the release tag. Without it, `extension-operator` and `placement-operator` request `develop` and stay in `ImagePullBackOff`.
+- `postgres` and `keycloak` are excluded from that bulk tag and would otherwise fall back to chart pins the bundle does not contain.
+- `etcd` is moved *by* the bulk tag and must be pinned back to the version in the bundle.
+
+Omitting the bulk tag, or any one of the three overrides, leaves a workload requesting a tag the local registry does not have.
+
+> **Installing over SSM, or any connection that can drop?** The install runs for
+> roughly 15-20 minutes in the foreground, and losing the session loses the
+> controlling process. Launch it as a transient systemd unit instead, so it
+> survives the shell:
+>
+> ```bash
+> sudo systemd-run --no-block --service-type=oneshot --remain-after-exit \
+>   --unit=kamiwaza-offline-install \
+>   /opt/kamiwaza/scripts/install-prod.sh <the same arguments as below>
+> ```
+>
+> Then judge the result from `systemctl show kamiwaza-offline-install` —
+> `Result=success` and `ExecMainStatus=0` — not from log activity. A quiet log
+> is not a finished install.
+
+> **Keep `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G`** in the block below unless you have sized `/var/lib` for the 700 GB default — it is what brings the requirement down to the 350 GB floor in [Prerequisites](#prerequisites). This env var and the online guide's `-e storage_host_prep_virtual_block_size` extra-var are the same setting expressed two ways; the offline path sets it via the environment, the online path via an installer argument.
 
 ```bash
-(
-set -euo pipefail
-read -rsp 'Initial Kamiwaza admin password: ' ADMIN_PASSWORD; printf '\n'
-sudo install -o root -g root -m 0600 /dev/null /run/kamiwaza-admin-password
-printf '%s' "${ADMIN_PASSWORD}" | sudo tee /run/kamiwaza-admin-password >/dev/null
-unset ADMIN_PASSWORD
-)
-```
+export DOMAIN="<domain>"
+export ADMIN_PASSWORD="<admin-password>"
 
-Create `/run/kamiwaza-offline-install.sh` as root with a quoted heredoc so the
-interactive shell cannot expand the script body:
+export APP_TAG="release-1.2.0"
+export FRONTEND_TAG="${APP_TAG}"
+export CONTAINERS_TAG="release-1.2.0"
+export EXTENSION_OPERATOR_TAG="release-1.2.0"
 
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-install.sh
-sudo tee /run/kamiwaza-offline-install.sh >/dev/null <<'KAMIWAZA_INSTALL'
-#!/usr/bin/env bash
-set -euo pipefail
+export KAMIWAZA_VERSION="${APP_TAG}"
+export KAMIWAZA_IMAGE_TAG="${APP_TAG}"
+export KAMIWAZA_K8S_RUNTIME="k0s-podman"
+export KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G
+export KAMIWAZA_RESOURCE_PROFILE=small
+export HELMFILE_EXTRA_SET="--set global.security.allowInsecureImages=true"
 
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
+export KAMIWAZA_OFFLINE_APP_IMAGE_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_CORE_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_FRONTEND_TAG="${FRONTEND_TAG}"
+export KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG="${CONTAINERS_TAG}"
+export KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG="${CONTAINERS_TAG}"
 
-CONTRACT=/run/kamiwaza-install-contract.json
-PASSWORD_FILE=/run/kamiwaza-admin-password
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-STATUS_ROOT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts"
-ATTEMPT_DIR="${STATUS_ROOT}/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-ADMIN_VARS_FILE="/run/kamiwaza-admin-extra-vars-${RUN_ID}-attempt${ATTEMPT_ID}.json"
+export KAMIWAZA_IMAGE_OVERRIDES="postgres=v18.4,keycloak=${CONTAINERS_TAG},etcd=v3.6.10"
 
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-test ! -e "${ADMIN_VARS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  rm -f "${PASSWORD_FILE}" "${ADMIN_VARS_FILE}"
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-test -s "${CONTRACT}"
-test -s "${PASSWORD_FILE}"
-test -f /opt/kamiwaza/prereqs/kamiwaza-helm.sha256
-test -f /opt/kamiwaza/prereqs/kamiwaza-helm.asc
-test -f /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg
-
-CONTRACT_KEYS=(
-  KAMIWAZA_VERSION
-  KAMIWAZA_IMAGE_TAG
-  KAMIWAZA_K8S_RUNTIME
-  KAMIWAZA_ROOK_OSD_IMAGE_SIZE
-  KAMIWAZA_RESOURCE_PROFILE
-  HELMFILE_EXTRA_SET
-  KAMIWAZA_OFFLINE_APP_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CORE_TAG
-  KAMIWAZA_OFFLINE_DATAHUB_TAG
-  KAMIWAZA_OFFLINE_FRONTEND_TAG
-  KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG
-  KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG
-  KAMIWAZA_IMAGE_OVERRIDES
-)
-for name in "${CONTRACT_KEYS[@]}"; do
-  value="$(jq -er --arg name "${name}" '.[$name] | strings' "${CONTRACT}")"
-  printf -v "${name}" '%s' "${value}"
-  export "${name}"
-done
-unset value
-
-jq -Rs '{admin_password: .}' <"${PASSWORD_FILE}" >"${ADMIN_VARS_FILE}"
-test -s "${ADMIN_VARS_FILE}"
-rm -f "${PASSWORD_FILE}"
-/opt/kamiwaza/scripts/install-prod.sh \
+sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
-  --skip-prereq-bootstrap \
   --domain "${DOMAIN}" \
+  --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
   --wrap-pubkey /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg \
-  --extra-vars "@${ADMIN_VARS_FILE}" \
+  -e helm_timeout=12m \
   -y
-KAMIWAZA_INSTALL
-)
 ```
 
-Replace `<domain>` with `sudoedit /run/kamiwaza-offline-install.sh`, then
-validate and protect the launcher:
+## Step 6: Finish Extension Installation
 
-```bash
-(
-set -euo pipefail
-sudo bash -n /run/kamiwaza-offline-install.sh
-sudo chmod 0700 /run/kamiwaza-offline-install.sh
-)
-```
-
-## 6. Launch through SSM without tying the install to the shell
-
-An SSM interactive shell can time out while a healthy installation is still
-running. Launch each attempt as a distinct transient systemd unit:
-
-```bash
-export RUN_ID="<release-or-run>"
-export ATTEMPT=1
-export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${CORE_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${CORE_UNIT}" "${CORE_ATTEMPT_DIR}"
-)
-```
-
-Immediately record the unit name and follow the persistent root-only log:
-
-```bash
-sudo tail -F "${CORE_ATTEMPT_DIR}/console.log"
-```
-
-Stop following with Ctrl-C only after the unit is terminal; then run the strict
-completion gate in the next section.
-
-Journal activity—or quietness—is not a completion signal. Because
-`KillMode=process` and `Delegate=yes` allow runtime children to survive the
-launcher, a stopped unit also does not prove all children stopped after an
-error. Declare the core launcher successful only when all of these agree:
-
-- `LoadState=loaded`, `ActiveState=active`, `SubState=exited`,
-  `Result=success`, `ExecMainCode=1`, and `ExecMainStatus=0` from one
-  `systemctl show` snapshot;
-- the recorded per-attempt `${CORE_STATUS}` contains `0`;
-- the final Ansible recap has `failed=0` and `unreachable=0`; and
-- the independent workload checks in the next section pass.
-
-`--remain-after-exit` keeps a successful transient unit loaded so a misspelled,
-garbage-collected, or never-created unit cannot look identical to success.
-`systemd-run` is preferred on RHEL because it preserves an authoritative exit
-status. If systemd transient units are unavailable, the launcher can be
-detached with `nohup` and the same attempt argument:
-
-```bash
-export ATTEMPT=2
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
-sudo /bin/bash -c '
-  exec nohup /bin/bash "$1" "$2" "$3" </dev/null >"$4" 2>&1 &
-' _ /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}" \
-  "${CORE_ATTEMPT_DIR}/launcher.log"
-)
-```
-
-In that fallback, require the runner's `.rc` file plus the final recap and all
-independent health gates; the background PID disappearing is not success.
-
-## 7. Verify the core installation
-
-The `k0s-podman` topology uses Podman as the k0s container engine on the host:
-
-```text
-RHEL host -> k0s with Podman container engine -> Kubernetes pods
-```
-
-Host processes and Kubernetes workloads do not share one network namespace.
-Use the root kubeconfig installed by the playbook and the node IP reported by Kubernetes. If an EC2
-instance role is intentionally available to workloads, the instance metadata
-response hop limit must support this nested path; explicit S3 credentials
-remain supported when ambient identity is not desired.
-
-For a same-boot verification, rebind the recorded values after reconnecting and
-run:
+Make sure `${DOMAIN}` resolves from the install host, then install the extensions from the pre-staged bundle:
 
 ```bash
 export DOMAIN="<domain>"
-export RUN_ID="<release-or-run>"
-export ATTEMPT=1
-export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
+export ADMIN_PASSWORD="<admin-password>"
 
-(
-set -euo pipefail
-test "$(sudo cat "${CORE_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-CORE_STATE="$(sudo systemctl show "${CORE_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${CORE_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${CORE_STATE}"; then
-    printf 'core unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${CORE_STATE}"
-test "$(sudo cat "${CORE_STATUS}")" = 0
-)
+# Add a hosts-file entry if the domain does not already resolve locally
+if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
+  NODE_IP="$(sudo kubectl get nodes -o wide --no-headers | awk 'NR==1 {print $6}')"
+  echo "${NODE_IP:-127.0.0.1} ${DOMAIN}" | sudo tee -a /etc/hosts
+fi
+
+BUNDLE_ROOT="$(sudo find /var/lib/kajiya-reports/extensions-bundle-preinstall \
+  -maxdepth 1 -type d -name 'kamiwaza-extensions-bundle-*' | sort | tail -1)"
+
+test -n "${BUNDLE_ROOT}" || { echo "No pre-extracted extension bundle found"; exit 1; }
+
+printf '%s\n' "${ADMIN_PASSWORD}" | sudo "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
+  --bundle-root "${BUNDLE_ROOT}" \
+  --container-cli podman \
+  --sudo-mode always \
+  --api-url "https://${DOMAIN}/api" \
+  --username admin \
+  --password-stdin
 ```
 
-Run the workload gates separately so the same block is usable after a verified
-post-success reboot:
+## Step 7: Verify the Installation
 
 ```bash
-export DOMAIN="<domain>"
-
-(
-set -euo pipefail
-ROOT_TOOLS=(sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
-NODES_JSON="$("${ROOT_TOOLS[@]}" kubectl get nodes -o json)"
-jq -e '
-  (.items | length) > 0 and
-  all(.items[]; any(.status.conditions[]?;
-    .type == "Ready" and .status == "True"))
-' <<<"${NODES_JSON}" >/dev/null
-
-PODS_JSON="$("${ROOT_TOOLS[@]}" kubectl get pods -A -o json)"
-jq -e '
-  (.items | length) > 0 and
-  all(.items[];
-    .status.phase == "Succeeded" or
-    (.status.phase == "Running" and
-     ((.status.containerStatuses // []) | length) > 0 and
-     all(.status.containerStatuses[]; .ready == true)))
-' <<<"${PODS_JSON}" >/dev/null
-jq -e '
-  all(.items[];
-    all((.status.containerStatuses // [])[];
-      (.imageID // "") | contains("sha256:")))
-' <<<"${PODS_JSON}" >/dev/null
-
-HELM_JSON="$("${ROOT_TOOLS[@]}" helm list -A -o json)"
-jq -e 'length > 0 and all(.[]; .status == "deployed")' \
-  <<<"${HELM_JSON}" >/dev/null
-
-NODE_IP="$("${ROOT_TOOLS[@]}" kubectl get nodes \
-  -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
-test -n "${NODE_IP}"
-HTTP_CODE="$(curl -kfsS --resolve "${DOMAIN}:443:${NODE_IP}" \
-  -o /dev/null -w '%{http_code}' \
-  "https://${DOMAIN}/api/auth/health")"
-test "${HTTP_CODE}" = 200
-
-"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
-"${ROOT_TOOLS[@]}" kubectl get pods -A
-"${ROOT_TOOLS[@]}" helm list -A
-printf 'health HTTP %s\n' "${HTTP_CODE}"
-)
+sudo kubectl get pods -A
+sudo kubectl get kamiwazaextensions -A
 ```
 
-If the host rebooted only **after** the durable `result.rc` reached `0`, the
-transient unit tuple is no longer available. Do not run the same-boot tuple
-gate. Instead require that attempt's root-only `console.log` to contain the
-final clean Ansible recap, then run the separate workload block and every login,
-digest, and provenance gate below. A missing or nonzero receipt is not
-recoverable success.
+All pods should be `Running`, `Ready`, or `Completed`. On a fresh install `kubectl get kamiwazaextensions -A` reports `No resources found` — the extension templates are cataloged but none is deployed until you launch one, so this is expected. Then log in at `https://<domain>/login` with `admin` and the password you set. The installer serves the site with a self-signed certificate by default, so your browser will show a security warning on first access — continue past it to reach the login page.
 
-The health endpoint is authentication-exempt and must return a successful HTTP
-status. Also verify login and an authenticated API request, deployed Helm
-releases, expected local-registry manifests, and the live pod `imageID` digests
-against the selected release contract. Health without expected digest evidence
-proves function, not artifact provenance. Passing the shell block alone is not
-level-1 completion; login and an authenticated request must also succeed. A
-missing expected manifest/digest comparison does not block that functional
-level, but it does block any claim that the running images match the selected
-release provenance.
+## Troubleshooting
 
-The domain must resolve both from the install host and from the operator's
-browser. Add one exact, reviewed `/etc/hosts` entry only when DNS is not ready;
-do not append duplicates on every retry.
+- **Output appears stalled during `bootstrap-prereqs.sh` or `install-prod.sh`.** The `dnf`/`rpm` output can appear to hang while these scripts run. This is not a prompt waiting for input; if output appears stalled, press Enter several times until it resumes.
+- **Disk pressure or staging failures.** Confirm `/`, `/tmp`, and `/var/lib` each have enough free space before installing (see [Prerequisites](#prerequisites)).
 
-For SSM port forwarding, map local port 8443 to target port 443, add
-`127.0.0.1 <domain>` to the operator workstation, and browse to
-`https://<domain>:8443/login`. The default certificate is self-signed, so the
-browser presents a warning until the operator explicitly trusts or replaces
-it. Preserve `:8443` after authentication redirects.
+## Next Steps
 
-## 8. Fully load bundled extensions (optional)
-
-Core success does not finish a bundle that contains extensions. Run the full
-load in a **separate** detached unit after the authenticated API is ready. Reuse
-the exact root recorded during pre-stage; do not extract another copy without a
-specific reason.
-
-Create `/run/kamiwaza-offline-extensions.sh` through a root-owned quoted
-heredoc:
-
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-extensions.sh
-sudo tee /run/kamiwaza-offline-extensions.sh >/dev/null <<'KAMIWAZA_EXTENSIONS'
-#!/usr/bin/env bash
-set -euo pipefail
-
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
-
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
-BUNDLE_ROOT="$(<"${ROOT_RECORD}")"
-
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-test -d "${BUNDLE_ROOT}"
-test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
-
-# Do not persist the seeded credential in a second file. Feed it to the helper
-# on stdin; see the argv limitation immediately below.
-ADMIN_PASSWORD="$(
-  kubectl -n kamiwaza get secret kamiwaza-user-admin \
-    -o jsonpath='{.data.password}' | base64 -d
-)"
-
-printf '%s\n' "${ADMIN_PASSWORD}" |
-  "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
-    --bundle-root "${BUNDLE_ROOT}" \
-    --container-cli podman \
-    --sudo-mode always \
-    --api-url "https://${DOMAIN}/api" \
-    --username admin \
-    --password-stdin
-unset ADMIN_PASSWORD
-KAMIWAZA_EXTENSIONS
-)
-```
-
-The current bundle helper accepts `--password-stdin`, but its catalog-import
-subprocess can still expand that value into a child command's arguments. This
-has the same temporary privileged-process visibility limitation as the core
-installer. Do not capture full process argument lists during this phase.
-
-Launch and monitor it like the core phase:
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_ATTEMPT=1
-export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
-export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
-export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${EXT_ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo bash -n /run/kamiwaza-offline-extensions.sh
-sudo chmod 0700 /run/kamiwaza-offline-extensions.sh
-sudo install -d -o root -g root -m 0700 "$(dirname "${EXT_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${EXT_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${EXT_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extensions.sh "${RUN_ID}" "${EXT_ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${EXT_UNIT}" "${EXT_ATTEMPT_DIR}"
-)
-
-sudo tail -F "${EXT_ATTEMPT_DIR}/console.log"
-```
-
-After the unit is terminal, stop following with Ctrl-C and gate the exact
-recorded attempt:
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_ATTEMPT=1
-export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
-export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
-export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-test "$(sudo cat "${EXT_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-EXT_STATE="$(sudo systemctl show "${EXT_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${EXT_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${EXT_STATE}"; then
-    printf 'extension unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${EXT_STATE}"
-test "$(sudo cat "${EXT_STATUS}")" = 0
-sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf \
-  kubectl get pods -A
-)
-```
-
-Also require all expected local-registry manifests and healthy workloads.
-Record the exact stored and visible catalog counts for the selected immutable
-bundle. Stored and visible counts can differ when product posture intentionally
-hides a template; verify both instead of assuming that an absent UI card means
-import failed.
-
-Customer level-2 completion does not require private Kajiya smoke helpers or
-unpublished expected-count files. If the publisher supplies an additional
-hash-authenticated validation pack, run its resource assertions; otherwise
-record the observed evidence without substituting dated counts from this page.
-
-Do not blindly rerun only the catalog importer after success. Existing hidden
-templates can be invisible to its list call and then cause a duplicate-create
-HTTP 400.
-
-## 9. Run the internal release deploy gate (release parity)
-
-This section is for Kamiwaza release engineers. The normal customer bundle does
-not contain `smoke-extension-deploy.sh`, the Konnectivity guard, or expected
-release-gate values. Do not require this section for customer level-1 or level-2
-completion. For release/nightly parity, transfer the selected run's separate
-validation pack and verify its recorded hashes; never download `develop` at
-install time.
-
-Install the verified gate into a fresh root-only directory:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_SOURCE="<secure-path-to-smoke-extension-deploy.sh>"
-export GATE_SHA256="<sha256-from-selected-validation-pack>"
-export GATE_HELPER_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${GATE_SHA256}" =~ ^[0-9a-fA-F]{64}$ ]]
-[[ "${GATE_SOURCE}" != *'<'* ]]
-test -f "${GATE_SOURCE}"
-printf '%s  %s\n' "${GATE_SHA256}" "${GATE_SOURCE}" | sha256sum -c -
-sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_HELPER_DIR}")"
-sudo mkdir -m 0700 "${GATE_HELPER_DIR}"
-sudo install -o root -g root -m 0700 "${GATE_SOURCE}" \
-  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh"
-printf '%s  %s\n' "${GATE_SHA256}" \
-  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh" | sudo sha256sum -c -
-)
-```
-
-The currently selected 1.2.0 gate deploys `kaizen`, but the selected release
-contract controls the exact template. The gate waits for readiness, proves that
-relocation left no external image references, and removes it through the
-supported API path. A raw `kubectl apply` bypasses that behavior and is not an
-equivalent test.
-
-Create `/run/kamiwaza-offline-extension-gate.sh` through a root-owned quoted
-heredoc, replacing the placeholders with the recorded domain and gate values:
-
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-extension-gate.sh
-sudo tee /run/kamiwaza-offline-extension-gate.sh >/dev/null <<'KAMIWAZA_GATE'
-#!/usr/bin/env bash
-set -euo pipefail
-
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
-
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-GATE_SCRIPT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation/smoke-extension-deploy.sh"
-GATE_TEMPLATE='<exact-gate-template-from-selected-release>'
-GATE_WAIT_TIMEOUT='<exact-gate-timeout-from-selected-release>'
-
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-[[ "${GATE_TEMPLATE}" != *'<'* ]]
-[[ "${GATE_WAIT_TIMEOUT}" != *'<'* ]]
-test -x "${GATE_SCRIPT}"
-ADMIN_PASSWORD="$(
-  kubectl -n kamiwaza get secret kamiwaza-user-admin \
-    -o jsonpath='{.data.password}' | base64 -d
-)"
-
-printf '%s\n' "${ADMIN_PASSWORD}" |
-  bash "${GATE_SCRIPT}" \
-    --api-url "https://${DOMAIN}/api" \
-    --username admin \
-    --password-stdin \
-    --template-name "${GATE_TEMPLATE}" \
-    --wait-timeout "${GATE_WAIT_TIMEOUT}"
-unset ADMIN_PASSWORD
-KAMIWAZA_GATE
-)
-```
-
-Launch and gate it independently:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_ATTEMPT=1
-export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
-export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
-export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${GATE_ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo bash -n /run/kamiwaza-offline-extension-gate.sh
-sudo chmod 0700 /run/kamiwaza-offline-extension-gate.sh
-sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${GATE_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${GATE_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extension-gate.sh "${RUN_ID}" "${GATE_ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${GATE_UNIT}" "${GATE_ATTEMPT_DIR}"
-)
-
-sudo tail -F "${GATE_ATTEMPT_DIR}/console.log"
-```
-
-After the unit is terminal, require the retained unit tuple and the matching
-durable receipt:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_ATTEMPT=1
-export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
-export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
-export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-test "$(sudo cat "${GATE_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-GATE_STATE="$(sudo systemctl show "${GATE_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${GATE_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${GATE_STATE}"; then
-    printf 'deploy-gate unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${GATE_STATE}"
-test "$(sudo cat "${GATE_STATUS}")" = 0
-)
-```
-
-Also run any Konnectivity or authenticated resource gate in the same validation
-pack. Record every script's source commit and SHA-256. The temporary child-argv
-limitation described in the extension-load phase also applies to this helper.
-
-SDK tests, UAT data seeding, DNS publication, and A/B promotion are separate
-demo or publication phases. They are not required to call the base platform or
-extension bundle installed.
-
-## Reruns, recovery, and diagnostics
-
-- Download and part assembly are safely repeatable. The download block removes
-  an unverifiable or unresumable `.partial`; remove a failed `.assembling`
-  before retrying assembly. Verify final-target SHA-256 after every transfer.
-- `rpm --replacepkgs` is intentional. A core installer rerun is **not** a
-  generic reset: inspect the existing unit, Ansible recap, cluster, registry,
-  and surviving child processes first. Recreate the root-only password file
-  before every core attempt because the launcher removes it on exit.
-- Before staging a different release, archive or remove only the previous
-  release's RPM, numbered wrap chunks, checksum, signature, public key, and
-  extension archive/sidecar, root-staged `*.parts.json` manifests, and
-  `artifacts.tsv` from `/opt/kamiwaza/prereqs`. Never mix release artifact
-  families or broadly delete the packaged prerequisite tree. For an
-  exact-release retry, verify the existing files and reuse them.
-- Use monotonically named units and fresh per-attempt directories. Never reuse
-  an attempt number or overwrite a terminal receipt, log, or recap before the
-  cause is understood. After preserving evidence, stop a retained unit to
-  release its systemd state. If a launcher was killed before its exit trap,
-  confirm that its unit and children have stopped, then remove its exact
-  `/run/kamiwaza-admin-extra-vars-<run>-attempt<n>.json` file before retrying.
-- Reuse a verified pre-extracted extension root. Do not select among stale
-  directories with an unordered search.
-- Do not blindly rerun an extension or deploy-gate phase after interruption.
-  First compare its persistent log, stored and visible catalog state, local
-  manifests, and API resources. If catalog import completed, reconcile it
-  instead of creating duplicates. If the deploy gate stranded its test
-  deployment, remove that exact deployment through the supported API before a
-  new attempt.
-- An SSM disconnect does not stop a system unit. A host reboot does remove all
-  transient units and every contract, secret, and launcher under `/run`. A
-  missing durable `result.rc` after reboot is interrupted/unknown, never
-  success. Inspect partial state, recreate `/run` inputs, and allocate a new
-  attempt. A pre-reboot `result.rc` of `0` is usable only with its saved recap
-  and fresh post-reboot health and provenance gates.
-- Never delete clusters, PVCs, registry volumes, or an instance as a default
-  retry. Destructive recovery requires a separate backup and rollback decision.
-- Do not treat repeated red `HEAD`/manifest-not-found lines from a local
-  registry as fatal by color alone. Determine whether the importer is probing
-  before upload, then use the unit result and final manifest/digest gates.
-
-Useful focused diagnostics:
-
-```bash
-ROOT_TOOLS=(sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
-sudo systemctl show <unit>.service \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID
-sudo journalctl -u <unit>.service -o cat
-"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
-"${ROOT_TOOLS[@]}" kubectl get pods -A -o wide
-"${ROOT_TOOLS[@]}" kubectl get events -A --sort-by=.lastTimestamp
-"${ROOT_TOOLS[@]}" helm list -A
-sudo podman ps -a
-df -hT / /tmp /var/tmp /var/lib /opt
-```
-
-If a preflight aborts at `storage_host_prep`, `/var/lib` cannot fit the
-configured storage image on its actual backing filesystem. Grow or remount that
-filesystem before retrying; do not treat the abort as a prompt or bypass the
-preflight.
-
-Keep secrets and full process argument lists out of diagnostic captures. If a
-password appears in output, treat it as exposed and rotate it through a
-supported path after the installation is stable.
-
-## Next steps
-
-- [Quickstart](../quickstart.md) — verify the user-facing platform.
+- [Quickstart](../quickstart.md) — confirm the service is running and take your first steps.
 - [Uninstalling Kamiwaza](uninstall.md).

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -31,7 +31,7 @@ The host's static hostname must be **55 characters or fewer**. Longer names
 overflow the certificate subject fields the cluster generates:
 
 ```bash
-hostnamectl --static | wc -c
+hostnamectl --static | tr -d '\n' | wc -c
 ```
 
 Throughout this guide, replace the placeholders:
@@ -248,18 +248,19 @@ Omitting the bulk tag, or any one of the three overrides, leaves a workload requ
 
 > **Installing over SSM, or any connection that can drop?** The install runs for
 > roughly 15-20 minutes in the foreground, and losing the session loses the
-> controlling process. Launch it as a transient systemd unit instead, so it
-> survives the shell:
+> controlling process. Run the whole Step 5 block inside a detached terminal
+> multiplexer, so the exported values below stay in the same shell as the
+> installer and the run survives a disconnect:
 >
 > ```bash
-> sudo systemd-run --no-block --service-type=oneshot --remain-after-exit \
->   --unit=kamiwaza-offline-install \
->   /opt/kamiwaza/scripts/install-prod.sh <the same arguments as below>
+> tmux new -s kamiwaza-install     # or: screen -S kamiwaza-install
 > ```
 >
-> Then judge the result from `systemctl show kamiwaza-offline-install` —
-> `Result=success` and `ExecMainStatus=0` — not from log activity. A quiet log
-> is not a finished install.
+> Export the block below and run `install-prod.sh` inside that session; reattach
+> after a drop with `tmux attach -t kamiwaza-install`. Judge the result from the
+> installer's exit status and the final Ansible recap (`failed=0`,
+> `unreachable=0`), not from log activity — a quiet log is not a finished
+> install.
 
 > **Keep `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G`** in the block below unless you have sized `/var/lib` for the 700 GB default — it is what brings the requirement down to the 350 GB floor in [Prerequisites](#prerequisites). This env var and the online guide's `-e storage_host_prep_virtual_block_size` extra-var are the same setting expressed two ways; the offline path sets it via the environment, the online path via an installer argument.
 

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -65,6 +65,14 @@ export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE
 sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
 cd /opt/kamiwaza/prereqs
 
+# Pass the license key to curl through a private header file rather than an
+# argument. Anything in argv is visible in `ps` output for the whole download.
+# Keep this file outside /opt/kamiwaza/prereqs so it is not carried along when
+# that directory is transferred to the target host.
+KEYGEN_HEADER="$(mktemp)"
+chmod 600 "${KEYGEN_HEADER}"
+printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" > "${KEYGEN_HEADER}"
+
 for file in \
   release_origination.md \
   kamiwaza-tools-rpm.pub.gpg \
@@ -95,7 +103,7 @@ do
   # resumes a partial one, so rerunning the block after an interruption
   # repairs truncated downloads instead of skipping them.
   curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
-    -H "Authorization: License ${KEYGEN_TOKEN}" \
+    -H @"${KEYGEN_HEADER}" \
     -o "$file" \
     "${BASE}/${file}"
 done
@@ -120,6 +128,8 @@ sha256sum -c "${EXT_BUNDLE}.sha256"
 grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
   | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
 sha256sum -c kamiwaza-prod.sha256
+
+rm -f "${KEYGEN_HEADER}"
 ```
 
 The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
@@ -277,7 +287,11 @@ Omitting the bulk tag, or any one of the three overrides, leaves a workload requ
 
 ```bash
 export DOMAIN="<domain>"
-export ADMIN_PASSWORD="<admin-password>"
+
+# install-prod.sh reads the admin password from this variable and unsets it
+# immediately, so it never appears in the installer's arguments where `ps` would
+# expose it for the whole run.
+export KAMIWAZA_ADMIN_PASSWORD="<admin-password>"
 
 export APP_TAG="release-1.2.0"
 export FRONTEND_TAG="${APP_TAG}"
@@ -303,7 +317,6 @@ export KAMIWAZA_IMAGE_OVERRIDES="postgres=v18.4,keycloak=${CONTAINERS_TAG},etcd=
 sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
   --domain "${DOMAIN}" \
-  --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
@@ -319,6 +332,7 @@ Make sure `${DOMAIN}` resolves from the install host, then install the extension
 ```bash
 export DOMAIN="<domain>"
 export ADMIN_PASSWORD="<admin-password>"
+export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 
 # Add a hosts-file entry if the domain does not already resolve locally
 if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
@@ -326,10 +340,11 @@ if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
   echo "${NODE_IP:-127.0.0.1} ${DOMAIN}" | sudo tee -a /etc/hosts
 fi
 
-BUNDLE_ROOT="$(sudo find /var/lib/kajiya-reports/extensions-bundle-preinstall \
-  -maxdepth 1 -type d -name 'kamiwaza-extensions-bundle-*' | sort | tail -1)"
+# Derive the staged path from the bundle name rather than searching for it, so a
+# retry or a second staged release cannot select the wrong extension tree.
+BUNDLE_ROOT="/var/lib/kajiya-reports/extensions-bundle-preinstall/${EXT_BUNDLE%.tar.gz}"
 
-test -n "${BUNDLE_ROOT}" || { echo "No pre-extracted extension bundle found"; exit 1; }
+sudo test -d "${BUNDLE_ROOT}" || { echo "No pre-staged extension bundle at ${BUNDLE_ROOT}"; exit 1; }
 
 printf '%s\n' "${ADMIN_PASSWORD}" | sudo "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
   --bundle-root "${BUNDLE_ROOT}" \

--- a/docs/docs/installation/offline_install.md
+++ b/docs/docs/installation/offline_install.md
@@ -44,16 +44,21 @@ Throughout this guide, replace the placeholders:
 
 The 1.2.0 offline bundle is published to Keygen as a set of split, checksummed artifacts. You download them (on a connected machine or on the host if it has temporary access), verify the checksums, and recombine the split parts.
 
-`RELEASE` must name the bundle exactly as it is published on Keygen. At the time of
-writing the published 1.2.0 bundle is `1.2.0-rc.3`; once a plain `1.2.0` bundle is
-published, use that instead. Check the artifact listing for your release rather than
-assuming — a `RELEASE` value that does not exist fails at the first download.
+`RELEASE` names the bundle as it is published on Keygen and must match an entry in
+your release's artifact listing — a value that does not exist fails at the first
+download.
+
+> **Installing before 1.2.0 is generally available?** The pre-release bundle is
+> published as `1.2.0-rc.3`. Set `RELEASE="1.2.0-rc.3"` and take the `EXT_BUNDLE`
+> filename from that bundle's artifact listing. Everything else on this page,
+> including the image tags and the override map, is unchanged — the pre-release
+> bundle already carries `release-1.2.0` images.
 
 The extension-bundle filename is likewise release-specific. The value below matches the published 1.2.0 bundle. If you are installing a different build, take the filename from the artifact listing for that release.
 
 ```bash
 export KEYGEN_TOKEN="<license-key>"
-export RELEASE="1.2.0-rc.3"
+export RELEASE="1.2.0"
 export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 

--- a/docs/docs/installation/online_install.md
+++ b/docs/docs/installation/online_install.md
@@ -17,6 +17,18 @@ images are pulled from Keygen.
 
 - A **Kamiwaza Prod license key**. The installer script is publicly downloadable, but a license key is required to pull the platform images. Contact your Kamiwaza representative if you do not have one.
 - A host that meets the [System Requirements](system_requirements.md).
+- **Free disk space on the volume backing `/var/lib`.** The installer preallocates
+  the cluster's storage image there, so this is the binding constraint and a large
+  total disk does not help if `/var` is a separate logical volume. The default
+  image is **700 GB**, which needs roughly **1.1 TB** free. To install on a smaller
+  host, pass `-e storage_host_prep_virtual_block_size=80G` in [Step 2](#step-2-run-the-installer),
+  which brings the requirement down to about **350 GB**. Check the backing
+  filesystem before you begin:
+
+  ```bash
+  df -hT /var/lib
+  findmnt -T /var/lib
+  ```
 - Outbound DNS and HTTPS access to:
   - your OS package repositories,
   - `raw.pkg.keygen.sh` (installer and fallback artifacts),
@@ -134,6 +146,7 @@ Frequently used **install arguments**:
 - `--admin-password <value>`: Initial admin password.
 - `-y`, `--yes`: Non-interactive install.
 - `-e k8s_runtime=kind`: Select the legacy Kind runtime when using the optional raw-image preload.
+- `-e storage_host_prep_virtual_block_size=<size>`: Size of the preallocated cluster storage image on the volume backing `/var/lib`. Defaults to `700G`, which requires roughly 1.1 TB free; `80G` reduces the requirement to about 350 GB. Size this for the data you expect to keep, not just to complete the install.
 
 Frequently used **installer options**:
 

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -42,7 +42,7 @@ See [Special Considerations](#special-considerations) for detailed unified memor
 
 ### Storage
 
-Storage requirements are the same across all platforms.
+Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
 
 #### Storage Performance
 
@@ -53,8 +53,10 @@ Storage requirements are the same across all platforms.
 
 #### Storage Capacity
 
-- **Minimum**: 100GB free disk space
-- **Recommended**: 200GB+ free disk space
+> **The installer preallocates cluster storage** on the volume backing `/var`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+
+- **Minimum**: 350GB free on the volume backing `/var` (with the `80G` OSD override)
+- **Recommended**: 1.1TB+ on `/var` at the default OSD size
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -68,7 +70,9 @@ Storage requirements are the same across all platforms.
 | **Vector Database** | 10GB | 100GB+ | For embeddings (if enabled) |
 | **Logs & Metrics** | 10GB | 50GB | Rotated logs, Ray dashboard data |
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
-| **Total** | **170GB** | **900GB+** | |
+| **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
+
+> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
 
 #### Storage Performance Requirements
 
@@ -201,9 +205,15 @@ free -h
 nproc
 # Expected: 8 or more cores
 
-# Check available disk space
+# Check available disk space on the volume backing /var (the binding constraint)
+df -h /var
+# Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
+
+# Check the root filesystem too
 df -h /
-# Expected: At least 100GB free (200GB+ recommended)
+# Expected: At least 30GB free (50GB for the offline install path)
+# If /var is not a separate mount, both commands report the same filesystem —
+# size the root volume to the /var figure, not the sum of the two.
 ```
 
 ---
@@ -241,7 +251,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 8-16 cores / 16-32 threads
 - **RAM:** 32GB (16GB minimum for development only)
-- **Storage:** 200GB NVMe SSD (100GB minimum)
+- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
 - **GPU:** Optional - Single GPU with 16-24GB VRAM
   - NVIDIA RTX 4090 (24GB)
   - NVIDIA RTX 4080 (16GB)
@@ -260,7 +270,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 32 cores / 64 threads
 - **RAM:** 128-256GB system RAM
-- **Storage:** 1-2TB NVMe SSD
+- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 350GB (provision 400GB to clear it comfortably), but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
 - **GPU:** 1-4 GPUs with 40GB+ VRAM each
   - 1-4x NVIDIA B200 (192GB HBM3e)
   - 1-4x NVIDIA H200 (141GB HBM3e)
@@ -287,7 +297,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Head Node (Control Plane):**
 - **CPU:** 16 cores / 32 threads
 - **RAM:** 64GB
-- **Storage:** 500GB NVMe SSD
+- **Storage:** 500GB NVMe SSD (assumes the `80G` OSD override; 1.1TB+ at the default OSD size)
 - **GPU:** Same class as worker nodes (homogeneous cluster recommended)
 - **Role:** Ray head, API gateway, scheduling, monitoring (head performs minimal extra work; Ray backend load is distributed across nodes)
 
@@ -322,14 +332,15 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | Instance Type | vCPU | RAM | GPU | Storage |
 |------|--------------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `m6i.2xlarge` | 8 | 32GB | None | 200GB gp3 |
-| **Tier 1: With GPU** | `g5.xlarge` | 4 | 16GB | 1x A10G (24GB) | 200GB gp3 |
-| **Tier 1: Alternative** | `g5.2xlarge` | 8 | 32GB | 1x A10G (24GB) | 200GB gp3 |
+| **Tier 1: CPU-only** | `m6i.2xlarge` | 8 | 32GB | None | 400GB gp3 |
+| **Tier 1: With GPU** | `g5.xlarge` | 4 | 16GB | 1x A10G (24GB) | 400GB gp3 |
+| **Tier 1: Alternative** | `g5.2xlarge` | 8 | 32GB | 1x A10G (24GB) | 400GB gp3 |
 | **Tier 2: Multi-GPU** | `g5.12xlarge` | 48 | 192GB | 4x A10G (96GB) | 2TB gp3 |
 | **Tier 2: Alternative** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 | **Tier 3: All Nodes** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use `gp3` SSD volumes (not `gp2`) for better performance/cost
 - For Tier 3 shared storage: Amazon FSx for Lustre or EFS (with Provisioned Throughput)
 - Use Placement Groups for low-latency multi-node clusters (Tier 3)
@@ -340,14 +351,15 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | Machine Type | vCPU | RAM | GPU | Storage |
 |------|-------------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `n2-standard-8` | 8 | 32GB | None | 200GB SSD |
-| **Tier 1: With GPU** | `n1-standard-8` + `1x T4` | 8 | 30GB | 1x T4 (16GB) | 200GB SSD |
-| **Tier 1: Alternative** | `g2-standard-8` + `1x L4` | 8 | 32GB | 1x L4 (24GB) | 200GB SSD |
+| **Tier 1: CPU-only** | `n2-standard-8` | 8 | 32GB | None | 400GB SSD |
+| **Tier 1: With GPU** | `n1-standard-8` + `1x T4` | 8 | 30GB | 1x T4 (16GB) | 400GB SSD |
+| **Tier 1: Alternative** | `g2-standard-8` + `1x L4` | 8 | 32GB | 1x L4 (24GB) | 400GB SSD |
 | **Tier 2: Multi-GPU** | `a2-highgpu-4g` | 48 | 340GB | 4x A100 (160GB) | 2TB SSD |
 | **Tier 2: Alternative** | `g2-standard-48` + `4x L4` | 48 | 192GB | 4x L4 (96GB) | 2TB SSD |
 | **Tier 3: All Nodes** | `a2-highgpu-8g` | 96 | 680GB | 8x A100 (320GB) | 2TB SSD |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use `pd-ssd` or `pd-balanced` persistent disks (not `pd-standard`)
 - For Tier 3 shared storage: Filestore High Scale tier (up to 10 GB/s)
 - Use Compact Placement for low-latency multi-node clusters (Tier 3)
@@ -358,9 +370,9 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | VM Size | vCPU | RAM | GPU | Storage |
 |------|---------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `Standard_D8s_v5` | 8 | 32GB | None | 200GB Premium SSD |
-| **Tier 1: With GPU** | `Standard_NC4as_T4_v3` | 4 | 28GB | 1x T4 (16GB) | 200GB Premium SSD |
-| **Tier 1: Alternative** | `Standard_NC6s_v3` | 6 | 112GB | 1x V100 (16GB) | 200GB Premium SSD |
+| **Tier 1: CPU-only** | `Standard_D8s_v5` | 8 | 32GB | None | 400GB Premium SSD |
+| **Tier 1: With GPU** | `Standard_NC4as_T4_v3` | 4 | 28GB | 1x T4 (16GB) | 400GB Premium SSD |
+| **Tier 1: Alternative** | `Standard_NC6s_v3` | 6 | 112GB | 1x V100 (16GB) | 400GB Premium SSD |
 | **Tier 2: H100 (recommended)** | `Standard_NC40ads_H100_v5` | 40 | 320GB | 1x H100 (80GB) | 2TB Premium SSD |
 | **Tier 2: H100 Multi-GPU** | `Standard_NC80adis_H100_v5` | 80 | 640GB | 2x H100 (160GB) | 2TB Premium SSD |
 | **Tier 2: A100 Multi-GPU** | `Standard_NC96ads_A100_v4` | 96 | 880GB | 4x A100 (320GB) | 2TB Premium SSD |
@@ -369,6 +381,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: A100 Alternative** | `Standard_ND96asr_v4` | 96 | 900GB | 8x A100 (320GB) | 2TB Premium SSD |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use Premium SSD (not Standard HDD or Standard SSD)
 - For Tier 3 shared storage: Azure NetApp Files Premium or Ultra tier
 - Use Proximity Placement Groups for low-latency multi-node clusters (Tier 3)

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -53,10 +53,15 @@ Storage *performance* requirements are the same across all platforms. Storage **
 
 #### Storage Capacity
 
-> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var/lib`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so that filesystem — not the total disk — is the binding constraint. How much you need depends on the storage image size, and the two install paths default differently:
 
-- **Minimum**: 350GB free on the volume backing `/var/lib` (with the `80G` OSD override)
-- **Recommended**: 1.1TB+ on `/var/lib` at the default OSD size
+| Install path | Storage image | Free space needed on `/var/lib` |
+|---|---|---|
+| **Offline** | `80G` — [the guide sets this](offline_install.md#step-5-install-kamiwaza) | **≥ 350 GB** |
+| **Online**, default | `700G` | **≈ 1.1 TB** |
+| **Online**, reduced | pass [`-e storage_host_prep_virtual_block_size=80G`](online_install.md#common-options) | **≥ 350 GB** |
+
+The image is preallocated at install time and also holds all stateful data, so size it for the data you expect to keep, not merely to complete the install.
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -70,9 +75,9 @@ Storage *performance* requirements are the same across all platforms. Storage **
 | **Vector Database** | 10GB | 100GB+ | For embeddings (if enabled) |
 | **Logs & Metrics** | 10GB | 50GB | Rotated logs, Ray dashboard data |
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
-| **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
+| **Total** | **350GB** | **1.1TB+** | Governed by the `/var/lib` floor above, not the sum of the rows |
 
-> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var/lib` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
+> The rows above describe how space is *used* once running. Sizing to their sum alone will fail at host prep: the binding constraint is the preallocated storage image, whose figure depends on your install path — see the table above.
 
 #### Storage Performance Requirements
 
@@ -207,13 +212,15 @@ nproc
 
 # Check available disk space on the volume backing /var/lib (the binding constraint)
 df -h /var/lib
-# Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
+# Expected: At least 350GB for an offline install, or an online install passing
+# -e storage_host_prep_virtual_block_size=80G; 1.1TB+ for an online install at
+# the default storage image size
 
 # Check the root filesystem too
 df -h /
 # Expected: At least 30GB free (50GB for the offline install path)
 # If /var is not a separate mount, both commands report the same filesystem —
-# size the root volume to the /var figure, not the sum of the two.
+# size the root volume to the /var/lib figure, not the sum of the two.
 ```
 
 ---

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -42,7 +42,7 @@ See [Special Considerations](#special-considerations) for detailed unified memor
 
 ### Storage
 
-Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
+Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var/lib`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
 
 #### Storage Performance
 
@@ -53,10 +53,10 @@ Storage *performance* requirements are the same across all platforms. Storage **
 
 #### Storage Capacity
 
-> **The installer preallocates cluster storage** on the volume backing `/var`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var/lib`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
 
-- **Minimum**: 350GB free on the volume backing `/var` (with the `80G` OSD override)
-- **Recommended**: 1.1TB+ on `/var` at the default OSD size
+- **Minimum**: 350GB free on the volume backing `/var/lib` (with the `80G` OSD override)
+- **Recommended**: 1.1TB+ on `/var/lib` at the default OSD size
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -72,7 +72,7 @@ Storage *performance* requirements are the same across all platforms. Storage **
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
 | **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
 
-> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
+> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var/lib` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
 
 #### Storage Performance Requirements
 
@@ -205,8 +205,8 @@ free -h
 nproc
 # Expected: 8 or more cores
 
-# Check available disk space on the volume backing /var (the binding constraint)
-df -h /var
+# Check available disk space on the volume backing /var/lib (the binding constraint)
+df -h /var/lib
 # Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
 
 # Check the root filesystem too
@@ -251,7 +251,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 8-16 cores / 16-32 threads
 - **RAM:** 32GB (16GB minimum for development only)
-- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
+- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var/lib` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
 - **GPU:** Optional - Single GPU with 16-24GB VRAM
   - NVIDIA RTX 4090 (24GB)
   - NVIDIA RTX 4080 (16GB)
@@ -340,7 +340,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: All Nodes** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use `gp3` SSD volumes (not `gp2`) for better performance/cost
 - For Tier 3 shared storage: Amazon FSx for Lustre or EFS (with Provisioned Throughput)
 - Use Placement Groups for low-latency multi-node clusters (Tier 3)
@@ -359,7 +359,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: All Nodes** | `a2-highgpu-8g` | 96 | 680GB | 8x A100 (320GB) | 2TB SSD |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use `pd-ssd` or `pd-balanced` persistent disks (not `pd-standard`)
 - For Tier 3 shared storage: Filestore High Scale tier (up to 10 GB/s)
 - Use Compact Placement for low-latency multi-node clusters (Tier 3)
@@ -381,7 +381,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: A100 Alternative** | `Standard_ND96asr_v4` | 96 | 900GB | 8x A100 (320GB) | 2TB Premium SSD |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use Premium SSD (not Standard HDD or Standard SSD)
 - For Tier 3 shared storage: Azure NetApp Files Premium or Ultra tier
 - Use Proximity Placement Groups for low-latency multi-node clusters (Tier 3)

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -27,7 +27,7 @@ findmnt -T /var/lib
 lsblk -f
 ```
 
-The host's static hostname must be **55 characters or fewer**. Longer names
+The host's static hostname must be **54 characters or fewer**. Longer names
 overflow the certificate subject fields the cluster generates:
 
 ```bash
@@ -58,9 +58,17 @@ The extension-bundle filename is likewise release-specific. The value below matc
 
 ```bash
 export KEYGEN_TOKEN="<license-key>"
-export RELEASE="1.2.0"
-export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
-export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
+
+# The whole block runs fail-fast in a subshell: any failed download, checksum, or
+# reassembly stops it immediately rather than leaving partial artifacts to be
+# transferred or installed. The trap removes the credential file on every exit
+# path, including failure.
+(
+set -euo pipefail
+
+RELEASE="1.2.0"
+EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
+BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 
 sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
 cd /opt/kamiwaza/prereqs
@@ -71,6 +79,7 @@ cd /opt/kamiwaza/prereqs
 # that directory is transferred to the target host.
 KEYGEN_HEADER="$(mktemp)"
 chmod 600 "${KEYGEN_HEADER}"
+trap 'rm -f "${KEYGEN_HEADER}"' EXIT
 printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" > "${KEYGEN_HEADER}"
 
 for file in \
@@ -128,8 +137,7 @@ sha256sum -c "${EXT_BUNDLE}.sha256"
 grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
   | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
 sha256sum -c kamiwaza-prod.sha256
-
-rm -f "${KEYGEN_HEADER}"
+)
 ```
 
 The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
@@ -228,7 +236,7 @@ Stage the extension bundle before installing the platform:
 ```bash
 cd /opt/kamiwaza/prereqs
 
-EXT_BUNDLE="${EXT_BUNDLE:-$(ls -1 kamiwaza-extensions-bundle-*.tar.gz | tail -1)}"
+EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 rm -rf /tmp/kamiwaza-ext-extract
 mkdir -p /tmp/kamiwaza-ext-extract
 tar -xzf "$EXT_BUNDLE" -C /tmp/kamiwaza-ext-extract

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -114,9 +114,15 @@ cat "${EXT_BUNDLE}".part-{000..004} > "${EXT_BUNDLE}"
 ln -sf kamiwaza-helm.00.tar kamiwaza-helm.tar
 sha256sum -c kamiwaza-helm.sha256
 sha256sum -c "${EXT_BUNDLE}.sha256"
+
+# Verify the prerequisites RPM against the hash recorded in release_origination.md.
+# Step 2 installs it as root, so establish its integrity first.
+grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
+  | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
+sha256sum -c kamiwaza-prod.sha256
 ```
 
-The `release_origination.md` artifact records the build provenance and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
+The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
 
 > If a download stalls, rerun the block — `curl --continue-at -` resumes partial files. If you downloaded on a separate connected machine, transfer the entire `/opt/kamiwaza/prereqs` directory to the same path on the target host before continuing.
 

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -1,1446 +1,348 @@
 # Offline Installation
 
-This guide installs Kamiwaza on a standalone RHEL 9 x86_64 host from a
-previously published offline bundle. The target does not pull product images
-during the install. Whether the **host bootstrap** can also run without any
-network access depends on the selected bundle: do not call an installation
-fully air-gapped unless that exact build was tested with disconnected RHEL
-package sources.
+The offline installer is for **air-gapped or restricted RHEL 9 environments** with no outbound internet access on the target host. You download the Kamiwaza bundle on a connected machine, transfer it to the target host, and install without pulling anything from the internet during installation.
 
-> This is an advanced, operator-driven path. If the target has normal internet
-> access, use [Online Installation](online_install.md). This page describes the
-> standalone `k0s-podman` topology; an EKS recipe is not an alternative source
-> of truth for this installation.
+**Supported host:** RHEL-compatible 9.x (x86_64).
 
-An offline deployment has three separate completion levels:
+> This is an advanced, operator-driven path. If your host has internet access, use the simpler [Online Installation](online_install.md) instead.
 
-1. **Core installed:** the platform is healthy and login works.
-2. **Bundle installed:** bundled extension images are loaded and the live
-   catalog is imported.
-3. **Release parity (publisher qualification):** one bundled extension is
-   deployed, verified, and removed through the supported catalog/API path, plus
-   any additional gates recorded by the selected release run.
+## Prerequisites
 
-Do not report level 2 or 3 after only pre-staging the extension catalog.
-Level 3 requires the private, hash-recorded Kajiya gate inputs from the selected
-run and is performed by Kamiwaza release engineers; it is not a customer
-installation requirement. A customer handoff without those internal inputs can
-complete and report levels 1 and 2.
+- A **Kamiwaza Prod license key**, used to download the bundle artifacts from Keygen.
+- A RHEL-compatible 9.x host (x86_64) that meets the [System Requirements](system_requirements.md).
+- **Free disk space, on the right filesystems.** The offline flow stages large artifacts and provisions cluster storage under `/`, `/tmp`, and `/var/lib`. Confirm each path has room on the **volume that actually backs it** — on hosts with LVM or separate partitions (most cloud RHEL images ship this way), a large total disk does **not** help if `/var` is a small separate volume. Recommended free space:
+  - **`/var/lib` ≥ 350 GB**, assuming `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G` is set in [Step 5](#step-5-install-kamiwaza). Without that export the OSD image defaults to 700 GB and you need **1.1 TB** instead. The OSD image is preallocated at install time and also holds all stateful data, so size it for the data you expect to keep, not just to complete the install.
+  - **`/tmp` ≥ 25 GB** — bundle extraction and install scratch space.
+  - **`/` ≥ 50 GB** — the downloaded bundle and its recombined tarballs under `/opt/kamiwaza/prereqs` (~25 GB), plus installed tooling under `/opt` and `/usr/local`.
 
-## Before you begin
+  A small default `/tmp` or `/var` is the most common cause of install failure. It surfaces in one of three ways, none of which mentions disk space directly: the preflight aborts at `storage_host_prep` with an `fs-virtual-block free space` error; an image import fails with `no space left on device`; or the helmfile sync fails roughly ten minutes in with `Progress deadline exceeded` on the `cert-manager` deployments and `FailedScheduling: 1 node(s) had untolerated taint(s)` on their pods — that last one is the kubelet disk-pressure taint, not a cert-manager fault. Grow the backing LV or partition (or mount adequate storage at `/var/lib`) **before** you begin.
+- A machine with internet access to download the bundle, and a way to transfer files to the target host.
 
-You need:
-
-- A supported RHEL-compatible 9.x x86_64 host that meets the
-  [System Requirements](system_requirements.md).
-- A host name no longer than 54 characters.
-- A Kamiwaza license and access to one **immutable** release or Kajiya run.
-- A connected staging machine if the target cannot download the artifacts.
-- Root access on the target. For a remote private host, Session Manager (SSM)
-  or an equivalent managed shell is preferred over SSH.
-- Bash 4.4 or newer plus GNU `coreutils`, `findutils`, `curl`, `jq`, `gpg`, and
-  `tar` on every machine that runs the snippets. They use GNU options and do not
-  run in stock macOS Bash; use a trusted Linux staging host or container when
-  the connected workstation is a Mac. If the target has no reachable RHEL
-  repositories, those tools and all OS packages required by the selected
-  prerequisite bootstrap must already be available through a trusted local
-  repository or the verified handoff.
-
-### Check the actual filesystems
-
-The bundle, extracted extensions, container images, and the Rook/Ceph OSD can
-live on different filesystems. A large virtual disk is not proof that
-`/var/lib` or `/tmp` has room; cloud RHEL images commonly put `/var` on a small
-logical volume.
-
-Before transfer, calculate the compressed bundle total, the extracted
-extension size, installer scratch, image-store growth, the configured OSD image
-size, and operational headroom. Then check the backing filesystems:
+Confirm which filesystem actually backs each path before you transfer anything — a
+large total disk tells you nothing if `/var` is a separate logical volume:
 
 ```bash
 df -hT / /tmp /var/tmp /var/lib /opt
-findmnt -T /tmp
-findmnt -T /var/tmp
 findmnt -T /var/lib
-findmnt -T /opt
 lsblk -f
 ```
 
-There is no release-independent free-space floor for this path. The verified
-staging copy, `/opt/kamiwaza/prereqs` copy, logical-wrap scratch space under
-`/var/tmp`, extracted extension tree, image store, and configured OSD can
-coexist. Calculate their peak sizes from the selected handoff and budget each
-copy on its actual backing filesystem. Grow the correct PV/LV/filesystem before
-installation and run `df` again afterward.
-
-Also confirm that no package manager, previous installer, Kubernetes bootstrap,
-or local-registry import is running. Understand any existing `/opt/kamiwaza`,
-`/var/lib/k0s`, Podman, or cluster state before rerunning an installer.
-
-Verify the host before transferring large artifacts:
+The host's static hostname must be **55 characters or fewer**. Longer names
+overflow the certificate subject fields the cluster generates:
 
 ```bash
-(
-set -euo pipefail
-test "$(uname -m)" = x86_64
-grep -E 'release 9([. ]|$)' /etc/redhat-release
-test "$(hostnamectl --static | wc -c)" -le 55
-((BASH_VERSINFO[0] > 4 ||
-  (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)))
-for command_name in \
-  awk curl find findmnt gpg jq lsblk rpm sha256sum sort stat sudo systemctl \
-  systemd-run tar; do
-  command -v "${command_name}" >/dev/null
-done
-)
+hostnamectl --static | wc -c
 ```
 
-If the host is reached through SSM, validate all four access paths before the
-install window: the instance is `Online`, a harmless Run Command succeeds, an
-interactive Session Manager shell opens, and local port forwarding starts.
-Resolve any configured Session Manager RunAs user mismatch first; do not enable
-SSH as an ad hoc fallback.
+Throughout this guide, replace the placeholders:
+
+- `<license-key>` — your Kamiwaza Prod license key.
+- `<domain>` — the base domain to serve Kamiwaza from (for example `kamiwaza.example.com`).
+- `<admin-password>` — the initial admin password.
+
+## Step 1: Download the Bundle Artifacts
+
+The 1.2.0 offline bundle is published to Keygen as a set of split, checksummed artifacts. You download them (on a connected machine or on the host if it has temporary access), verify the checksums, and recombine the split parts.
+
+`RELEASE` must name the bundle exactly as it is published on Keygen. At the time of
+writing the published 1.2.0 bundle is `1.2.0-rc.3`; once a plain `1.2.0` bundle is
+published, use that instead. Check the artifact listing for your release rather than
+assuming — a `RELEASE` value that does not exist fails at the first download.
+
+The extension-bundle filename is likewise release-specific. The value below matches the published 1.2.0 bundle. If you are installing a different build, take the filename from the artifact listing for that release.
 
 ```bash
-aws ssm describe-instance-information \
-  --filters Key=InstanceIds,Values=<instance-id> \
-  --region <region> --profile <profile>
+export KEYGEN_TOKEN="<license-key>"
+export RELEASE="1.2.0-rc.3"
+export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
+export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 
-COMMAND_ID="$(aws ssm send-command \
-  --instance-ids <instance-id> \
-  --document-name AWS-RunShellScript \
-  --parameters 'commands=["id","true"]' \
-  --query 'Command.CommandId' --output text \
-  --region <region> --profile <profile>)"
-aws ssm wait command-executed \
-  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
-  --region <region> --profile <profile>
-aws ssm get-command-invocation \
-  --command-id "${COMMAND_ID}" --instance-id <instance-id> \
-  --query '{Status:Status,ResponseCode:ResponseCode}' \
-  --region <region> --profile <profile>
+sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
+cd /opt/kamiwaza/prereqs
 
-aws ssm start-session \
-  --target <instance-id> \
-  --region <region> --profile <profile>
-
-aws ssm start-session \
-  --target <instance-id> \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["443"],"localPortNumber":["8443"]}' \
-  --region <region> --profile <profile>
-```
-
-## 1. Select and record the exact bundle
-
-Never copy artifact names, tags, or image overrides from another release. Start
-with the Keygen release or exact Kajiya workflow run selected for this install
-and record:
-
-- release/run identifier, attempt, source prefix, and publication inventory;
-- immutable Kajiya, Deploy, Core, Containers, and extension source commits;
-- every object name and SHA-256, plus sizes where the publisher exposes them;
-- runtime, resource profile, OSD size, and compatibility flags;
-- every product tag and the complete `KAMIWAZA_IMAGE_OVERRIDES` map;
-- extension helper names and hashes; and
-- the release's required verification gates.
-
-Download `release_origination.md` first. Its `## Artifacts` section is the
-authoritative hash list for source artifacts and its repository section records
-provenance. It is **not** by itself the full launcher contract: settings such as
-the complete image-override map can come from the exact Kajiya run. If the
-publisher cannot supply both provenance and the complete install contract, stop
-instead of guessing from a previous release.
-
-Modern bundle roles normally include:
-
-- `release_origination.md`;
-- one `kamiwaza-prod-*.el9.x86_64.rpm`;
-- one or more `kamiwaza-helm.<number>.tar` wrap chunks;
-- `kamiwaza-helm.sha256`, `kamiwaza-helm.asc`, and the signing public key;
-- optionally, one extension bundle plus its `.sha256`; and
-- for files split by the distribution service, `.part-NNN` files, per-part
-  sidecars, and a `.parts.json` assembly manifest.
-
-The number and names are release-specific. The publisher must supply a complete
-post-distribution `artifacts.tsv` with tab-separated filename and SHA-256
-columns, including any generated part manifests, parts, and part sidecars. The
-customer-reachable `release_origination.md` authenticates source-artifact
-hashes, but does not enumerate every distribution-added object or provide a
-byte count for every artifact. If the publisher does not supply the complete
-post-distribution inventory, stop. Keep it with the installation record.
-
-## 2. Download, transfer, and verify artifacts
-
-On the connected staging machine, use the selected package URL and the exact
-inventory. The example below is deliberately parameterized; `<release>` is the
-immutable selected release or run tag, not a version copied from this page.
-
-```bash
-export RELEASE="<release>"
-export PACKAGE_KEY="<exact-package-key-from-the-selected-release>"
-export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@${PACKAGE_KEY}/${RELEASE}"
-export ARTIFACT_DIR="${PWD}/kamiwaza-offline-${RELEASE}"
-export INVENTORY_SOURCE="<secure-path-to-artifacts.tsv>"
-
-(
-set -euo pipefail
-[[ "${RELEASE}" =~ ^[A-Za-z0-9._-]+$ ]]
-[[ "${INVENTORY_SOURCE}" != *'<'* ]]
-test -f "${INVENTORY_SOURCE}"
-
-read -rsp 'Kamiwaza license token: ' KEYGEN_TOKEN; printf '\n'
-
-AUTH_HEADER="$(mktemp)"
-chmod 0600 "${AUTH_HEADER}"
-trap 'rm -f "${AUTH_HEADER}"' EXIT
-printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" >"${AUTH_HEADER}"
-unset KEYGEN_TOKEN
-
-install -d -m 0755 "${ARTIFACT_DIR}"
-cp "${INVENTORY_SOURCE}" "${ARTIFACT_DIR}/artifacts.tsv"
-cd "${ARTIFACT_DIR}"
-
-artifact_count=0
-while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
-  [[ -n "${file}" && "${file}" != \#* ]] || continue
-  [[ -z "${extra:-}" ]]
-  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  ((artifact_count += 1))
-
-  if [[ -f "${file}" ]] &&
-     printf '%s  %s\n' "${expected_sha}" "${file}" | sha256sum -c - >/dev/null; then
-    printf 'already verified: %s\n' "${file}"
-    continue
-  fi
-  rm -f "${file}"
-
-  if [[ -f "${file}.partial" ]] &&
-     printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c - >/dev/null; then
-    mv "${file}.partial" "${file}"
-    continue
-  fi
-
-  curl_rc=0
+for file in \
+  release_origination.md \
+  kamiwaza-tools-rpm.pub.gpg \
+  kamiwaza-helm.sha256 \
+  kamiwaza-helm.asc \
+  kamiwaza-helm.00.tar.part-000 \
+  kamiwaza-helm.00.tar.part-000.sha256 \
+  kamiwaza-helm.00.tar.part-001 \
+  kamiwaza-helm.00.tar.part-001.sha256 \
+  kamiwaza-helm.00.tar.part-002 \
+  kamiwaza-helm.00.tar.part-002.sha256 \
+  kamiwaza-helm.00.tar.parts.json \
+  kamiwaza-prod-1.2.0-1.el9.x86_64.rpm \
+  "${EXT_BUNDLE}.sha256" \
+  "${EXT_BUNDLE}.part-000" \
+  "${EXT_BUNDLE}.part-000.sha256" \
+  "${EXT_BUNDLE}.part-001" \
+  "${EXT_BUNDLE}.part-001.sha256" \
+  "${EXT_BUNDLE}.part-002" \
+  "${EXT_BUNDLE}.part-002.sha256" \
+  "${EXT_BUNDLE}.part-003" \
+  "${EXT_BUNDLE}.part-003.sha256" \
+  "${EXT_BUNDLE}.part-004" \
+  "${EXT_BUNDLE}.part-004.sha256" \
+  "${EXT_BUNDLE}.parts.json"
+do
+  # Always attempt a resume: curl --continue-at - fetches a fresh file or
+  # resumes a partial one, so rerunning the block after an interruption
+  # repairs truncated downloads instead of skipping them.
   curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
-    --header "@${AUTH_HEADER}" \
-    -o "${file}.partial" \
-    "${BASE}/${file}" || curl_rc=$?
-  if ((curl_rc != 0)); then
-    # A rejected/invalid range cannot become resumable without discarding it.
-    # Preserve partial bytes for ordinary transport timeouts.
-    case "${curl_rc}" in
-      22|33|36) rm -f "${file}.partial" ;;
-    esac
-    exit "${curl_rc}"
-  fi
-
-  if ! printf '%s  %s\n' "${expected_sha}" "${file}.partial" | sha256sum -c -; then
-    rm -f "${file}.partial"
-    printf 'download verification failed: %s\n' "${file}" >&2
-    exit 1
-  fi
-  mv "${file}.partial" "${file}"
-done < artifacts.tsv
-((artifact_count > 0)) || {
-  printf 'artifacts.tsv contained no artifact records\n' >&2
-  exit 1
-}
-)
-```
-
-Do not put license tokens in command logs, shell history, or the installation
-record. A cloud-to-cloud relay may be faster than a local upload, but use a
-managed identity or short-lived prefix-scoped credential and verify again on
-the final target. S3 ETags are not SHA-256 integrity checks.
-
-### Reassemble distribution parts
-
-Each `.parts.json` records the original filename/hash and the ordered part
-inventory. Reassemble from that manifest instead of hardcoding part counts:
-
-Skip this block when the inventory contains no `.parts.json` files.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-shopt -s nullglob
-manifests=( *.parts.json )
-((${#manifests[@]} > 0)) || {
-  printf 'no part manifests found\n' >&2
-  exit 1
-}
-
-for manifest in "${manifests[@]}"; do
-  output="$(jq -er '.source.filename' "${manifest}")"
-  expected_size="$(jq -er '.source.size' "${manifest}")"
-  expected_sha="$(jq -er '.source.sha256' "${manifest}")"
-  [[ "${output}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_size}" =~ ^[0-9]+$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  jq -e '.parts | type == "array" and length > 0' "${manifest}" >/dev/null
-
-  : > "${output}.assembling"
-  part_count=0
-  while IFS=$'\t' read -r part part_sha; do
-    [[ "${part}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-    [[ "${part_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-    printf '%s  %s\n' "${part_sha}" "${part}" | sha256sum -c -
-    cat "${part}" >> "${output}.assembling"
-    ((part_count += 1))
-  done < <(jq -r '.parts[] | [.filename, .sha256] | @tsv' "${manifest}")
-
-  ((part_count > 0))
-  test "$(stat -c %s "${output}.assembling")" = "${expected_size}"
-  printf '%s  %s\n' "${expected_sha}" "${output}.assembling" | sha256sum -c -
-  mv "${output}.assembling" "${output}"
-done
-)
-```
-
-### Verify source artifacts and the logical wrap
-
-Verify every artifact recorded in `release_origination.md`:
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-artifact_count=0
-while read -r file expected; do
-  test -f "${file}"
-  printf '%s  %s\n' "${expected}" "${file}" | sha256sum -c -
-  ((artifact_count += 1))
-done < <(
-  awk '
-    $0 == "## Artifacts" { in_artifacts=1; next }
-    in_artifacts && /^## / { exit }
-    in_artifacts && /^- / {
-      name=$2; sub(/:$/, "", name); print name, $3
-    }
-  ' release_origination.md
-)
-((artifact_count > 0)) || {
-  printf 'release_origination.md contained no artifact records\n' >&2
-  exit 1
-}
-)
-```
-
-`kamiwaza-helm.sha256` names the **logical concatenated wrap**, which might not
-exist as a physical file. Hash the bytewise concatenation of all numbered wrap
-chunks in natural numeric order. Creating a similarly named symlink does not
-verify this contract.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-mapfile -d '' WRAP_CHUNKS < <(
-  find . -maxdepth 1 -type f -regextype posix-extended \
-    -regex './kamiwaza-helm\.[0-9]+\.tar' -print0 | sort -z -V
-)
-((${#WRAP_CHUNKS[@]} > 0))
-
-expected="$(awk 'NR==1 {print $1}' kamiwaza-helm.sha256)"
-actual="$(cat "${WRAP_CHUNKS[@]}" | sha256sum | awk '{print $1}')"
-test "${actual}" = "${expected}"
-printf 'logical wrap checksum: OK (%s chunks)\n' "${#WRAP_CHUNKS[@]}"
-)
-```
-
-Verify the detached signature over the checksum file. Confirm the signer
-fingerprint through an independent trusted channel; a key delivered in the same
-directory proves bundle consistency, not independently anchored provenance.
-
-```bash
-(
-set -euo pipefail
-cd "${ARTIFACT_DIR:?export ARTIFACT_DIR first}"
-export GNUPGHOME="$(mktemp -d)"
-chmod 0700 "${GNUPGHOME}"
-trap 'rm -rf "${GNUPGHOME}"' EXIT
-gpg --batch --import ./kamiwaza-tools-rpm.pub.gpg
-gpg --batch --verify ./kamiwaza-helm.asc ./kamiwaza-helm.sha256
-gpg --batch --with-colons --fingerprint
-)
-```
-
-Transfer the entire verified directory to
-`/var/tmp/kamiwaza-offline/<release-or-run>` on the target, then repeat the
-hash, logical-wrap, and signature checks there. Perform the rest of this guide
-only from that final target copy.
-
-## 3. Install and verify embedded prerequisites
-
-Move the verified artifacts into the fixed prerequisite path, install the exact
-RPM, and run its packaged bootstrap noninteractively:
-
-```bash
-export ARTIFACT_DIR="/var/tmp/kamiwaza-offline/<release-or-run>"
-
-(
-set -euo pipefail
-
-mapfile -t RPM_FILES < <(
-  find "${ARTIFACT_DIR}" -maxdepth 1 -type f \
-    -name 'kamiwaza-prod-*.el9.x86_64.rpm' -print
-)
-mapfile -t WRAP_FILES < <(
-  find "${ARTIFACT_DIR}" -maxdepth 1 -type f -regextype posix-extended \
-    -regex '.*/kamiwaza-helm\.[0-9]+\.tar' -print | sort -V
-)
-test "${#RPM_FILES[@]}" -eq 1
-((${#WRAP_FILES[@]} > 0))
-
-sudo install -d -m 0755 /opt/kamiwaza/prereqs
-existing_bundle_file="$({
-  sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
-    \( -name 'kamiwaza-prod-*.el9.x86_64.rpm' \
-       -o -name 'kamiwaza-helm.*.tar' \
-       -o -name 'kamiwaza-helm.sha256' \
-       -o -name 'kamiwaza-helm.asc' \
-       -o -name 'kamiwaza-tools-rpm.pub.gpg' \
-       -o -name '*.parts.json' \
-       -o -name 'artifacts.tsv' \) \
-    -print -quit
-})"
-if [[ -n "${existing_bundle_file}" ]]; then
-  printf 'existing staged bundle artifact: %s\n' "${existing_bundle_file}" >&2
-  printf 'verify and archive or remove the complete staged set before retrying, even for the same release\n' >&2
-  exit 1
-fi
-
-sudo install -o root -g root -m 0600 "${ARTIFACT_DIR}/artifacts.tsv" \
-  /opt/kamiwaza/prereqs/artifacts.tsv
-
-declare -A INVENTORY=()
-while IFS=$'\t' read -r file expected_sha extra || [[ -n "${file}" ]]; do
-  [[ -n "${file}" && "${file}" != \#* ]] || continue
-  [[ -z "${extra:-}" ]]
-  [[ "${file}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  [[ ! -v "INVENTORY[${file}]" ]]
-  INVENTORY["${file}"]="${expected_sha}"
-done < <(sudo cat /opt/kamiwaza/prereqs/artifacts.tsv)
-((${#INVENTORY[@]} > 0))
-
-# A split source is reconstructed locally and therefore is not itself a row in
-# the post-distribution inventory. Root-stage each authenticated manifest and
-# add its source hash to the accepted source map.
-declare -A SOURCE_INVENTORY=()
-shopt -s nullglob
-PART_MANIFESTS=("${ARTIFACT_DIR}"/*.parts.json)
-for manifest in "${PART_MANIFESTS[@]}"; do
-  manifest_name="$(basename "${manifest}")"
-  [[ -v "INVENTORY[${manifest_name}]" ]]
-  sudo cp "${manifest}" /opt/kamiwaza/prereqs/
-  printf '%s  %s\n' "${INVENTORY[${manifest_name}]}" \
-    "/opt/kamiwaza/prereqs/${manifest_name}" | sudo sha256sum -c -
-  source_name="$(sudo jq -er '.source.filename' \
-    "/opt/kamiwaza/prereqs/${manifest_name}")"
-  source_sha="$(sudo jq -er '.source.sha256' \
-    "/opt/kamiwaza/prereqs/${manifest_name}")"
-  [[ "${source_name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-  [[ "${source_sha}" =~ ^[0-9a-fA-F]{64}$ ]]
-  [[ ! -v "SOURCE_INVENTORY[${source_name}]" ]]
-  SOURCE_INVENTORY["${source_name}"]="${source_sha}"
+    -H "Authorization: License ${KEYGEN_TOKEN}" \
+    -o "$file" \
+    "${BASE}/${file}"
 done
 
-sudo cp "${RPM_FILES[@]}" \
-  "${WRAP_FILES[@]}" \
-  "${ARTIFACT_DIR}"/kamiwaza-helm.sha256 \
-  "${ARTIFACT_DIR}"/kamiwaza-helm.asc \
-  "${ARTIFACT_DIR}"/kamiwaza-tools-rpm.pub.gpg \
-  /opt/kamiwaza/prereqs/
-
-STAGED_FILES=(
-  "${RPM_FILES[@]}"
-  "${WRAP_FILES[@]}"
-  "${ARTIFACT_DIR}/kamiwaza-helm.sha256"
-  "${ARTIFACT_DIR}/kamiwaza-helm.asc"
-  "${ARTIFACT_DIR}/kamiwaza-tools-rpm.pub.gpg"
-)
-for source in "${STAGED_FILES[@]}"; do
-  name="$(basename "${source}")"
-  if [[ -v "INVENTORY[${name}]" ]]; then
-    expected_sha="${INVENTORY[${name}]}"
-  else
-    [[ -v "SOURCE_INVENTORY[${name}]" ]]
-    expected_sha="${SOURCE_INVENTORY[${name}]}"
-  fi
-  printf '%s  %s\n' "${expected_sha}" \
-    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
+# Verify part checksums
+for checksum in \
+  kamiwaza-helm.00.tar.part-*.sha256 \
+  "${EXT_BUNDLE}".part-*.sha256
+do
+  sha256sum -c "${checksum}"
 done
 
-RPM_NAME="$(basename "${RPM_FILES[0]}")"
-sudo rpm -Uvh --replacepkgs "/opt/kamiwaza/prereqs/${RPM_NAME}"
+# Recombine split parts and verify the full-artifact checksums
+cat kamiwaza-helm.00.tar.part-{000..002} > kamiwaza-helm.00.tar
+cat "${EXT_BUNDLE}".part-{000..004} > "${EXT_BUNDLE}"
+ln -sf kamiwaza-helm.00.tar kamiwaza-helm.tar
+sha256sum -c kamiwaza-helm.sha256
+sha256sum -c "${EXT_BUNDLE}.sha256"
+```
+
+The `release_origination.md` artifact records the build provenance and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
+
+> If a download stalls, rerun the block — `curl --continue-at -` resumes partial files. If you downloaded on a separate connected machine, transfer the entire `/opt/kamiwaza/prereqs` directory to the same path on the target host before continuing.
+
+## Step 2: Install Prerequisites
+
+Install the prerequisites RPM and run the bootstrap script, which installs the container runtime, cluster tooling, and Ansible from the embedded artifacts:
+
+```bash
+cd /opt/kamiwaza/prereqs
+
+sudo rpm -Uvh --replacepkgs ./kamiwaza-prod-*.x86_64.rpm
+
 sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
-  --yes \
   --embedded-root /opt/kamiwaza/prereqs \
   --os rhel
-)
-```
 
-The release/1.2.0 RPM overlay accepts `--yes` for noninteractive bootstrap.
-Do not pipe repeated `yes` or press Enter to drive a long unattended install.
-
-The install runs as root, so verify tools using root's actual environment:
-
-```bash
-(
-set -euo pipefail
-sudo env \
-  HOME=/root \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  bash -euo pipefail -c '
-    ansible-playbook --version | head -n1
-    podman --version
-    kubectl version --client
-    helm version --short
-    helmfile --version
-    helm dt version
-  '
-)
-```
-
-Do not repair a missing embedded tool by silently installing an arbitrary
-internet version. Reconcile the selected RPM/bootstrap contract first.
-
-## 4. Pre-stage the extension bundle (optional)
-
-Skip this section when the selected bundle has no extension archive. Pre-stage
-loads the bundled catalog files and writes offline catalog values needed by the
-core install. It does **not** load all images or import the live catalog.
-
-Copy the verified extension archive and sidecar into `/opt/kamiwaza/prereqs`.
-Derive and validate its single top-level directory, then record the exact final
-bundle root. Do not rediscover it later with `find | head`; stale extractions
-can coexist after a retry.
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_BUNDLE="<exact-extension-filename-from-inventory>"
-export EXTRACT_DIR="/var/lib/kajiya-reports/extensions-${RUN_ID}"
-export ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${EXT_BUNDLE}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-HELPER_DIR="$(sudo mktemp -d -p /var/tmp \
-  "kamiwaza-extension-helper-${RUN_ID}.XXXXXX")"
-trap 'sudo rm -rf -- "${HELPER_DIR}"' EXIT
-
-sudo cp "${ARTIFACT_DIR}/${EXT_BUNDLE}" \
-  "${ARTIFACT_DIR}/${EXT_BUNDLE}.sha256" \
-  /opt/kamiwaza/prereqs/
-
-for name in "${EXT_BUNDLE}" "${EXT_BUNDLE}.sha256"; do
-  mapfile -t expected_rows < <(
-    sudo awk -F '\t' -v name="${name}" '$1 == name {print $2}' \
-      /opt/kamiwaza/prereqs/artifacts.tsv
-  )
-  if ((${#expected_rows[@]} == 0)); then
-    mapfile -t root_manifests < <(
-      sudo find /opt/kamiwaza/prereqs -maxdepth 1 -type f \
-        -name '*.parts.json' -print
-    )
-    for manifest in "${root_manifests[@]}"; do
-      if [[ "$(sudo jq -er '.source.filename' "${manifest}")" = "${name}" ]]; then
-        expected_rows+=("$(sudo jq -er '.source.sha256' "${manifest}")")
-      fi
-    done
+# Put the bundled tools on sudo's PATH. Later steps call `sudo kubectl`, and the
+# bootstrap's own verification cannot see them either, so re-run it afterwards —
+# the second run reports "Bootstrap complete".
+for tool in helm helmfile k0s kind kubectl; do
+  if [[ -x "/usr/local/bin/${tool}" ]]; then
+    sudo ln -sfn "/usr/local/bin/${tool}" "/usr/bin/${tool}"
   fi
-  test "${#expected_rows[@]}" -eq 1
-  [[ "${expected_rows[0]}" =~ ^[0-9a-fA-F]{64}$ ]]
-  printf '%s  %s\n' "${expected_rows[0]}" \
-    "/opt/kamiwaza/prereqs/${name}" | sudo sha256sum -c -
 done
 
-mapfile -t BUNDLE_TOP_LEVELS < <(
-  sudo tar -tzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" |
-    awk -F/ 'NF {print $1}' | sort -u
-)
-test "${#BUNDLE_TOP_LEVELS[@]}" -eq 1
-export BUNDLE_DIR_NAME="${BUNDLE_TOP_LEVELS[0]}"
-[[ "${BUNDLE_DIR_NAME}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+sudo /opt/kamiwaza/scripts/bootstrap-prereqs.sh \
+  --embedded-root /opt/kamiwaza/prereqs \
+  --os rhel
+```
 
-sudo tar -xzf "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" -C "${HELPER_DIR}" -- \
-  "${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
-sudo test -x \
-  "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh"
-sudo bash "${HELPER_DIR}/${BUNDLE_DIR_NAME}/scripts/install-extensions-bundle.sh" \
+The first bootstrap run commonly exits nonzero on RHEL 9 with `ERROR: required
+bundled command missing after install: helm`, even though every tool installed
+correctly: the bootstrap installs into `/usr/local/bin`, which sudo's
+`secure_path` omits, so its own verification cannot see them. The symlink loop
+and second run in the block above resolve it.
+
+Verify the tools are present:
+
+```bash
+export HELM_PLUGINS="/usr/local/share/helm/plugins"
+
+checks=(
+  "ansible::ansible-playbook --version | head -n1"
+  "podman::podman --version"
+  "kubectl::kubectl version --client"
+  "helm::helm version --short"
+  "helmfile::helmfile --version"
+  "helm dt::helm dt version"
+)
+
+for check in "${checks[@]}"; do
+  label="${check%%::*}"; command="${check#*::}"
+  if output="$(bash -o pipefail -c "${command}" 2>&1)"; then
+    result=GOOD
+  else
+    result=BAD
+  fi
+  output="$(printf '%s' "${output}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  printf '[%-4s] %s: %s\n' "${result}" "${label}" "${output:-no output}"
+done
+```
+
+Every tool above ships in the bundle, so a failure here means the bootstrap did
+not complete rather than that something is missing from the host. Re-run the
+bootstrap and re-verify before considering other sources.
+
+On a host that still has repository access you can install a missing tool
+directly, but this reaches the OS package repositories and is not available on
+an air-gapped host:
+
+```bash
+sudo dnf install -y ansible-core podman kubectl
+```
+
+## Step 3: Create the Overrides File
+
+Create the cluster overrides file with your domain. This is also where you add optional deployment customizations.
+
+```bash
+sudo install -d -m 0755 /opt/kamiwaza/cluster/values
+sudo tee /opt/kamiwaza/cluster/values/overrides.yaml > /dev/null <<'EOF'
+global:
+  domain: <domain>
+EOF
+```
+
+> Advanced deployments (for example, external S3-backed workroom storage or a classification banner) add further keys under `global:` and `core:` in this file. Those are optional and not required for a standard install.
+
+## Step 4: Pre-Extract the Extension Bundle
+
+Stage the extension bundle before installing the platform:
+
+```bash
+cd /opt/kamiwaza/prereqs
+
+EXT_BUNDLE="${EXT_BUNDLE:-$(ls -1 kamiwaza-extensions-bundle-*.tar.gz | tail -1)}"
+rm -rf /tmp/kamiwaza-ext-extract
+mkdir -p /tmp/kamiwaza-ext-extract
+tar -xzf "$EXT_BUNDLE" -C /tmp/kamiwaza-ext-extract
+
+sudo /tmp/kamiwaza-ext-extract/kamiwaza-extensions-bundle-*/scripts/install-extensions-bundle.sh \
   --bundle "/opt/kamiwaza/prereqs/${EXT_BUNDLE}" \
   --sha256-file "/opt/kamiwaza/prereqs/${EXT_BUNDLE}.sha256" \
-  --extract-dir "${EXTRACT_DIR}" \
+  --extract-dir /var/lib/kajiya-reports/extensions-bundle-preinstall \
   --skip-images \
   --skip-catalog
 
-export BUNDLE_ROOT="${EXTRACT_DIR}/${BUNDLE_DIR_NAME}"
-sudo test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
-sudo install -d -m 0700 "$(dirname "${ROOT_RECORD}")"
-printf '%s\n' "${BUNDLE_ROOT}" | sudo tee "${ROOT_RECORD}" >/dev/null
-sudo chmod 0600 "${ROOT_RECORD}"
-)
+# The /tmp copy only supplies the helper script. The install itself runs from
+# the --extract-dir copy, so reclaim the scratch space before installing.
+rm -rf /tmp/kamiwaza-ext-extract
 ```
 
-When helpers are supplied separately from the archive, use only the exact
-Kajiya commit recorded by the selected run and verify each helper SHA-256 before
-execution.
+This stages the bundle under `/var/lib/kajiya-reports/extensions-bundle-preinstall`
+(about 24 GB); [Step 6](#step-6-finish-extension-installation) installs from
+there.
 
-## 5. Prepare a durable core launcher
-
-The selected immutable run must supply a complete, non-secret install contract.
-Record it as JSON so values containing spaces cannot become shell syntax. Fill
-every value from the selected run, including the complete infrastructure and
-inference image map:
-
-```json
-{
-  "KAMIWAZA_VERSION": "<exact>",
-  "KAMIWAZA_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_K8S_RUNTIME": "k0s-podman",
-  "KAMIWAZA_ROOK_OSD_IMAGE_SIZE": "<exact>",
-  "KAMIWAZA_RESOURCE_PROFILE": "<exact>",
-  "HELMFILE_EXTRA_SET": "<exact, including spaces>",
-  "KAMIWAZA_OFFLINE_APP_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CORE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_DATAHUB_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_FRONTEND_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG": "<exact>",
-  "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG": "<exact>",
-  "KAMIWAZA_IMAGE_OVERRIDES": "<exact comma-separated map>"
-}
-```
-
-Validate that the document contains only the expected string keys, then install
-it root-owned:
-
-```bash
-(
-set -euo pipefail
-CONTRACT_SOURCE='<secure-path-to-kamiwaza-install-contract.json>'
-[[ "${CONTRACT_SOURCE}" != *'<'* ]]
-test -f "${CONTRACT_SOURCE}"
-if ! jq -e '
-  type == "object" and
-  (keys | sort) == ([
-    "HELMFILE_EXTRA_SET",
-    "KAMIWAZA_IMAGE_OVERRIDES",
-    "KAMIWAZA_IMAGE_TAG",
-    "KAMIWAZA_K8S_RUNTIME",
-    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
-    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CORE_TAG",
-    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
-    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
-    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
-    "KAMIWAZA_RESOURCE_PROFILE",
-    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
-    "KAMIWAZA_VERSION"
-  ] | sort) and
-  all(.[]; type == "string") and
-  all(.[]; (contains("<") or contains(">")) | not) and
-  .KAMIWAZA_K8S_RUNTIME == "k0s-podman" and
-  (. as $contract | all([
-    "KAMIWAZA_IMAGE_OVERRIDES",
-    "KAMIWAZA_IMAGE_TAG",
-    "KAMIWAZA_K8S_RUNTIME",
-    "KAMIWAZA_OFFLINE_APP_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG",
-    "KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_CORE_TAG",
-    "KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG",
-    "KAMIWAZA_OFFLINE_DATAHUB_TAG",
-    "KAMIWAZA_OFFLINE_FRONTEND_TAG",
-    "KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG",
-    "KAMIWAZA_RESOURCE_PROFILE",
-    "KAMIWAZA_ROOK_OSD_IMAGE_SIZE",
-    "KAMIWAZA_VERSION"
-  ][]; ($contract[.] | length > 0)))
-' "${CONTRACT_SOURCE}" >/dev/null; then
-  printf 'install contract has missing, extra, empty, placeholder, or topology-invalid values\n' >&2
-  exit 1
-fi
-sudo install -o root -g root -m 0600 \
-  "${CONTRACT_SOURCE}" /run/kamiwaza-install-contract.json
-)
-```
-
-Use the exact release contract even when several values happen to share a tag.
-Do not synthesize missing values from the release number.
-`KAMIWAZA_K8S_RUNTIME` must be `k0s-podman` for this guide. If the selected
-contract names another runtime, stop and use that runtime's runbook.
-`KAMIWAZA_OFFLINE_EXTRA_IMAGES` is a Kajiya wrap-build input, not an installer
-environment variable; record it in build provenance when it is nonempty, but do
-not add it to this runtime contract.
+## Step 5: Install Kamiwaza
 
 > **Upgrading a 1.0.0 production database to 1.2.0?** Stop here and follow the
 > [Core database upgrade runbook](../runbooks/core-database-upgrade-1.2.md)
-> before invoking `install-prod.sh`. It requires the exact 1.2.0 candidate, a
-> pre-mutation backup, schema gates, stop rules, and recovery evidence.
+> before invoking `install-prod.sh`. The runbook requires the exact 1.2.0
+> candidate and its `release_origination.md`; the fresh-install values below
+> are not upgrade inputs.
 
-### Password handling
+Set the image tags for the bundle and run the offline installer. The values below match the published 1.2.0 build. If you are installing a different build, obtain its image override map from the publisher — `release_origination.md` records the app, containers, and frontend tags only.
 
-The packaged release/1.2.0 RPM passes unknown arguments through to Ansible. The
-launcher below writes `admin_password` to a root-only, attempt-bound JSON
-extra-vars file under `/run` and passes only that file's path. The password is
-not placed in the installer or child-process arguments or environment. Root can
-still read the temporary file while the phase is running; the launcher's exit
-trap removes it.
+Both `KAMIWAZA_IMAGE_TAG` and `KAMIWAZA_IMAGE_OVERRIDES` are required, and they correct each other:
 
-Read the password without echoing it and create a transient root-only file:
+- `KAMIWAZA_IMAGE_TAG` moves the platform images to the release tag. Without it, `extension-operator` and `placement-operator` request `develop` and stay in `ImagePullBackOff`.
+- `postgres` and `keycloak` are excluded from that bulk tag and would otherwise fall back to chart pins the bundle does not contain.
+- `etcd` is moved *by* the bulk tag and must be pinned back to the version in the bundle.
+
+Omitting the bulk tag, or any one of the three overrides, leaves a workload requesting a tag the local registry does not have.
+
+> **Installing over SSM, or any connection that can drop?** The install runs for
+> roughly 15-20 minutes in the foreground, and losing the session loses the
+> controlling process. Launch it as a transient systemd unit instead, so it
+> survives the shell:
+>
+> ```bash
+> sudo systemd-run --no-block --service-type=oneshot --remain-after-exit \
+>   --unit=kamiwaza-offline-install \
+>   /opt/kamiwaza/scripts/install-prod.sh <the same arguments as below>
+> ```
+>
+> Then judge the result from `systemctl show kamiwaza-offline-install` —
+> `Result=success` and `ExecMainStatus=0` — not from log activity. A quiet log
+> is not a finished install.
+
+> **Keep `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G`** in the block below unless you have sized `/var/lib` for the 700 GB default — it is what brings the requirement down to the 350 GB floor in [Prerequisites](#prerequisites). This env var and the online guide's `-e storage_host_prep_virtual_block_size` extra-var are the same setting expressed two ways; the offline path sets it via the environment, the online path via an installer argument.
 
 ```bash
-(
-set -euo pipefail
-read -rsp 'Initial Kamiwaza admin password: ' ADMIN_PASSWORD; printf '\n'
-sudo install -o root -g root -m 0600 /dev/null /run/kamiwaza-admin-password
-printf '%s' "${ADMIN_PASSWORD}" | sudo tee /run/kamiwaza-admin-password >/dev/null
-unset ADMIN_PASSWORD
-)
-```
+export DOMAIN="<domain>"
+export ADMIN_PASSWORD="<admin-password>"
 
-Create `/run/kamiwaza-offline-install.sh` as root with a quoted heredoc so the
-interactive shell cannot expand the script body:
+export APP_TAG="release-1.2.0"
+export FRONTEND_TAG="${APP_TAG}"
+export CONTAINERS_TAG="release-1.2.0"
+export EXTENSION_OPERATOR_TAG="release-1.2.0"
 
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-install.sh
-sudo tee /run/kamiwaza-offline-install.sh >/dev/null <<'KAMIWAZA_INSTALL'
-#!/usr/bin/env bash
-set -euo pipefail
+export KAMIWAZA_VERSION="${APP_TAG}"
+export KAMIWAZA_IMAGE_TAG="${APP_TAG}"
+export KAMIWAZA_K8S_RUNTIME="k0s-podman"
+export KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G
+export KAMIWAZA_RESOURCE_PROFILE=small
+export HELMFILE_EXTRA_SET="--set global.security.allowInsecureImages=true"
 
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
+export KAMIWAZA_OFFLINE_APP_IMAGE_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_CORE_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_FRONTEND_TAG="${FRONTEND_TAG}"
+export KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG="${APP_TAG}"
+export KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG="${CONTAINERS_TAG}"
+export KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG="${CONTAINERS_TAG}"
 
-CONTRACT=/run/kamiwaza-install-contract.json
-PASSWORD_FILE=/run/kamiwaza-admin-password
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-STATUS_ROOT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts"
-ATTEMPT_DIR="${STATUS_ROOT}/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-ADMIN_VARS_FILE="/run/kamiwaza-admin-extra-vars-${RUN_ID}-attempt${ATTEMPT_ID}.json"
+export KAMIWAZA_IMAGE_OVERRIDES="postgres=v18.4,keycloak=${CONTAINERS_TAG},etcd=v3.6.10"
 
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-test ! -e "${ADMIN_VARS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  rm -f "${PASSWORD_FILE}" "${ADMIN_VARS_FILE}"
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-test -s "${CONTRACT}"
-test -s "${PASSWORD_FILE}"
-test -f /opt/kamiwaza/prereqs/kamiwaza-helm.sha256
-test -f /opt/kamiwaza/prereqs/kamiwaza-helm.asc
-test -f /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg
-
-CONTRACT_KEYS=(
-  KAMIWAZA_VERSION
-  KAMIWAZA_IMAGE_TAG
-  KAMIWAZA_K8S_RUNTIME
-  KAMIWAZA_ROOK_OSD_IMAGE_SIZE
-  KAMIWAZA_RESOURCE_PROFILE
-  HELMFILE_EXTRA_SET
-  KAMIWAZA_OFFLINE_APP_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CURL_SHELL_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CORE_TAG
-  KAMIWAZA_OFFLINE_DATAHUB_TAG
-  KAMIWAZA_OFFLINE_FRONTEND_TAG
-  KAMIWAZA_OFFLINE_INIT_KEYCLOAK_USERS_TAG
-  KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG
-  KAMIWAZA_OFFLINE_CHAINGUARD_BASE_TAG
-  KAMIWAZA_IMAGE_OVERRIDES
-)
-for name in "${CONTRACT_KEYS[@]}"; do
-  value="$(jq -er --arg name "${name}" '.[$name] | strings' "${CONTRACT}")"
-  printf -v "${name}" '%s' "${value}"
-  export "${name}"
-done
-unset value
-
-jq -Rs '{admin_password: .}' <"${PASSWORD_FILE}" >"${ADMIN_VARS_FILE}"
-test -s "${ADMIN_VARS_FILE}"
-rm -f "${PASSWORD_FILE}"
-/opt/kamiwaza/scripts/install-prod.sh \
+sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
-  --skip-prereq-bootstrap \
   --domain "${DOMAIN}" \
+  --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
   --wrap-pubkey /opt/kamiwaza/prereqs/kamiwaza-tools-rpm.pub.gpg \
-  --extra-vars "@${ADMIN_VARS_FILE}" \
+  -e helm_timeout=12m \
   -y
-KAMIWAZA_INSTALL
-)
 ```
 
-Replace `<domain>` with `sudoedit /run/kamiwaza-offline-install.sh`, then
-validate and protect the launcher:
+## Step 6: Finish Extension Installation
 
-```bash
-(
-set -euo pipefail
-sudo bash -n /run/kamiwaza-offline-install.sh
-sudo chmod 0700 /run/kamiwaza-offline-install.sh
-)
-```
-
-## 6. Launch through SSM without tying the install to the shell
-
-An SSM interactive shell can time out while a healthy installation is still
-running. Launch each attempt as a distinct transient systemd unit:
-
-```bash
-export RUN_ID="<release-or-run>"
-export ATTEMPT=1
-export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${CORE_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${CORE_UNIT}" "${CORE_ATTEMPT_DIR}"
-)
-```
-
-Immediately record the unit name and follow the persistent root-only log:
-
-```bash
-sudo tail -F "${CORE_ATTEMPT_DIR}/console.log"
-```
-
-Stop following with Ctrl-C only after the unit is terminal; then run the strict
-completion gate in the next section.
-
-Journal activity—or quietness—is not a completion signal. Because
-`KillMode=process` and `Delegate=yes` allow runtime children to survive the
-launcher, a stopped unit also does not prove all children stopped after an
-error. Declare the core launcher successful only when all of these agree:
-
-- `LoadState=loaded`, `ActiveState=active`, `SubState=exited`,
-  `Result=success`, `ExecMainCode=1`, and `ExecMainStatus=0` from one
-  `systemctl show` snapshot;
-- the recorded per-attempt `${CORE_STATUS}` contains `0`;
-- the final Ansible recap has `failed=0` and `unreachable=0`; and
-- the independent workload checks in the next section pass.
-
-`--remain-after-exit` keeps a successful transient unit loaded so a misspelled,
-garbage-collected, or never-created unit cannot look identical to success.
-`systemd-run` is preferred on RHEL because it preserves an authoritative exit
-status. If systemd transient units are unavailable, the launcher can be
-detached with `nohup` and the same attempt argument:
-
-```bash
-export ATTEMPT=2
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo install -d -o root -g root -m 0700 "$(dirname "${CORE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${CORE_ATTEMPT_DIR}"
-sudo /bin/bash -c '
-  exec nohup /bin/bash "$1" "$2" "$3" </dev/null >"$4" 2>&1 &
-' _ /run/kamiwaza-offline-install.sh "${RUN_ID}" "${ATTEMPT}" \
-  "${CORE_ATTEMPT_DIR}/launcher.log"
-)
-```
-
-In that fallback, require the runner's `.rc` file plus the final recap and all
-independent health gates; the background PID disappearing is not success.
-
-## 7. Verify the core installation
-
-The `k0s-podman` topology uses Podman as the k0s container engine on the host:
-
-```text
-RHEL host -> k0s with Podman container engine -> Kubernetes pods
-```
-
-Host processes and Kubernetes workloads do not share one network namespace.
-Use the root kubeconfig installed by the playbook and the node IP reported by Kubernetes. If an EC2
-instance role is intentionally available to workloads, the instance metadata
-response hop limit must support this nested path; explicit S3 credentials
-remain supported when ambient identity is not desired.
-
-For a same-boot verification, rebind the recorded values after reconnecting and
-run:
+Make sure `${DOMAIN}` resolves from the install host, then install the extensions from the pre-staged bundle:
 
 ```bash
 export DOMAIN="<domain>"
-export RUN_ID="<release-or-run>"
-export ATTEMPT=1
-export CORE_UNIT="kamiwaza-offline-install-${RUN_ID}-attempt${ATTEMPT}.service"
-export CORE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/core-attempts/attempt${ATTEMPT}"
-export CORE_STATUS="${CORE_ATTEMPT_DIR}/result.rc"
+export ADMIN_PASSWORD="<admin-password>"
 
-(
-set -euo pipefail
-test "$(sudo cat "${CORE_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-CORE_STATE="$(sudo systemctl show "${CORE_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${CORE_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${CORE_STATE}"; then
-    printf 'core unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${CORE_STATE}"
-test "$(sudo cat "${CORE_STATUS}")" = 0
-)
+# Add a hosts-file entry if the domain does not already resolve locally
+if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
+  NODE_IP="$(sudo kubectl get nodes -o wide --no-headers | awk 'NR==1 {print $6}')"
+  echo "${NODE_IP:-127.0.0.1} ${DOMAIN}" | sudo tee -a /etc/hosts
+fi
+
+BUNDLE_ROOT="$(sudo find /var/lib/kajiya-reports/extensions-bundle-preinstall \
+  -maxdepth 1 -type d -name 'kamiwaza-extensions-bundle-*' | sort | tail -1)"
+
+test -n "${BUNDLE_ROOT}" || { echo "No pre-extracted extension bundle found"; exit 1; }
+
+printf '%s\n' "${ADMIN_PASSWORD}" | sudo "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
+  --bundle-root "${BUNDLE_ROOT}" \
+  --container-cli podman \
+  --sudo-mode always \
+  --api-url "https://${DOMAIN}/api" \
+  --username admin \
+  --password-stdin
 ```
 
-Run the workload gates separately so the same block is usable after a verified
-post-success reboot:
+## Step 7: Verify the Installation
 
 ```bash
-export DOMAIN="<domain>"
-
-(
-set -euo pipefail
-ROOT_TOOLS=(sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
-NODES_JSON="$("${ROOT_TOOLS[@]}" kubectl get nodes -o json)"
-jq -e '
-  (.items | length) > 0 and
-  all(.items[]; any(.status.conditions[]?;
-    .type == "Ready" and .status == "True"))
-' <<<"${NODES_JSON}" >/dev/null
-
-PODS_JSON="$("${ROOT_TOOLS[@]}" kubectl get pods -A -o json)"
-jq -e '
-  (.items | length) > 0 and
-  all(.items[];
-    .status.phase == "Succeeded" or
-    (.status.phase == "Running" and
-     ((.status.containerStatuses // []) | length) > 0 and
-     all(.status.containerStatuses[]; .ready == true)))
-' <<<"${PODS_JSON}" >/dev/null
-jq -e '
-  all(.items[];
-    all((.status.containerStatuses // [])[];
-      (.imageID // "") | contains("sha256:")))
-' <<<"${PODS_JSON}" >/dev/null
-
-HELM_JSON="$("${ROOT_TOOLS[@]}" helm list -A -o json)"
-jq -e 'length > 0 and all(.[]; .status == "deployed")' \
-  <<<"${HELM_JSON}" >/dev/null
-
-NODE_IP="$("${ROOT_TOOLS[@]}" kubectl get nodes \
-  -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
-test -n "${NODE_IP}"
-HTTP_CODE="$(curl -kfsS --resolve "${DOMAIN}:443:${NODE_IP}" \
-  -o /dev/null -w '%{http_code}' \
-  "https://${DOMAIN}/api/auth/health")"
-test "${HTTP_CODE}" = 200
-
-"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
-"${ROOT_TOOLS[@]}" kubectl get pods -A
-"${ROOT_TOOLS[@]}" helm list -A
-printf 'health HTTP %s\n' "${HTTP_CODE}"
-)
+sudo kubectl get pods -A
+sudo kubectl get kamiwazaextensions -A
 ```
 
-If the host rebooted only **after** the durable `result.rc` reached `0`, the
-transient unit tuple is no longer available. Do not run the same-boot tuple
-gate. Instead require that attempt's root-only `console.log` to contain the
-final clean Ansible recap, then run the separate workload block and every login,
-digest, and provenance gate below. A missing or nonzero receipt is not
-recoverable success.
+All pods should be `Running`, `Ready`, or `Completed`. On a fresh install `kubectl get kamiwazaextensions -A` reports `No resources found` — the extension templates are cataloged but none is deployed until you launch one, so this is expected. Then log in at `https://<domain>/login` with `admin` and the password you set. The installer serves the site with a self-signed certificate by default, so your browser will show a security warning on first access — continue past it to reach the login page.
 
-The health endpoint is authentication-exempt and must return a successful HTTP
-status. Also verify login and an authenticated API request, deployed Helm
-releases, expected local-registry manifests, and the live pod `imageID` digests
-against the selected release contract. Health without expected digest evidence
-proves function, not artifact provenance. Passing the shell block alone is not
-level-1 completion; login and an authenticated request must also succeed. A
-missing expected manifest/digest comparison does not block that functional
-level, but it does block any claim that the running images match the selected
-release provenance.
+## Troubleshooting
 
-The domain must resolve both from the install host and from the operator's
-browser. Add one exact, reviewed `/etc/hosts` entry only when DNS is not ready;
-do not append duplicates on every retry.
+- **Output appears stalled during `bootstrap-prereqs.sh` or `install-prod.sh`.** The `dnf`/`rpm` output can appear to hang while these scripts run. This is not a prompt waiting for input; if output appears stalled, press Enter several times until it resumes.
+- **Disk pressure or staging failures.** Confirm `/`, `/tmp`, and `/var/lib` each have enough free space before installing (see [Prerequisites](#prerequisites)).
 
-For SSM port forwarding, map local port 8443 to target port 443, add
-`127.0.0.1 <domain>` to the operator workstation, and browse to
-`https://<domain>:8443/login`. The default certificate is self-signed, so the
-browser presents a warning until the operator explicitly trusts or replaces
-it. Preserve `:8443` after authentication redirects.
+## Next Steps
 
-## 8. Fully load bundled extensions (optional)
-
-Core success does not finish a bundle that contains extensions. Run the full
-load in a **separate** detached unit after the authenticated API is ready. Reuse
-the exact root recorded during pre-stage; do not extract another copy without a
-specific reason.
-
-Create `/run/kamiwaza-offline-extensions.sh` through a root-owned quoted
-heredoc:
-
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-extensions.sh
-sudo tee /run/kamiwaza-offline-extensions.sh >/dev/null <<'KAMIWAZA_EXTENSIONS'
-#!/usr/bin/env bash
-set -euo pipefail
-
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
-
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-ROOT_RECORD="/var/lib/kajiya-reports/offline-install/${RUN_ID}/bundle-root"
-BUNDLE_ROOT="$(<"${ROOT_RECORD}")"
-
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-test -d "${BUNDLE_ROOT}"
-test -x "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh"
-
-# Do not persist the seeded credential in a second file. Feed it to the helper
-# on stdin; see the argv limitation immediately below.
-ADMIN_PASSWORD="$(
-  kubectl -n kamiwaza get secret kamiwaza-user-admin \
-    -o jsonpath='{.data.password}' | base64 -d
-)"
-
-printf '%s\n' "${ADMIN_PASSWORD}" |
-  "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
-    --bundle-root "${BUNDLE_ROOT}" \
-    --container-cli podman \
-    --sudo-mode always \
-    --api-url "https://${DOMAIN}/api" \
-    --username admin \
-    --password-stdin
-unset ADMIN_PASSWORD
-KAMIWAZA_EXTENSIONS
-)
-```
-
-The current bundle helper accepts `--password-stdin`, but its catalog-import
-subprocess can still expand that value into a child command's arguments. This
-has the same temporary privileged-process visibility limitation as the core
-installer. Do not capture full process argument lists during this phase.
-
-Launch and monitor it like the core phase:
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_ATTEMPT=1
-export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
-export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
-export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${EXT_ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo bash -n /run/kamiwaza-offline-extensions.sh
-sudo chmod 0700 /run/kamiwaza-offline-extensions.sh
-sudo install -d -o root -g root -m 0700 "$(dirname "${EXT_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${EXT_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${EXT_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extensions.sh "${RUN_ID}" "${EXT_ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${EXT_UNIT}" "${EXT_ATTEMPT_DIR}"
-)
-
-sudo tail -F "${EXT_ATTEMPT_DIR}/console.log"
-```
-
-After the unit is terminal, stop following with Ctrl-C and gate the exact
-recorded attempt:
-
-```bash
-export RUN_ID="<release-or-run>"
-export EXT_ATTEMPT=1
-export EXT_UNIT="kamiwaza-offline-extensions-${RUN_ID}-attempt${EXT_ATTEMPT}.service"
-export EXT_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/extension-attempts/attempt${EXT_ATTEMPT}"
-export EXT_STATUS="${EXT_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-test "$(sudo cat "${EXT_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-EXT_STATE="$(sudo systemctl show "${EXT_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${EXT_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${EXT_STATE}"; then
-    printf 'extension unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${EXT_STATE}"
-test "$(sudo cat "${EXT_STATUS}")" = 0
-sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf \
-  kubectl get pods -A
-)
-```
-
-Also require all expected local-registry manifests and healthy workloads.
-Record the exact stored and visible catalog counts for the selected immutable
-bundle. Stored and visible counts can differ when product posture intentionally
-hides a template; verify both instead of assuming that an absent UI card means
-import failed.
-
-Customer level-2 completion does not require private Kajiya smoke helpers or
-unpublished expected-count files. If the publisher supplies an additional
-hash-authenticated validation pack, run its resource assertions; otherwise
-record the observed evidence without substituting dated counts from this page.
-
-Do not blindly rerun only the catalog importer after success. Existing hidden
-templates can be invisible to its list call and then cause a duplicate-create
-HTTP 400.
-
-## 9. Run the internal release deploy gate (release parity)
-
-This section is for Kamiwaza release engineers. The normal customer bundle does
-not contain `smoke-extension-deploy.sh`, the Konnectivity guard, or expected
-release-gate values. Do not require this section for customer level-1 or level-2
-completion. For release/nightly parity, transfer the selected run's separate
-validation pack and verify its recorded hashes; never download `develop` at
-install time.
-
-Install the verified gate into a fresh root-only directory:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_SOURCE="<secure-path-to-smoke-extension-deploy.sh>"
-export GATE_SHA256="<sha256-from-selected-validation-pack>"
-export GATE_HELPER_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${GATE_SHA256}" =~ ^[0-9a-fA-F]{64}$ ]]
-[[ "${GATE_SOURCE}" != *'<'* ]]
-test -f "${GATE_SOURCE}"
-printf '%s  %s\n' "${GATE_SHA256}" "${GATE_SOURCE}" | sha256sum -c -
-sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_HELPER_DIR}")"
-sudo mkdir -m 0700 "${GATE_HELPER_DIR}"
-sudo install -o root -g root -m 0700 "${GATE_SOURCE}" \
-  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh"
-printf '%s  %s\n' "${GATE_SHA256}" \
-  "${GATE_HELPER_DIR}/smoke-extension-deploy.sh" | sudo sha256sum -c -
-)
-```
-
-The currently selected 1.2.0 gate deploys `kaizen`, but the selected release
-contract controls the exact template. The gate waits for readiness, proves that
-relocation left no external image references, and removes it through the
-supported API path. A raw `kubectl apply` bypasses that behavior and is not an
-equivalent test.
-
-Create `/run/kamiwaza-offline-extension-gate.sh` through a root-owned quoted
-heredoc, replacing the placeholders with the recorded domain and gate values:
-
-```bash
-(
-set -euo pipefail
-sudo install -o root -g root -m 0700 /dev/null \
-  /run/kamiwaza-offline-extension-gate.sh
-sudo tee /run/kamiwaza-offline-extension-gate.sh >/dev/null <<'KAMIWAZA_GATE'
-#!/usr/bin/env bash
-set -euo pipefail
-
-export HOME=/root
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-export HELM_PLUGINS=/usr/local/share/helm/plugins
-export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-unset NAMESPACE
-
-DOMAIN='<domain>'
-RUN_ID="${1:?pass the recorded run ID}"
-ATTEMPT_ID="${2:?pass the recorded attempt number}"
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${ATTEMPT_ID}" =~ ^[0-9]+$ ]]
-ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${ATTEMPT_ID}"
-STATUS_FILE="${ATTEMPT_DIR}/result.rc"
-GATE_SCRIPT="/var/lib/kajiya-reports/offline-install/${RUN_ID}/release-validation/smoke-extension-deploy.sh"
-GATE_TEMPLATE='<exact-gate-template-from-selected-release>'
-GATE_WAIT_TIMEOUT='<exact-gate-timeout-from-selected-release>'
-
-test -d "${ATTEMPT_DIR}"
-test ! -e "${STATUS_FILE}"
-umask 077
-cat /proc/sys/kernel/random/boot_id >"${ATTEMPT_DIR}/boot-id"
-exec >"${ATTEMPT_DIR}/console.log" 2>&1
-
-finish() {
-  rc=$?
-  trap - EXIT
-  status_tmp="$(mktemp "${STATUS_FILE}.tmp.XXXXXX")"
-  printf '%s\n' "${rc}" >"${status_tmp}"
-  chmod 0600 "${status_tmp}"
-  mv -f "${status_tmp}" "${STATUS_FILE}"
-  exit "${rc}"
-}
-trap finish EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-[[ -n "${DOMAIN}" && "${DOMAIN}" != *'<'* ]]
-[[ "${GATE_TEMPLATE}" != *'<'* ]]
-[[ "${GATE_WAIT_TIMEOUT}" != *'<'* ]]
-test -x "${GATE_SCRIPT}"
-ADMIN_PASSWORD="$(
-  kubectl -n kamiwaza get secret kamiwaza-user-admin \
-    -o jsonpath='{.data.password}' | base64 -d
-)"
-
-printf '%s\n' "${ADMIN_PASSWORD}" |
-  bash "${GATE_SCRIPT}" \
-    --api-url "https://${DOMAIN}/api" \
-    --username admin \
-    --password-stdin \
-    --template-name "${GATE_TEMPLATE}" \
-    --wait-timeout "${GATE_WAIT_TIMEOUT}"
-unset ADMIN_PASSWORD
-KAMIWAZA_GATE
-)
-```
-
-Launch and gate it independently:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_ATTEMPT=1
-export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
-export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
-export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-[[ "${RUN_ID}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
-[[ "${GATE_ATTEMPT}" =~ ^[0-9]+$ ]]
-sudo bash -n /run/kamiwaza-offline-extension-gate.sh
-sudo chmod 0700 /run/kamiwaza-offline-extension-gate.sh
-sudo install -d -o root -g root -m 0700 "$(dirname "${GATE_ATTEMPT_DIR}")"
-sudo mkdir -m 0700 "${GATE_ATTEMPT_DIR}"
-sudo systemd-run \
-  --no-block \
-  --service-type=oneshot \
-  --remain-after-exit \
-  --unit="${GATE_UNIT%.service}" \
-  --property=KillMode=process \
-  --property=Delegate=yes \
-  --property=TimeoutStartSec=infinity \
-  /bin/bash /run/kamiwaza-offline-extension-gate.sh "${RUN_ID}" "${GATE_ATTEMPT}"
-printf 'record unit=%s attempt_dir=%s\n' "${GATE_UNIT}" "${GATE_ATTEMPT_DIR}"
-)
-
-sudo tail -F "${GATE_ATTEMPT_DIR}/console.log"
-```
-
-After the unit is terminal, require the retained unit tuple and the matching
-durable receipt:
-
-```bash
-export RUN_ID="<release-or-run>"
-export GATE_ATTEMPT=1
-export GATE_UNIT="kamiwaza-offline-extension-gate-${RUN_ID}-attempt${GATE_ATTEMPT}.service"
-export GATE_ATTEMPT_DIR="/var/lib/kajiya-reports/offline-install/${RUN_ID}/gate-attempts/attempt${GATE_ATTEMPT}"
-export GATE_STATUS="${GATE_ATTEMPT_DIR}/result.rc"
-
-(
-set -euo pipefail
-test "$(sudo cat "${GATE_ATTEMPT_DIR}/boot-id")" = \
-  "$(cat /proc/sys/kernel/random/boot_id)"
-GATE_STATE="$(sudo systemctl show "${GATE_UNIT}" \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID)"
-printf '%s\n' "${GATE_STATE}"
-for expected in \
-  LoadState=loaded ActiveState=active SubState=exited \
-  Result=success ExecMainCode=1 ExecMainStatus=0; do
-  if ! grep -Fxq "${expected}" <<<"${GATE_STATE}"; then
-    printf 'deploy-gate unit state gate failed: missing %s\n' "${expected}" >&2
-    exit 1
-  fi
-done
-grep -Eq '^InvocationID=.+$' <<<"${GATE_STATE}"
-test "$(sudo cat "${GATE_STATUS}")" = 0
-)
-```
-
-Also run any Konnectivity or authenticated resource gate in the same validation
-pack. Record every script's source commit and SHA-256. The temporary child-argv
-limitation described in the extension-load phase also applies to this helper.
-
-SDK tests, UAT data seeding, DNS publication, and A/B promotion are separate
-demo or publication phases. They are not required to call the base platform or
-extension bundle installed.
-
-## Reruns, recovery, and diagnostics
-
-- Download and part assembly are safely repeatable. The download block removes
-  an unverifiable or unresumable `.partial`; remove a failed `.assembling`
-  before retrying assembly. Verify final-target SHA-256 after every transfer.
-- `rpm --replacepkgs` is intentional. A core installer rerun is **not** a
-  generic reset: inspect the existing unit, Ansible recap, cluster, registry,
-  and surviving child processes first. Recreate the root-only password file
-  before every core attempt because the launcher removes it on exit.
-- Before staging a different release, archive or remove only the previous
-  release's RPM, numbered wrap chunks, checksum, signature, public key, and
-  extension archive/sidecar, root-staged `*.parts.json` manifests, and
-  `artifacts.tsv` from `/opt/kamiwaza/prereqs`. Never mix release artifact
-  families or broadly delete the packaged prerequisite tree. For an
-  exact-release retry, verify the existing files and reuse them.
-- Use monotonically named units and fresh per-attempt directories. Never reuse
-  an attempt number or overwrite a terminal receipt, log, or recap before the
-  cause is understood. After preserving evidence, stop a retained unit to
-  release its systemd state. If a launcher was killed before its exit trap,
-  confirm that its unit and children have stopped, then remove its exact
-  `/run/kamiwaza-admin-extra-vars-<run>-attempt<n>.json` file before retrying.
-- Reuse a verified pre-extracted extension root. Do not select among stale
-  directories with an unordered search.
-- Do not blindly rerun an extension or deploy-gate phase after interruption.
-  First compare its persistent log, stored and visible catalog state, local
-  manifests, and API resources. If catalog import completed, reconcile it
-  instead of creating duplicates. If the deploy gate stranded its test
-  deployment, remove that exact deployment through the supported API before a
-  new attempt.
-- An SSM disconnect does not stop a system unit. A host reboot does remove all
-  transient units and every contract, secret, and launcher under `/run`. A
-  missing durable `result.rc` after reboot is interrupted/unknown, never
-  success. Inspect partial state, recreate `/run` inputs, and allocate a new
-  attempt. A pre-reboot `result.rc` of `0` is usable only with its saved recap
-  and fresh post-reboot health and provenance gates.
-- Never delete clusters, PVCs, registry volumes, or an instance as a default
-  retry. Destructive recovery requires a separate backup and rollback decision.
-- Do not treat repeated red `HEAD`/manifest-not-found lines from a local
-  registry as fatal by color alone. Determine whether the importer is probing
-  before upload, then use the unit result and final manifest/digest gates.
-
-Useful focused diagnostics:
-
-```bash
-ROOT_TOOLS=(sudo env \
-  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-  HELM_PLUGINS=/usr/local/share/helm/plugins \
-  KUBECONFIG=/var/lib/k0s/pki/admin.conf)
-sudo systemctl show <unit>.service \
-  -p LoadState -p ActiveState -p SubState -p Result \
-  -p ExecMainCode -p ExecMainStatus -p InvocationID
-sudo journalctl -u <unit>.service -o cat
-"${ROOT_TOOLS[@]}" kubectl get nodes -o wide
-"${ROOT_TOOLS[@]}" kubectl get pods -A -o wide
-"${ROOT_TOOLS[@]}" kubectl get events -A --sort-by=.lastTimestamp
-"${ROOT_TOOLS[@]}" helm list -A
-sudo podman ps -a
-df -hT / /tmp /var/tmp /var/lib /opt
-```
-
-If a preflight aborts at `storage_host_prep`, `/var/lib` cannot fit the
-configured storage image on its actual backing filesystem. Grow or remount that
-filesystem before retrying; do not treat the abort as a prompt or bypass the
-preflight.
-
-Keep secrets and full process argument lists out of diagnostic captures. If a
-password appears in output, treat it as exposed and rotate it through a
-supported path after the installation is stable.
-
-## Next steps
-
-- [Quickstart](../quickstart.md) — verify the user-facing platform.
+- [Quickstart](../quickstart.md) — confirm the service is running and take your first steps.
 - [Uninstalling Kamiwaza](uninstall.md).

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -31,7 +31,7 @@ The host's static hostname must be **55 characters or fewer**. Longer names
 overflow the certificate subject fields the cluster generates:
 
 ```bash
-hostnamectl --static | wc -c
+hostnamectl --static | tr -d '\n' | wc -c
 ```
 
 Throughout this guide, replace the placeholders:
@@ -248,18 +248,19 @@ Omitting the bulk tag, or any one of the three overrides, leaves a workload requ
 
 > **Installing over SSM, or any connection that can drop?** The install runs for
 > roughly 15-20 minutes in the foreground, and losing the session loses the
-> controlling process. Launch it as a transient systemd unit instead, so it
-> survives the shell:
+> controlling process. Run the whole Step 5 block inside a detached terminal
+> multiplexer, so the exported values below stay in the same shell as the
+> installer and the run survives a disconnect:
 >
 > ```bash
-> sudo systemd-run --no-block --service-type=oneshot --remain-after-exit \
->   --unit=kamiwaza-offline-install \
->   /opt/kamiwaza/scripts/install-prod.sh <the same arguments as below>
+> tmux new -s kamiwaza-install     # or: screen -S kamiwaza-install
 > ```
 >
-> Then judge the result from `systemctl show kamiwaza-offline-install` —
-> `Result=success` and `ExecMainStatus=0` — not from log activity. A quiet log
-> is not a finished install.
+> Export the block below and run `install-prod.sh` inside that session; reattach
+> after a drop with `tmux attach -t kamiwaza-install`. Judge the result from the
+> installer's exit status and the final Ansible recap (`failed=0`,
+> `unreachable=0`), not from log activity — a quiet log is not a finished
+> install.
 
 > **Keep `KAMIWAZA_ROOK_OSD_IMAGE_SIZE=80G`** in the block below unless you have sized `/var/lib` for the 700 GB default — it is what brings the requirement down to the 350 GB floor in [Prerequisites](#prerequisites). This env var and the online guide's `-e storage_host_prep_virtual_block_size` extra-var are the same setting expressed two ways; the offline path sets it via the environment, the online path via an installer argument.
 

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -65,6 +65,14 @@ export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE
 sudo install -d -m 0755 -o "$USER" -g "$USER" /opt/kamiwaza/prereqs
 cd /opt/kamiwaza/prereqs
 
+# Pass the license key to curl through a private header file rather than an
+# argument. Anything in argv is visible in `ps` output for the whole download.
+# Keep this file outside /opt/kamiwaza/prereqs so it is not carried along when
+# that directory is transferred to the target host.
+KEYGEN_HEADER="$(mktemp)"
+chmod 600 "${KEYGEN_HEADER}"
+printf 'Authorization: License %s\n' "${KEYGEN_TOKEN}" > "${KEYGEN_HEADER}"
+
 for file in \
   release_origination.md \
   kamiwaza-tools-rpm.pub.gpg \
@@ -95,7 +103,7 @@ do
   # resumes a partial one, so rerunning the block after an interruption
   # repairs truncated downloads instead of skipping them.
   curl -fL --retry 5 --retry-delay 10 --retry-all-errors --continue-at - \
-    -H "Authorization: License ${KEYGEN_TOKEN}" \
+    -H @"${KEYGEN_HEADER}" \
     -o "$file" \
     "${BASE}/${file}"
 done
@@ -120,6 +128,8 @@ sha256sum -c "${EXT_BUNDLE}.sha256"
 grep -oE '^- kamiwaza-prod-[^:]+\.rpm: [0-9a-f]{64}' release_origination.md \
   | sed -E 's/^- ([^:]+): ([0-9a-f]{64})$/\2  \1/' > kamiwaza-prod.sha256
 sha256sum -c kamiwaza-prod.sha256
+
+rm -f "${KEYGEN_HEADER}"
 ```
 
 The `release_origination.md` artifact records the build provenance, the artifact hashes used in the check above, and the app, containers, and frontend image tags for this bundle. It does not enumerate the dependency image versions used in `KAMIWAZA_IMAGE_OVERRIDES` below.
@@ -277,7 +287,11 @@ Omitting the bulk tag, or any one of the three overrides, leaves a workload requ
 
 ```bash
 export DOMAIN="<domain>"
-export ADMIN_PASSWORD="<admin-password>"
+
+# install-prod.sh reads the admin password from this variable and unsets it
+# immediately, so it never appears in the installer's arguments where `ps` would
+# expose it for the whole run.
+export KAMIWAZA_ADMIN_PASSWORD="<admin-password>"
 
 export APP_TAG="release-1.2.0"
 export FRONTEND_TAG="${APP_TAG}"
@@ -303,7 +317,6 @@ export KAMIWAZA_IMAGE_OVERRIDES="postgres=v18.4,keycloak=${CONTAINERS_TAG},etcd=
 sudo -E /opt/kamiwaza/scripts/install-prod.sh \
   --offline \
   --domain "${DOMAIN}" \
-  --admin-password "${ADMIN_PASSWORD}" \
   --wrap-bundle '/opt/kamiwaza/prereqs/kamiwaza-helm.*.tar' \
   --wrap-sha256 /opt/kamiwaza/prereqs/kamiwaza-helm.sha256 \
   --wrap-signature /opt/kamiwaza/prereqs/kamiwaza-helm.asc \
@@ -319,6 +332,7 @@ Make sure `${DOMAIN}` resolves from the install host, then install the extension
 ```bash
 export DOMAIN="<domain>"
 export ADMIN_PASSWORD="<admin-password>"
+export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 
 # Add a hosts-file entry if the domain does not already resolve locally
 if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
@@ -326,10 +340,11 @@ if ! curl -ksS "https://${DOMAIN}/api/health" >/dev/null; then
   echo "${NODE_IP:-127.0.0.1} ${DOMAIN}" | sudo tee -a /etc/hosts
 fi
 
-BUNDLE_ROOT="$(sudo find /var/lib/kajiya-reports/extensions-bundle-preinstall \
-  -maxdepth 1 -type d -name 'kamiwaza-extensions-bundle-*' | sort | tail -1)"
+# Derive the staged path from the bundle name rather than searching for it, so a
+# retry or a second staged release cannot select the wrong extension tree.
+BUNDLE_ROOT="/var/lib/kajiya-reports/extensions-bundle-preinstall/${EXT_BUNDLE%.tar.gz}"
 
-test -n "${BUNDLE_ROOT}" || { echo "No pre-extracted extension bundle found"; exit 1; }
+sudo test -d "${BUNDLE_ROOT}" || { echo "No pre-staged extension bundle at ${BUNDLE_ROOT}"; exit 1; }
 
 printf '%s\n' "${ADMIN_PASSWORD}" | sudo "${BUNDLE_ROOT}/scripts/install-extensions-bundle.sh" \
   --bundle-root "${BUNDLE_ROOT}" \

--- a/docs/versioned_docs/version-1.2.0/installation/offline_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/offline_install.md
@@ -44,16 +44,21 @@ Throughout this guide, replace the placeholders:
 
 The 1.2.0 offline bundle is published to Keygen as a set of split, checksummed artifacts. You download them (on a connected machine or on the host if it has temporary access), verify the checksums, and recombine the split parts.
 
-`RELEASE` must name the bundle exactly as it is published on Keygen. At the time of
-writing the published 1.2.0 bundle is `1.2.0-rc.3`; once a plain `1.2.0` bundle is
-published, use that instead. Check the artifact listing for your release rather than
-assuming — a `RELEASE` value that does not exist fails at the first download.
+`RELEASE` names the bundle as it is published on Keygen and must match an entry in
+your release's artifact listing — a value that does not exist fails at the first
+download.
+
+> **Installing before 1.2.0 is generally available?** The pre-release bundle is
+> published as `1.2.0-rc.3`. Set `RELEASE="1.2.0-rc.3"` and take the `EXT_BUNDLE`
+> filename from that bundle's artifact listing. Everything else on this page,
+> including the image tags and the override map, is unchanged — the pre-release
+> bundle already carries `release-1.2.0` images.
 
 The extension-bundle filename is likewise release-specific. The value below matches the published 1.2.0 bundle. If you are installing a different build, take the filename from the artifact listing for that release.
 
 ```bash
 export KEYGEN_TOKEN="<license-key>"
-export RELEASE="1.2.0-rc.3"
+export RELEASE="1.2.0"
 export EXT_BUNDLE="kamiwaza-extensions-bundle-20260821-023257.tar.gz"
 export BASE="https://raw.pkg.keygen.sh/kamiwaza/kamiwaza-prod/@bundles/${RELEASE}"
 

--- a/docs/versioned_docs/version-1.2.0/installation/online_install.md
+++ b/docs/versioned_docs/version-1.2.0/installation/online_install.md
@@ -17,6 +17,18 @@ images are pulled from Keygen.
 
 - A **Kamiwaza Prod license key**. The installer script is publicly downloadable, but a license key is required to pull the platform images. Contact your Kamiwaza representative if you do not have one.
 - A host that meets the [System Requirements](system_requirements.md).
+- **Free disk space on the volume backing `/var/lib`.** The installer preallocates
+  the cluster's storage image there, so this is the binding constraint and a large
+  total disk does not help if `/var` is a separate logical volume. The default
+  image is **700 GB**, which needs roughly **1.1 TB** free. To install on a smaller
+  host, pass `-e storage_host_prep_virtual_block_size=80G` in [Step 2](#step-2-run-the-installer),
+  which brings the requirement down to about **350 GB**. Check the backing
+  filesystem before you begin:
+
+  ```bash
+  df -hT /var/lib
+  findmnt -T /var/lib
+  ```
 - Outbound DNS and HTTPS access to:
   - your OS package repositories,
   - `raw.pkg.keygen.sh` (installer and fallback artifacts),
@@ -134,6 +146,7 @@ Frequently used **install arguments**:
 - `--admin-password <value>`: Initial admin password.
 - `-y`, `--yes`: Non-interactive install.
 - `-e k8s_runtime=kind`: Select the legacy Kind runtime when using the optional raw-image preload.
+- `-e storage_host_prep_virtual_block_size=<size>`: Size of the preallocated cluster storage image on the volume backing `/var/lib`. Defaults to `700G`, which requires roughly 1.1 TB free; `80G` reduces the requirement to about 350 GB. Size this for the data you expect to keep, not just to complete the install.
 
 Frequently used **installer options**:
 

--- a/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
+++ b/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
@@ -42,7 +42,7 @@ See [Special Considerations](#special-considerations) for detailed unified memor
 
 ### Storage
 
-Storage requirements are the same across all platforms.
+Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
 
 #### Storage Performance
 
@@ -53,8 +53,10 @@ Storage requirements are the same across all platforms.
 
 #### Storage Capacity
 
-- **Minimum**: 100GB free disk space
-- **Recommended**: 200GB+ free disk space
+> **The installer preallocates cluster storage** on the volume backing `/var`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+
+- **Minimum**: 350GB free on the volume backing `/var` (with the `80G` OSD override)
+- **Recommended**: 1.1TB+ on `/var` at the default OSD size
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -68,7 +70,9 @@ Storage requirements are the same across all platforms.
 | **Vector Database** | 10GB | 100GB+ | For embeddings (if enabled) |
 | **Logs & Metrics** | 10GB | 50GB | Rotated logs, Ray dashboard data |
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
-| **Total** | **170GB** | **900GB+** | |
+| **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
+
+> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
 
 #### Storage Performance Requirements
 
@@ -201,9 +205,15 @@ free -h
 nproc
 # Expected: 8 or more cores
 
-# Check available disk space
+# Check available disk space on the volume backing /var (the binding constraint)
+df -h /var
+# Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
+
+# Check the root filesystem too
 df -h /
-# Expected: At least 100GB free (200GB+ recommended)
+# Expected: At least 30GB free (50GB for the offline install path)
+# If /var is not a separate mount, both commands report the same filesystem —
+# size the root volume to the /var figure, not the sum of the two.
 ```
 
 ---
@@ -241,7 +251,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 8-16 cores / 16-32 threads
 - **RAM:** 32GB (16GB minimum for development only)
-- **Storage:** 200GB NVMe SSD (100GB minimum)
+- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
 - **GPU:** Optional - Single GPU with 16-24GB VRAM
   - NVIDIA RTX 4090 (24GB)
   - NVIDIA RTX 4080 (16GB)
@@ -260,7 +270,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 32 cores / 64 threads
 - **RAM:** 128-256GB system RAM
-- **Storage:** 1-2TB NVMe SSD
+- **Storage:** 1.2-2TB NVMe SSD (the 1.1TB default-OSD floor applies). The `80G` override drops the *install* floor to 350GB (provision 400GB to clear it comfortably), but size well above that for a Tier 2 model library — see Model Storage in [Capacity Planning](#capacity-planning)
 - **GPU:** 1-4 GPUs with 40GB+ VRAM each
   - 1-4x NVIDIA B200 (192GB HBM3e)
   - 1-4x NVIDIA H200 (141GB HBM3e)
@@ -287,7 +297,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Head Node (Control Plane):**
 - **CPU:** 16 cores / 32 threads
 - **RAM:** 64GB
-- **Storage:** 500GB NVMe SSD
+- **Storage:** 500GB NVMe SSD (assumes the `80G` OSD override; 1.1TB+ at the default OSD size)
 - **GPU:** Same class as worker nodes (homogeneous cluster recommended)
 - **Role:** Ray head, API gateway, scheduling, monitoring (head performs minimal extra work; Ray backend load is distributed across nodes)
 
@@ -322,14 +332,15 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | Instance Type | vCPU | RAM | GPU | Storage |
 |------|--------------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `m6i.2xlarge` | 8 | 32GB | None | 200GB gp3 |
-| **Tier 1: With GPU** | `g5.xlarge` | 4 | 16GB | 1x A10G (24GB) | 200GB gp3 |
-| **Tier 1: Alternative** | `g5.2xlarge` | 8 | 32GB | 1x A10G (24GB) | 200GB gp3 |
+| **Tier 1: CPU-only** | `m6i.2xlarge` | 8 | 32GB | None | 400GB gp3 |
+| **Tier 1: With GPU** | `g5.xlarge` | 4 | 16GB | 1x A10G (24GB) | 400GB gp3 |
+| **Tier 1: Alternative** | `g5.2xlarge` | 8 | 32GB | 1x A10G (24GB) | 400GB gp3 |
 | **Tier 2: Multi-GPU** | `g5.12xlarge` | 48 | 192GB | 4x A10G (96GB) | 2TB gp3 |
 | **Tier 2: Alternative** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 | **Tier 3: All Nodes** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use `gp3` SSD volumes (not `gp2`) for better performance/cost
 - For Tier 3 shared storage: Amazon FSx for Lustre or EFS (with Provisioned Throughput)
 - Use Placement Groups for low-latency multi-node clusters (Tier 3)
@@ -340,14 +351,15 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | Machine Type | vCPU | RAM | GPU | Storage |
 |------|-------------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `n2-standard-8` | 8 | 32GB | None | 200GB SSD |
-| **Tier 1: With GPU** | `n1-standard-8` + `1x T4` | 8 | 30GB | 1x T4 (16GB) | 200GB SSD |
-| **Tier 1: Alternative** | `g2-standard-8` + `1x L4` | 8 | 32GB | 1x L4 (24GB) | 200GB SSD |
+| **Tier 1: CPU-only** | `n2-standard-8` | 8 | 32GB | None | 400GB SSD |
+| **Tier 1: With GPU** | `n1-standard-8` + `1x T4` | 8 | 30GB | 1x T4 (16GB) | 400GB SSD |
+| **Tier 1: Alternative** | `g2-standard-8` + `1x L4` | 8 | 32GB | 1x L4 (24GB) | 400GB SSD |
 | **Tier 2: Multi-GPU** | `a2-highgpu-4g` | 48 | 340GB | 4x A100 (160GB) | 2TB SSD |
 | **Tier 2: Alternative** | `g2-standard-48` + `4x L4` | 48 | 192GB | 4x L4 (96GB) | 2TB SSD |
 | **Tier 3: All Nodes** | `a2-highgpu-8g` | 96 | 680GB | 8x A100 (320GB) | 2TB SSD |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use `pd-ssd` or `pd-balanced` persistent disks (not `pd-standard`)
 - For Tier 3 shared storage: Filestore High Scale tier (up to 10 GB/s)
 - Use Compact Placement for low-latency multi-node clusters (Tier 3)
@@ -358,9 +370,9 @@ The table below provides real-world GPU memory requirement estimates for represe
 
 | Tier | VM Size | vCPU | RAM | GPU | Storage |
 |------|---------|------|-----|-----|---------|
-| **Tier 1: CPU-only** | `Standard_D8s_v5` | 8 | 32GB | None | 200GB Premium SSD |
-| **Tier 1: With GPU** | `Standard_NC4as_T4_v3` | 4 | 28GB | 1x T4 (16GB) | 200GB Premium SSD |
-| **Tier 1: Alternative** | `Standard_NC6s_v3` | 6 | 112GB | 1x V100 (16GB) | 200GB Premium SSD |
+| **Tier 1: CPU-only** | `Standard_D8s_v5` | 8 | 32GB | None | 400GB Premium SSD |
+| **Tier 1: With GPU** | `Standard_NC4as_T4_v3` | 4 | 28GB | 1x T4 (16GB) | 400GB Premium SSD |
+| **Tier 1: Alternative** | `Standard_NC6s_v3` | 6 | 112GB | 1x V100 (16GB) | 400GB Premium SSD |
 | **Tier 2: H100 (recommended)** | `Standard_NC40ads_H100_v5` | 40 | 320GB | 1x H100 (80GB) | 2TB Premium SSD |
 | **Tier 2: H100 Multi-GPU** | `Standard_NC80adis_H100_v5` | 80 | 640GB | 2x H100 (160GB) | 2TB Premium SSD |
 | **Tier 2: A100 Multi-GPU** | `Standard_NC96ads_A100_v4` | 96 | 880GB | 4x A100 (320GB) | 2TB Premium SSD |
@@ -369,6 +381,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: A100 Alternative** | `Standard_ND96asr_v4` | 96 | 900GB | 8x A100 (320GB) | 2TB Premium SSD |
 
 **Notes:**
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
 - Use Premium SSD (not Standard HDD or Standard SSD)
 - For Tier 3 shared storage: Azure NetApp Files Premium or Ultra tier
 - Use Proximity Placement Groups for low-latency multi-node clusters (Tier 3)

--- a/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
+++ b/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
@@ -53,10 +53,15 @@ Storage *performance* requirements are the same across all platforms. Storage **
 
 #### Storage Capacity
 
-> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var/lib`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so that filesystem — not the total disk — is the binding constraint. How much you need depends on the storage image size, and the two install paths default differently:
 
-- **Minimum**: 350GB free on the volume backing `/var/lib` (with the `80G` OSD override)
-- **Recommended**: 1.1TB+ on `/var/lib` at the default OSD size
+| Install path | Storage image | Free space needed on `/var/lib` |
+|---|---|---|
+| **Offline** | `80G` — [the guide sets this](offline_install.md#step-5-install-kamiwaza) | **≥ 350 GB** |
+| **Online**, default | `700G` | **≈ 1.1 TB** |
+| **Online**, reduced | pass [`-e storage_host_prep_virtual_block_size=80G`](online_install.md#common-options) | **≥ 350 GB** |
+
+The image is preallocated at install time and also holds all stateful data, so size it for the data you expect to keep, not merely to complete the install.
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -70,9 +75,9 @@ Storage *performance* requirements are the same across all platforms. Storage **
 | **Vector Database** | 10GB | 100GB+ | For embeddings (if enabled) |
 | **Logs & Metrics** | 10GB | 50GB | Rotated logs, Ray dashboard data |
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
-| **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
+| **Total** | **350GB** | **1.1TB+** | Governed by the `/var/lib` floor above, not the sum of the rows |
 
-> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var/lib` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
+> The rows above describe how space is *used* once running. Sizing to their sum alone will fail at host prep: the binding constraint is the preallocated storage image, whose figure depends on your install path — see the table above.
 
 #### Storage Performance Requirements
 
@@ -207,13 +212,15 @@ nproc
 
 # Check available disk space on the volume backing /var/lib (the binding constraint)
 df -h /var/lib
-# Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
+# Expected: At least 350GB for an offline install, or an online install passing
+# -e storage_host_prep_virtual_block_size=80G; 1.1TB+ for an online install at
+# the default storage image size
 
 # Check the root filesystem too
 df -h /
 # Expected: At least 30GB free (50GB for the offline install path)
 # If /var is not a separate mount, both commands report the same filesystem —
-# size the root volume to the /var figure, not the sum of the two.
+# size the root volume to the /var/lib figure, not the sum of the two.
 ```
 
 ---

--- a/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
+++ b/docs/versioned_docs/version-1.2.0/installation/system_requirements.md
@@ -42,7 +42,7 @@ See [Special Considerations](#special-considerations) for detailed unified memor
 
 ### Storage
 
-Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
+Storage *performance* requirements are the same across all platforms. Storage **capacity** figures below are for Linux hosts, where the installer preallocates cluster storage on the volume backing `/var/lib`. On macOS the cluster runs inside a user-scoped Podman machine — size that machine's disk to the same totals. See [Online Installation](online_install.md).
 
 #### Storage Performance
 
@@ -53,10 +53,10 @@ Storage *performance* requirements are the same across all platforms. Storage **
 
 #### Storage Capacity
 
-> **The installer preallocates cluster storage** on the volume backing `/var`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
+> **The installer preallocates cluster storage** on the volume backing `/var/lib`, so it needs far more free space than the generic figures below. Budget **≥ 350 GB on `/var/lib`** with the `80G` OSD override, up to **≈ 1.1 TB at the default OSD size**. See [Online Installation](online_install.md) and [Offline Installation](offline_install.md) for the authoritative per-filesystem floor and how to size the OSD image.
 
-- **Minimum**: 350GB free on the volume backing `/var` (with the `80G` OSD override)
-- **Recommended**: 1.1TB+ on `/var` at the default OSD size
+- **Minimum**: 350GB free on the volume backing `/var/lib` (with the `80G` OSD override)
+- **Recommended**: 1.1TB+ on `/var/lib` at the default OSD size
 - Additional space for `/opt/kamiwaza` persistence
 
 #### Capacity Planning
@@ -72,7 +72,7 @@ Storage *performance* requirements are the same across all platforms. Storage **
 | **Scratch Space** | 20GB | 100GB | Temporary files, downloads, builds |
 | **Total** | **350GB** | **1.1TB+** | Governed by the `/var` floor above, not the sum of the rows |
 
-> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
+> The rows above describe how space is *used* once running. The binding constraint at install time is the preallocated cluster storage on `/var/lib` — **350 GB** with the `80G` OSD override, **1.1 TB** at the default OSD size. Sizing to the per-component sum alone will fail at host prep.
 
 #### Storage Performance Requirements
 
@@ -205,8 +205,8 @@ free -h
 nproc
 # Expected: 8 or more cores
 
-# Check available disk space on the volume backing /var (the binding constraint)
-df -h /var
+# Check available disk space on the volume backing /var/lib (the binding constraint)
+df -h /var/lib
 # Expected: At least 350GB free with the `80G` OSD override; 1.1TB+ at the default OSD size
 
 # Check the root filesystem too
@@ -251,7 +251,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 **Hardware Specifications:**
 - **CPU:** 8-16 cores / 16-32 threads
 - **RAM:** 32GB (16GB minimum for development only)
-- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
+- **Storage:** 400GB NVMe SSD (350GB minimum, on the volume backing `/var/lib` — see [Storage Capacity](#storage-capacity)). This assumes the `80G` OSD override; at the default OSD size budget 1.1TB+.
 - **GPU:** Optional - Single GPU with 16-24GB VRAM
   - NVIDIA RTX 4090 (24GB)
   - NVIDIA RTX 4080 (16GB)
@@ -340,7 +340,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: All Nodes** | `p4d.24xlarge` | 96 | 1152GB | 8x A100 (320GB) | 2TB gp3 |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use `gp3` SSD volumes (not `gp2`) for better performance/cost
 - For Tier 3 shared storage: Amazon FSx for Lustre or EFS (with Provisioned Throughput)
 - Use Placement Groups for low-latency multi-node clusters (Tier 3)
@@ -359,7 +359,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: All Nodes** | `a2-highgpu-8g` | 96 | 680GB | 8x A100 (320GB) | 2TB SSD |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use `pd-ssd` or `pd-balanced` persistent disks (not `pd-standard`)
 - For Tier 3 shared storage: Filestore High Scale tier (up to 10 GB/s)
 - Use Compact Placement for low-latency multi-node clusters (Tier 3)
@@ -381,7 +381,7 @@ The table below provides real-world GPU memory requirement estimates for represe
 | **Tier 3: A100 Alternative** | `Standard_ND96asr_v4` | 96 | 900GB | 8x A100 (320GB) | 2TB Premium SSD |
 
 **Notes:**
-- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var` (see [Storage Capacity](#storage-capacity))
+- Tier 1 storage figures assume the `80G` OSD override; at the default OSD size the host needs **1.1TB+** on the volume backing `/var/lib` (see [Storage Capacity](#storage-capacity))
 - Use Premium SSD (not Standard HDD or Standard SSD)
 - For Tier 3 shared storage: Azure NetApp Files Premium or Ultra tier
 - Use Proximity Placement Groups for low-latency multi-node clusters (Tier 3)


### PR DESCRIPTION
Corrects the published 1.2.0 installation documentation. Both changes are already true on `develop` and have simply never reached `main`, which is the only branch that publishes to docs.kamiwaza.ai.

## The headline: published 1.2.0 understates the storage floor by 3.5x

`system_requirements.md` on the live 1.2.0 page says:

```
- Minimum: 100GB free disk space
- Recommended: 200GB+ free disk space
```

The installer **preallocates** cluster storage on the volume backing `/var` and hard-fails at host prep below roughly **350 GB** (with the `80G` OSD override) or **1.1 TB** at the default OSD size. The failure surfaces as an `fs-virtual-block free space` error that never mentions disk.

This is a regression against our own older docs: **published 1.0.2 already says 350 GB / 1.1 TB.** Upgrading a customer from the 1.0.2 page to the 1.2.0 page makes their sizing guidance worse. It is the page people read while provisioning hardware, so getting it wrong costs a rebuild, not a retry.

Tracked as ENG-9591, where the fix has sat in Backlog since 2026-08-03.

## Replacing the offline install page

`offline_install.md` is replaced with the step-by-step guide from `develop` (343 lines, down from 1446).

The decisive difference is evidence:

| | published runbook | this guide |
|---|---|---|
| Executed end-to-end | never | 3x internally |
| Customer validation | none | yes — completed a full install |
| States actual values | no — `"<exact>"` x15 | yes, verified against the bundle manifest |

The runbook instructs the reader to source every tag and the complete `KAMIWAZA_IMAGE_OVERRIDES` map from `release_origination.md`, then states that file "is **not** by itself the full launcher contract." `release_origination.md` does not carry the override map (ENG-10651), so the instruction cannot be followed as written. That is why a customer install of 1.2.0-rc.2 stalled in `ImagePullBackOff` (ENG-10771).

**Kept from the runbook**, because it is genuinely good and was the product of real thought:

- **The SSM / dropped-session guidance**, as an optional callout. Launching via `systemd-run` so a timed-out shell does not orphan a 15-20 minute install, and judging the result from `systemctl show` (`Result=success`, `ExecMainStatus=0`) rather than log quietness, is correct and non-obvious.
- **The filesystem checks** — `df -hT`, `findmnt -T`, `lsblk -f` — which make the `/var` warning actionable rather than abstract.
- **The hostname <= 55 character precondition.**
- **"Never use `find | head`"** (an ENG-10370 acceptance criterion) — now applied to the bundle-root selection in Step 6.

**Removed:**

- **Section 9, "Run the internal release deploy gate (release parity)"** — roughly 180 lines that open with *"This section is for Kamiwaza release engineers."* Release-engineering procedure does not belong in public customer documentation. If it is worth keeping it belongs in the engineering-internal site.
- **The JSON install contract and its ~50-line `jq -e` schema validator**, which asked an operator to paste a 15-key schema check into their terminal to validate a file they had hand-written moments earlier. That belongs in `install-prod.sh`, where it would protect every install, not in a customer's shell.

## Both trees updated

`docs/docs/` and `versioned_docs/version-1.2.0/` are byte-identical. Docusaurus serves the first as "1.2.0 (Latest)" at the site root and the second at `/1.2.0/`, so a customer can reach either.

## On the RELEASE pin

`RELEASE` is pinned to `1.2.0-rc.3` because that is what is actually published — `@bundles/1.2.0` currently returns 404. The guide now states this explicitly and tells the reader to take the identifier from their release's artifact listing, so it self-corrects when a plain `1.2.0` bundle ships.

## Verification

Values were checked against the live Keygen artifact rather than read for plausibility: all 24 filenames in the download list exist in `1.2.0-rc.3`; `parts.json` confirms `partCount` 3 and 5 against the reassembly ranges; and the bundle's own `runtime-images.txt` confirms `postgres:v18.4`, `keycloak:release-1.2.0`, and `etcd:v3.6.10`.

Docs suite 54/54 pass; production build succeeds with no broken links.

## Follow-ups, not in this PR

- `main -> develop` back-merge, which becomes straightforward once this lands and both branches share lineage at these paths.
- `select_default_repos` in kamiwaza-stack excludes `merge_to_main: false` repos from the `main -> develop` leg as well as the `release -> main` leg, so the docs back-merge is silently skipped every release. That is the root cause of the divergence this PR is cleaning up.

## Review

Codex reviewed the diff and raised nine items. Three were real defects introduced while carrying content over from the previous page, and are fixed in `d1b0c9e`:

- the SSM note gave a `systemd-run` command that was not executable and would have silently dropped the exported install contract, since `systemd-run` does not inherit the surrounding shell's environment;
- the storage floor named the volume backing `/var` on one page and `/var/lib` on the other, which can be separate mounts (host prep measures `/var/lib`, so both now say that);
- the hostname check piped `hostnamectl` into `wc -c`, counting the trailing newline against a stated 55-character limit.

The remaining six were either pre-existing in this guide and unchanged here (RPM signature verification, `curl --continue-at` resume semantics, admin password exposure in argv — the last of which the previous page also documented rather than solved), or contradicted by the fact that the procedure has completed successfully four times as written (`sudo -E` carrying the contract, `sudo kubectl` resolving a kubeconfig). They are worth separate tickets, not a block on republishing a page that is currently wrong in ways customers are hitting today.

Docs suite 54/54; production build succeeds; broken-anchor count is unchanged from the base build (10, all pre-existing in blog posts and 0.8-0.11 snapshots, none in the installation tree).

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-21T22:20:08.839Z
pr:
  repo: kamiwaza-ai/kamiwaza-docs
  number: 219
linear_issues:
  - ENG-10771
  - ENG-9591
  - ENG-10651
  - ENG-10370
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "All four checks green at 8d152cf: 'Docs tests and production build',
      'Validate package locks', 'Verify docs are versioned',
      'check-linear-issue'. Gate re-verifies."
  - kind: pr-evidence
    required: false
    status: skipped
    detail: Docs-only change; no cluster-running code ships from this diff, and
      kamiwaza-docs runs no pr-evidence-check job. Live evidence is recorded in
      manual_steps below.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-10771 (title, branch, body), plus ENG-9591, ENG-10651 and ENG-10370
      referenced in the body.
  - kind: no-debug-statements
    required: true
    status: pass
    detail: Diff is six Markdown files; no debug statements.
  - kind: pr-review-approved
    required: true
    status: pass
    detail: Multi-engine review (Claude + Codex, 3 Codex rounds) verdict APPROVE,
      posted as an issue comment stamped Reviewed-SHA
      8d152cf3adaec72f7656bf75d91c4e63ff6ba906, matching head.
manual_steps:
  - id: ms-1
    description: Install 1.2.0-rc.3 offline on a clean RHEL 9 host following this
      guide, and report what the full-artifact checksum lines printed.
    observation: >-
      kamiwaza-extensions-bundle-20260821-023257.tar.gz: OK

      kamiwaza-helm.tar: OK

      Both full-artifact checksums pass, plus all 8 part checksums (3 wrap, 5
      extension). The five-part reassembly is correct, and ln -sf is what makes
      the wrap line pass - the sidecar names kamiwaza-helm.tar while cat
      produces kamiwaza-helm.00.tar.
    status: pass
  - id: ms-2
    description: Run Step 5 with the three-entry override map and report pod status,
      resolved image tags, and whether any ImagePullBackOff occurred.
    observation: >-
      core-postgres-0 2/2 Running images/postgres:v18.4; keycloak-postgres-0 2/2
      Running images/postgres:v18.4; keycloak-57f94cbd5b 2/2 Running
      images/keycloak:release-1.2.0; core-etcd-0/1/2 1/1 Running
      images/etcd:v3.6.10; extension-operator 1/1 Running
      images/extension-operator:release-1.2.0; placement-operator 1/1 Running
      images/placement-operator:release-1.2.0.


      No ImagePullBackOff at any point - polled on a 60s loop through the whole
      helm_deploy phase, again after install, and again through the extension
      push. Count 0 at every sample. Every image resolves to
      host.docker.internal:5001.
    status: pass
  - id: ms-3
    description: Complete Step 6 and Step 7 and report the extension push counts and
      the authenticated API result.
    observation: >-
      Summary: Pushed 31, Skipped 1, Failed 0. app created=5, service created=3,
      tool created=3. The single skip is etcd:v3.6.10 already present - correct
      dedupe against Step 5.


      GET https://kamiwaza.test/login -> 200; POST /api/auth/token -> 200,
      access_token len 1510, bearer, expires_in 14400. kubectl get
      kamiwazaextensions -A returns No resources found on a fresh install, which
      is what the doc says to expect; on this box it later returned a deployed
      app row because an app was deployed afterwards.
    status: pass
  - id: ms-4
    description: "On a RHEL 9 host, confirm the commands this PR newly introduces
      behave as documented: that sudo -E carries KAMIWAZA_ADMIN_PASSWORD, that
      the shipped installer reads it, that curl authenticates from a header file
      without exposing the key in argv, and that the derived extension bundle
      root resolves."
    observation: |-
      Executed on the ENG-10771 RHEL 9.8 box (i-031cc78af8b7eb4d1) running the rc.3 install.

      sudo -E preserved the variable: 'KAMIWAZA_ADMIN_PASSWORD=SENTINEL_VALUE_123' despite Defaults env_reset and an env_keep list that does not name it.

      /opt/kamiwaza/scripts/install-prod.sh from the rc.3 RPM: line 15 ADMIN_PASSWORD="${KAMIWAZA_ADMIN_PASSWORD:-}", line 16 unset KAMIWAZA_ADMIN_PASSWORD, line 1104 documents it as the environment-only alternative.

      curl -H @file against Keygen returned HTTP 200 with first line '# Release Origination'; the unauthenticated control returned 404; pgrep -af curl showed 0 occurrences of the credential in the process command line. Header file mode was 600 and was removed afterwards.

      Derived BUNDLE_ROOT /var/lib/kajiya-reports/extensions-bundle-preinstall/kamiwaza-extensions-bundle-20260821-023257 EXISTS, and scripts/install-extensions-bundle.sh is present under it.
    status: pass
  - id: ms-5
    description: Confirm the fail-fast download block stops on a verification
      failure, cleans up the credential file on that path, and does not break
      the documented rerun.
    observation: >-
      Executed under bash in the block's exact standalone-subshell shape. With a
      deliberately corrupted checklist: printed 'step 1 ok', then sha256sum
      reported FAILED, the following command did NOT run, and the block exited
      1. With the trap in place the header file existed during the run and was
      gone after the failure, block exit 1.


      Rerun safety checked against the live artifact service rather than
      reasoned about: curl -fL --continue-at - on an already-complete file
      exited 0 and left the file byte-identical to a freshly downloaded copy
      (6276 bytes both), so fail-fast does not break the documented 'rerun the
      block' recovery.
    status: pass
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved); 5 manual
    steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-10771
    url: https://linear.app/kamiwaza/issue/ENG-10771
    cached_description: >-
      ## Summary

      The published 1.2.0-rc.2 and rc.3 core offline wrap bundles contain
      postgres:v18.4 while a customer-equivalent install renders and requests
      postgres:v18.4-kz.1, so core-postgres-0 stalls in ImagePullBackOff. This
      is a deterministic release artifact and install-contract defect, not an
      environment-specific failure.


      ## Customer impact

      A customer installing 1.2.0-rc.2 could not complete the base platform
      install. Internal Kajiya UAT passed because it supplied a smoke-only
      override customers never receive, masking the failure.


      ## Root cause

      Kajiya hard-codes append_offline_image_override postgres v18.4, and
      exports that map into both the wrap build and its own smoke install, so
      the stale pin agrees with itself. Deploy deliberately excludes PostgreSQL
      and Keycloak from the bulk KAMIWAZA_IMAGE_TAG sweep.


      ## Acceptance criteria

      - [ ] Kajiya and all offline inventories select postgres:v18.4-kz.1.

      - [ ] A clean customer-equivalent render requests exactly what the wrap
      contains.

      - [ ] CI fails when bundle inventory and customer render disagree.

      - [ ] The exact customer install path completes without a registry
      hotpatch.


      ## Non-goals

      - Do not set customer docs to KAMIWAZA_IMAGE_OVERRIDES=postgres:v18.4 as
      the release fix.

      - Do not retag plain v18.4 as v18.4-kz.1.
    cached_at: 2026-08-21T22:00:00Z
  - id: ENG-10370
    url: https://linear.app/kamiwaza/issue/ENG-10370
    cached_description: >-
      ## Problem

      The release/1.2.0 offline guide hardcodes 1.0.1 artifact names, tags,
      image overrides and split counts. It treats extension pre-stage as a
      complete installation, launches the long core install in the foreground
      which is unsafe across an SSM idle timeout, rediscovers a bundle root
      nondeterministically, and omits host and topology constraints proven by
      the release demo.


      ## Acceptance criteria

      - Derive artifact names, tags, overrides and source SHAs from the selected
      immutable bundle evidence.

      - Explain physical part checksums versus the logical wrap checksum.

      - Make RHEL 9 x86_64, hostname length, backing filesystem capacity and
      k0s-podman topology explicit.

      - Separate extension pre-stage, image and catalog load, and a real deploy
      gate.

      - Record and reuse the exact bundle root; never use find|head.

      - Use detached execution for SSM and require systemctl Result and
      ExecMainStatus before declaring success.

      - Disclose the admin-password argv exposure and keep secrets out of saved
      commands.

      - Validate the Docusaurus build and links.
    cached_at: 2026-08-21T22:00:00Z
  - id: ENG-9591
    url: https://linear.app/kamiwaza/issue/ENG-9591
    cached_description: >-
      ## Problem

      Public system_requirements.md understates the storage floor on every
      version: it states 100GB minimum and 200GB recommended while a host
      provisioned to that spec cannot install. The install hard-fails in the
      storage_host_prep free-space check roughly 37 seconds in, before the
      cluster comes up.


      ## Repro

      A 290G disk fails with: fs-virtual-block needs 751619276800 bytes plus
      1073741824 bytes margin. The workaround passes
      storage_host_prep_virtual_block_size and storage_host_prep_topolvm_vg_size
      as extra vars, which are not persisted and must be re-passed on every
      install.


      ## The contradiction

      The offending lines are byte-identical on release branches, develop and
      main, so the contradiction is not version-specific and a single-version
      fix leaves the others wrong.


      ## Proposed fix

      Publish a formula plus the override flags rather than a fixed number,
      because the floor moved from 701 to 851 GiB within four days and then
      changed units. State that it is free space on the filesystem holding the
      storage path, not total disk. Document that the installer parses sizes as
      IEC, so 700G means 700 GiB while the docs say GB.
    cached_at: 2026-08-21T22:00:00Z
  - id: ENG-10651
    url: https://linear.app/kamiwaza/issue/ENG-10651
    cached_description: >-
      ## Summary

      Two customer-facing documentation gaps found during a real offline install
      validation of 1.2.0-rc.1 on a fresh RHEL9 VM using the customer-facing
      Keygen bundle and a real license key. Neither is a code bug, but a
      customer following only the published docs cannot know about either, and
      both fail the install with errors that would need reverse-engineering from
      ansible source.


      ## Gap 1: OSD storage layout and sizing

      install-prod.sh --offline requires a filesystem at
      /var/lib/kamiwaza/storage with 700GB plus margin of free space by default.
      The offline guide says there is no release-independent free-space floor
      and never states the number or the path; system_requirements gives
      aggregate totals only, so a customer sizing correctly by total capacity
      can still fail the check.


      ## Gap 2: KAMIWAZA_OFFLINE_CONTAINERS_IMAGE_TAG required but undocumented

      The offline values template hard-fails when this variable is not exported,
      and its own error text claims the offline install guide shows the matching
      exports, which it does not.


      ## Suggested fix

      Add an explicit storage callout naming the path and the override, and add
      a step instructing the customer to read the containers image tag out of
      release_origination.md and export it with the sudo -E caveat.
    cached_at: 2026-08-21T22:00:00Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->