### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kamiwaza-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kamiwaza-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from 1.2.0 to 1.2.1.
- Part of the release/1.2.1 cutover; `kamiwaza-extensions-tomo` is being added to this release (ENG-11008).

## Test plan
- [x] package.json parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-27T14:05:26.000Z
pr:
  repo: kamiwaza-ai/kamiwaza-docs
  number: 228
linear_issues:
  - ENG-11008
auto_checks:
  - kind: required-checks
    required: true
    status: pass
  - kind: pr-evidence
    required: false
    status: absent
  - kind: linear-issue-present
    required: true
    status: pass
  - kind: no-debug-statements
    required: true
    status: pass
  - kind: pr-review-approved
    required: true
    status: fail
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "minimum PR age satisfied: created 2026-08-26T22:08:42.000Z; eligible
      since 2026-08-26T22:53:42.000Z"
manual_steps: []
verdict:
  decision: hold
  rationale: "failing required auto-checks: pr-review-approved=fail"
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-11008
    url: https://linear.app/kamiwaza/issue/ENG-11008/kamiwaza-extensions-tomo-is-not-promoted-to-keygen-no-package-exists
    cached_description: >-
      ## Summary


      `kamiwaza-extensions-tomo` has no corresponding package in Keygen under
      `kamiwaza-prod`, in either the `oci` or `raw` engine. Verified directly
      against the live Keygen API (not from a stale manifest): 0 matches out of
      105 OCI packages and 29 raw packages. This isn't specific to 1.2.0 -- no
      package for `tomo` has ever existed at any version, so it has never been
      shipped to a customer via a license-only online or offline install.


      It was also absent from `kamiwaza-stack/repos.yaml` (the stack's repo
      manifest used by `clone-repos.py`/`sync-repos.py`/release tooling) --
      fixed in this same pass by adding it alongside the other
      `kamiwaza-extensions-*` entries (`type: extension`, `release: true`), so
      it will at least be included in future clone/sync/release-branch
      operations going forward.


      ## Evidence


      ```python

      # Queried live via KeygenClient.list_packages(product_id=<kamiwaza-prod>,
      engine=...)

      engine=oci: total=105 tomo_matches=[]

      engine=raw: total=29 tomo_matches=[]

      ```


      Existing extension/connector-type package keys follow the pattern
      `kamiwaza-connector-builder`, `kamiwaza-connector-google`,
      `kamiwaza-connector-m365`, `kamiwaza-extension-operator` -- no
      `kamiwaza-extensions-tomo` equivalent exists among them.


      ## Open questions


      - Is `tomo` supposed to ship in 1.2.0 (App Garden entry, chart reference,
      etc.), or is it still pre-release/internal-only? If the former, this
      blocks a genuinely license-only install the same way
      `kamiwaza-extensions-connector-builder` did (ENG-10943) -- worth checking
      whether `tomo` has the same OCI-promotion issue once someone attempts it,
      or whether it was simply never attempted.

      - If `tomo` is customer-facing, it needs the standard OCI image promotion
      (and raw package promotion if it ships a raw-only component) added to the
      release-branch Keygen promotion process
      (engineering.kamiwaza.ai/processes/release/keygen-release).


      ## Related


      - ENG-10943 -- kamiwaza-extensions-connector-builder Keygen promotion
      failure (same class of gap: a shipped extension repo not actually reaching
      Keygen)

      - ENG-10911 -- online install is not license-only (broader gap this ticket
      is a specific instance of, if `tomo` turns out to be customer-facing in
      1.2.0)
    cached_at: 2026-08-27T03:20:00Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->