### PR TITLE
docs(rebac): document tenant-mode ordinary Ray job validation (ENG-10946)

### DIFF
--- a/docs/docs/federation/job-submission.md
+++ b/docs/docs/federation/job-submission.md
@@ -12,6 +12,34 @@ Submit and manage Ray jobs on local or remote clusters. Jobs run Python entrypoi
 - Admin authentication (JWT token with admin role)
 - Ray cluster running on the target cluster
 
+## Tenant-mode ReBAC
+
+On an authenticated tenant-mode install, ordinary cluster jobs work with
+ReBAC enabled and the community fallback disabled. The request is authorized
+at the Kamiwaza API, then the Core API submits the job to the in-cluster Ray
+Dashboard Jobs API on port `8265`. The Core API is served by the Ray head
+workload, so the chart's Ray-head `AuthorizationPolicy` must allow the
+`core-ray` service account to use that port. The public ingress rule alone is
+not sufficient for this east-west request, and the Ray Dashboard should not
+be exposed as a public job-submission endpoint.
+
+For a fresh strict-ReBAC install, verify the complete lifecycle before making
+the environment available to users:
+
+```bash
+# Run from the stack root with the deploy checkout present.
+KAMIWAZA_HOST=<tenant-host> \
+KUBECONFIG=<tenant-kubeconfig> \
+python3 deploy/scripts/kamiwaza-smoke.py recoverable-job
+```
+
+The check submits a small recoverable job, observes its status transition,
+retrieves the structured result, and exercises cancellation handling. A
+`502` containing `Ray submit failed (403)` indicates a mesh authorization
+policy problem on the Ray Dashboard hop; inspect the rendered `ray-head`
+policy and confirm the `core-ray` principal and port `8265` rule before
+changing ReBAC fallback settings.
+
 ## Submit a Job (Async)
 
 ```bash

--- a/docs/docs/federation/job-submission.md
+++ b/docs/docs/federation/job-submission.md
@@ -33,8 +33,8 @@ KUBECONFIG=<tenant-kubeconfig> \
 python3 deploy/scripts/kamiwaza-smoke.py recoverable-job
 ```
 
-The check submits a small recoverable job, observes its status transition,
-retrieves the structured result, and exercises cancellation handling. A
+The check submits a small recoverable job, observes its status transition, and
+retrieves the structured result. A
 `502` containing `Ray submit failed (403)` indicates a mesh authorization
 policy problem on the Ray Dashboard hop; inspect the rendered `ray-head`
 policy and confirm the `core-ray` principal and port `8265` rule before


### PR DESCRIPTION
## Summary\n\nDocument the tenant-mode ReBAC contract for ordinary Ray jobs and the fresh-install lifecycle smoke.\n\n## Changes\n\n- Explain that the Core API is served by the Ray-head workload and uses the in-cluster Ray Dashboard Jobs API on port 8265.\n- Identify the required core-ray service-account authorization and clarify that ingress access or public dashboard exposure is not a substitute.\n- Add the recoverable-job validation command and troubleshooting guidance for a Ray Dashboard 403 surfaced as a 502.\n\n## Verification\n\n- git diff --check passes.\n- Documentation build was not run because npm ci could not complete in the available environment; it stalled while resolving dependencies. No generated files were changed.\n\nCloses ENG-10946

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.3
generated_at: 2026-08-26T00:21:23.789Z
manifest_hash: sha256:1e2d2d0264ecee30acbe3a4b574c917b908627c6e432995aebb4dbb50fcbb734
phase_a_complete: true
phase_b_complete: true
repos:
  - name: deploy
    path: /tmp/kz-eng10946-deploy
    branch: fix/eng-10946-ray-head-rebac
    head_sha: 8d0bea579c74ee62373ef18d066254b8786128d6
    head_sha_short: 8d0bea579
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/fix/eng-10946-ray-head-rebac
    delivery:
      mode: not-applicable
      verified: true
      note: This PR is a Helm chart policy change. The exact PR HEAD was applied to the live release with
        helm upgrade --reuse-values; pr-evidence v0.3.3 has no chart-delivery verification mode, so
        the rendered policy and Helm revision are recorded in the evidence narrative.
  - name: kamiwaza-docs
    path: /tmp/kz-eng10946-docs
    branch: docs/eng-10946-ray-job-rebac
    head_sha: fdceb83ceed04672ed689fe38d14d9a626540465
    head_sha_short: fdceb83ce
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/docs/eng-10946-ray-job-rebac
    delivery:
      mode: not-applicable
      verified: true
      note: Documentation only; it is not delivered to the running cluster.
clusters:
  - name: laptop
    host: jxs-kz-mbp.kale.wemodulate.com
    kubectl_context: Default
    namespace: kamiwaza
    pod_exec_target: deployment/core-scheduler
    identity:
      k8s_distribution: k0s
      k8s_version: v1.36.1+k0s
      container_runtime: containerd-cri
      host_vm_layer: macos-lima
      network_mode: kube-router
    health:
      pods_total: 42
      pods_by_phase:
        Running: 37
        Succeeded: 5
      non_running: []
      api_plane:
        url: https://jxs-kz-mbp.kale.wemodulate.com/api/cluster/capabilities
        http_code: 401
        expected_code: 401
        match: true
```

</details>

# PR Evidence — generated 2026-08-26T00:21:23.789Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| deploy | fix/eng-10946-ray-head-rebac | `8d0bea579` | clean | not-applicable ✓ |
| kamiwaza-docs | docs/eng-10946-ray-job-rebac | `fdceb83ce` | clean | not-applicable ✓ |

## Cluster identity

| Cluster | k8s distro | Runtime | Host/VM | Network | k8s version |
|---------|-----------|---------|---------|---------|-------------|
| laptop | k0s | containerd-cri | macos-lima | kube-router | v1.36.1+k0s |

## Cluster health

| Cluster | Total pods | By phase | Non-Running | API plane |
|---------|-----------|----------|-------------|-----------|
| laptop | 42 | 37 Running, 5 Succeeded | 0 | 401 (✓) |

## Cross-references

- Linear: `ENG-10946`
- PR: https://github.com/kamiwaza-internal/deploy/pull/875
- PR: https://github.com/kamiwaza-ai/kamiwaza-docs/pull/226
- Evidence file: `~/.cache/kamiwaza/pr-evidence/eng-10946-live.md`

## Runtime validation

- The deploy PR HEAD `8d0bea579c74ee62373ef18d066254b8786128d6` was applied
  from `/tmp/kz-eng10946-deploy` with `helm upgrade kamiwaza ...
  --reuse-values`. The release reported `STATUS: deployed`, `REVISION: 4`,
  and chart `kamiwaza-1.1.0`.
- The live `ray-head` AuthorizationPolicy rendered the scoped principal
  `cluster.local/ns/kamiwaza/sa/core-ray` for port `8265` with methods
  `GET, POST, PUT, DELETE, OPTIONS`; no Kubernetes RBAC objects changed.
- Command: `KAMIWAZA_HOST=jxs-kz-mbp.kale.wemodulate.com KAMIWAZA_VERIFY_SSL=false
  FULL_ADMIN_PASSWORD=... python3 deploy/scripts/kamiwaza-smoke.py
  recoverable-job`
- Observed output: `submitted job_id=f8a26688-29f3-4f5e-a034-bf593ca5507b`,
  `status=PENDING`, `status=SUCCEEDED`, `result={'ok': True}`, and
  `RECOVERABLE-JOB PASS`.
- A prior attempt against `kamiwaza.test` was not counted: that hostname
  resolved to the stale local 443 tunnel and failed before authentication with
  TLS `UNEXPECTED_EOF_WHILE_READING`. The canonical live gateway hostname was
  then used for the passing run.

<!-- pr-evidence-end -->

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-26T00:23:19.665Z
pr:
  repo: kamiwaza-ai/kamiwaza-docs
  number: 226
linear_issues:
  - ENG-10946
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: Docs CI was green before the wording correction; the new head is
      awaiting its fresh run.
  - kind: pr-evidence
    required: true
    status: pass
    detail: The live cluster evidence is attached; documentation delivery is
      explicitly not applicable.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-10946 appears in the PR title and body.
  - kind: no-debug-statements
    required: true
    status: pass
    detail: The documentation-only diff contains no debug statements.
  - kind: pr-review-approved
    required: true
    status: absent
    detail: A current-head /pr-review verdict still needs to be recorded.
manual_steps: []
verdict:
  decision: hold
  rationale: "failing required auto-checks: pr-review-approved=absent"
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->